### PR TITLE
[AN/STAFF] feat: QR 스캔 화면 커스텀 및 기능을 변경(#63)

### DIFF
--- a/android/festago-staff/app/src/main/java/com/festago/festagostaff/data/dto/TicketValidationRequestDto.kt
+++ b/android/festago-staff/app/src/main/java/com/festago/festagostaff/data/dto/TicketValidationRequestDto.kt
@@ -1,0 +1,6 @@
+package com.festago.festagostaff.data.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TicketValidationRequestDto(val code: String)

--- a/android/festago-staff/app/src/main/java/com/festago/festagostaff/data/repository/TicketDefaultRepository.kt
+++ b/android/festago-staff/app/src/main/java/com/festago/festagostaff/data/repository/TicketDefaultRepository.kt
@@ -1,5 +1,6 @@
 package com.festago.festagostaff.data.repository
 
+import com.festago.festagostaff.data.dto.TicketValidationRequestDto
 import com.festago.festagostaff.data.service.TicketRetrofitService
 import com.festago.festagostaff.domain.model.TicketState
 import com.festago.festagostaff.domain.repository.TicketRepository
@@ -8,6 +9,9 @@ class TicketDefaultRepository(
     private val ticketRetrofitService: TicketRetrofitService,
 ) : TicketRepository {
     override suspend fun validateTicket(code: String): TicketState {
-        return ticketRetrofitService.validateTicket(code).body()!!.toTicketState()
+        return ticketRetrofitService
+            .validateTicket(TicketValidationRequestDto(code))
+            .body()!!
+            .toTicketState()
     }
 }

--- a/android/festago-staff/app/src/main/java/com/festago/festagostaff/data/service/TicketRetrofitService.kt
+++ b/android/festago-staff/app/src/main/java/com/festago/festagostaff/data/service/TicketRetrofitService.kt
@@ -1,11 +1,12 @@
 package com.festago.festagostaff.data.service
 
 import com.festago.festagostaff.data.dto.TicketValidationDto
+import com.festago.festagostaff.data.dto.TicketValidationRequestDto
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface TicketRetrofitService {
     @POST("/staff/tickets/validation")
-    suspend fun validateTicket(@Body code: String): Response<TicketValidationDto>
+    suspend fun validateTicket(@Body code: TicketValidationRequestDto): Response<TicketValidationDto>
 }

--- a/android/festago-staff/app/src/main/java/com/festago/festagostaff/presentation/ui/ticketvalidation/TicketValidationActivity.kt
+++ b/android/festago-staff/app/src/main/java/com/festago/festagostaff/presentation/ui/ticketvalidation/TicketValidationActivity.kt
@@ -3,14 +3,16 @@ package com.festago.festagostaff.presentation.ui.ticketvalidation
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.KeyEvent
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.festago.festagostaff.data.RetrofitClient
 import com.festago.festagostaff.data.repository.TicketDefaultRepository
 import com.festago.festagostaff.databinding.ActivityTicketValidationBinding
-import com.journeyapps.barcodescanner.ScanContract
-import com.journeyapps.barcodescanner.ScanOptions
+import com.google.zxing.BarcodeFormat
+import com.journeyapps.barcodescanner.BarcodeCallback
+import com.journeyapps.barcodescanner.DefaultDecoderFactory
 
 class TicketValidationActivity : AppCompatActivity() {
 
@@ -24,19 +26,20 @@ class TicketValidationActivity : AppCompatActivity() {
         )
     }
 
-    private val barcodeLauncher = registerForActivityResult(ScanContract()) { result ->
-        if (result.contents == null) {
+    private val barcodeCallback = BarcodeCallback { result ->
+        if (result.text == null) {
             Toast.makeText(this, "No content", Toast.LENGTH_SHORT).show()
-            return@registerForActivityResult
+            return@BarcodeCallback
         }
-        vm.validateTicketCode(result.contents.toString())
+        if (!vm.isLatestCode(result.text)) {
+            vm.validateTicketCode(result.text)
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         initBinding()
-        initBarcodeLauncher()
     }
 
     private fun initBinding() {
@@ -45,13 +48,25 @@ class TicketValidationActivity : AppCompatActivity() {
 
         binding.lifecycleOwner = this
         binding.vm = vm
+        binding.dbvScanner.apply {
+            decoderFactory = DefaultDecoderFactory(listOf(BarcodeFormat.QR_CODE))
+            initializeFromIntent(intent)
+            decodeContinuous(barcodeCallback)
+        }
     }
 
-    private fun initBarcodeLauncher() {
-        val scanOptions = ScanOptions().apply {
-            setDesiredBarcodeFormats(ScanOptions.QR_CODE)
-        }
-        barcodeLauncher.launch(scanOptions)
+    override fun onResume() {
+        super.onResume()
+        binding.dbvScanner.resume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        binding.dbvScanner.pause()
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        return binding.dbvScanner.onKeyDown(keyCode, event) || super.onKeyDown(keyCode, event)
     }
 
     companion object {

--- a/android/festago-staff/app/src/main/java/com/festago/festagostaff/presentation/ui/ticketvalidation/TicketValidationViewModel.kt
+++ b/android/festago-staff/app/src/main/java/com/festago/festagostaff/presentation/ui/ticketvalidation/TicketValidationViewModel.kt
@@ -15,11 +15,21 @@ class TicketValidationViewModel(
     private val _ticketState: MutableLiveData<String> = MutableLiveData("")
     val ticketState: LiveData<String> = _ticketState
 
+    private var latestCode = ""
+
     fun validateTicketCode(code: String) {
         viewModelScope.launch {
             _ticketState.value = ticketRepository.validateTicket(code).toString()
         }
+        latestCode = code
     }
+
+    fun clearLatestCode() {
+        _ticketState.value = ""
+        latestCode = ""
+    }
+
+    fun isLatestCode(code: String): Boolean = latestCode == code
 
     class TicketScanViewModelFactory(
         private val ticketRepository: TicketRepository,

--- a/android/festago-staff/app/src/main/res/drawable/btn_circle_primary.xml
+++ b/android/festago-staff/app/src/main/res/drawable/btn_circle_primary.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="@color/md_theme_light_primary" />
+</shape>

--- a/android/festago-staff/app/src/main/res/drawable/ic_refresh.xml
+++ b/android/festago-staff/app/src/main/res/drawable/ic_refresh.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/android/festago-staff/app/src/main/res/layout/activity_ticket_validation.xml
+++ b/android/festago-staff/app/src/main/res/layout/activity_ticket_validation.xml
@@ -23,7 +23,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <ImageButton
-            android:id="@+id/btnScan"
+            android:id="@+id/btnRefresh"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/space"
@@ -34,7 +34,7 @@
             android:src="@drawable/ic_refresh"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/dbvScanner"
-            app:tint="@color/design_default_color_on_primary" />
+            app:tint="@color/md_theme_light_onPrimary" />
 
         <TextView
             android:id="@+id/tvScanResult"

--- a/android/festago-staff/app/src/main/res/layout/activity_ticket_validation.xml
+++ b/android/festago-staff/app/src/main/res/layout/activity_ticket_validation.xml
@@ -15,14 +15,37 @@
         android:layout_height="match_parent"
         tools:context=".presentation.ui.ticketvalidation.TicketValidationActivity">
 
+        <com.journeyapps.barcodescanner.DecoratedBarcodeView
+            android:id="@+id/dbvScanner"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageButton
+            android:id="@+id/btnScan"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/space"
+            android:background="@drawable/btn_circle_primary"
+            android:importantForAccessibility="no"
+            android:onClick="@{() -> vm.clearLatestCode()}"
+            android:padding="@dimen/space_sm"
+            android:src="@drawable/ic_refresh"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/dbvScanner"
+            app:tint="@color/design_default_color_on_primary" />
+
         <TextView
+            android:id="@+id/tvScanResult"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@{vm.ticketState}"
+            android:textSize="28sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/dbvScanner" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/festago-staff/app/src/test/java/com/festago/festagostaff/presentation/ui/ticketvalidation/TicketValidationViewModelTest.kt
+++ b/android/festago-staff/app/src/test/java/com/festago/festagostaff/presentation/ui/ticketvalidation/TicketValidationViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.festago.festagostaff.domain.model.TicketState
 import com.festago.festagostaff.domain.repository.TicketRepository
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -18,6 +19,7 @@ class TicketValidationViewModelTest {
     private lateinit var ticketRepository: TicketRepository
 
     private val fakeTicketState = TicketState.AFTER_ENTRY
+    private val fakeCode = "XXX"
 
     @get:Rule
     val instantExecutorRule = InstantTaskExecutorRule()
@@ -33,12 +35,36 @@ class TicketValidationViewModelTest {
     fun `티켓 코드 검증을 하면 새로운 티켓 상태를 불러올 수 있다`() {
         // given
         coEvery { ticketRepository.validateTicket(any()) } returns fakeTicketState
-        val fakeCode = "xxx"
 
         // when
         vm.validateTicketCode(fakeCode)
 
         // then
         assertThat(vm.ticketState.value).isEqualTo(fakeTicketState.toString())
+    }
+
+    @Test
+    fun `티켓 코드를 검증을 하면 검증한 코드는 최근 검증 코드와 같다`() {
+        // given
+        coJustRun { ticketRepository.validateTicket(any()) }
+
+        // when
+        vm.validateTicketCode(fakeCode)
+
+        // then
+        assertThat(vm.isLatestCode(fakeCode)).isEqualTo(true)
+    }
+
+    @Test
+    fun `티켓 코드 검증 후 최근 검증 코드를 초기화하면 검증한 코드는 최근 검증 코드와 다르다`() {
+        // given
+        coJustRun { ticketRepository.validateTicket(any()) }
+
+        // when
+        vm.validateTicketCode(fakeCode)
+        vm.clearLatestCode()
+
+        // then
+        assertThat(vm.isLatestCode(fakeCode)).isEqualTo(false)
     }
 }

--- a/android/festago-staff/app/src/test/java/com/festago/festagostaff/presentation/ui/ticketvalidation/TicketValidationViewModelTest.kt
+++ b/android/festago-staff/app/src/test/java/com/festago/festagostaff/presentation/ui/ticketvalidation/TicketValidationViewModelTest.kt
@@ -52,7 +52,7 @@ class TicketValidationViewModelTest {
         vm.validateTicketCode(fakeCode)
 
         // then
-        assertThat(vm.isLatestCode(fakeCode)).isEqualTo(true)
+        assertThat(vm.isLatestCode(fakeCode)).isTrue
     }
 
     @Test
@@ -65,6 +65,6 @@ class TicketValidationViewModelTest {
         vm.clearLatestCode()
 
         // then
-        assertThat(vm.isLatestCode(fakeCode)).isEqualTo(false)
+        assertThat(vm.isLatestCode(fakeCode)).isFalse
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #63 

## ✨ PR 세부 내용

- QR을 연속적으로 스캔할 수 있도록 수정
- 별도 화면에서 스캔하지않고, ScanValidationActivity 내에서 스캔 및 결과 확인할 수 있도록 수정
- 직전에 인식했던 QR 코드가 또 인식되면 코드 검증 요청을 보내지 않도록 함



