### PR TITLE
[ALL] FEAT: dev 브랜치로 PR 요청, 병합 시 슬랙에 알림을 보낸다. (#17)

### DIFF
--- a/.github/workflows/closed-pr-notification.yml
+++ b/.github/workflows/closed-pr-notification.yml
@@ -1,0 +1,103 @@
+name: Closed PR Notification
+on:
+  pull_request:
+    branches: [ dev ]
+    types: [ closed ]
+
+jobs:
+  create-issue:
+    name: PR closed notification to slack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send closed PR notification
+        if: github.event.pull_request.merged != true
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": "*PR이 닫혔습니다!*",
+              "attachments": [
+                {
+                  "color": "#CF2027",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "*Title*\n<${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
+                      }
+                    },
+                    {
+                      "type": "section",
+                      "fields": [
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Base branch*\n${{ github.base_ref }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Compare branch*\n${{ github.head_ref }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*PR number*\n#${{ github.event.pull_request.number }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Author*\n${{ github.event.pull_request.user.login }}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Send merged PR notification
+        if: github.event.pull_request.merged == true
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": "*PR이 머지됐습니다!*",
+              "attachments": [
+                {
+                  "color": "#7539DE",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "*Title*\n<${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
+                      }
+                    },
+                    {
+                      "type": "section",
+                      "fields": [
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Base branch*\n${{ github.base_ref }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Compare branch*\n${{ github.head_ref }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*PR number*\n#${{ github.event.pull_request.number }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Author*\n${{ github.event.pull_request.user.login }}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/opened-pr-notification.yml
+++ b/.github/workflows/opened-pr-notification.yml
@@ -1,0 +1,56 @@
+name: Opened PR Notification
+on:
+  pull_request:
+    branches: [ dev ]
+    types: [ opened ]
+
+jobs:
+  create-issue:
+    name: PR opened notification to slack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send opened PR notification
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": "*새로운 PR이 생성되었습니다!*",
+              "attachments": [
+                {
+                  "color": "#1F7629",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "*Title*\n<${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
+                      }
+                    },
+                    {
+                      "type": "section",
+                      "fields": [
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Base branch*\n${{ github.base_ref }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Compare branch*\n${{ github.head_ref }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*PR number*\n#${{ github.event.pull_request.number }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Author*\n${{ github.event.pull_request.user.login }}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] FEAT: ~~(#issueNum)
[AN/STAFF] FEAT: ~~(#issueNum)
[AN/USER] FIX: ~~(#issueNum)
-->
## 📌 관련 이슈
<!--
- closed: #issueNum
-->

## 🚅 PR 한 줄 요약
dev 브랜치로 PR 요청, 병합 시 슬랙에 알림을 보내는 기능 추가

## 🧑‍💻 PR 세부 내용
GIthub Actions를 사용하여 PR이 생성되거나, 병합이 되면 슬랙에 알림을 보내는 기능을 추가

## 📸 스크린샷
![image](https://github.com/woowacourse-teams/2023-festa-go/assets/116627736/0e1f9d8b-6a2a-46d0-b8bb-da00c69ba6bf)

