### PR TITLE
[AN/USER]  feat: 메인 화면을 프래그먼트, 바텀네비게이션 구현(#92)

### DIFF
--- a/android/festago/app/src/main/AndroidManifest.xml
+++ b/android/festago/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -15,10 +16,7 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
-            android:name=".presentation.ui.ticketentry.TicketEntryActivity"
-            android:exported="true"></activity>
-        <activity
-            android:name=".presentation.ui.MainActivity"
+            android:name=".presentation.ui.home.HomeActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -26,6 +24,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".presentation.ui.ticketentry.TicketEntryActivity"
+            android:exported="false" />
+        <activity
+            android:name=".presentation.ui.MainActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/MainViewModel.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/MainViewModel.kt
@@ -37,7 +37,7 @@ class MainViewModel(
 
     fun loadTicket() {
         viewModelScope.launch(exceptionHandler) {
-            _ticket.postValue(ticketRepository.loadTicket(0L).toPresentation())
+            _ticket.postValue(ticketRepository.loadTicket(9L).toPresentation())
         }
     }
 

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/HomeActivity.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/HomeActivity.kt
@@ -1,0 +1,59 @@
+package com.festago.festago.presentation.ui.home
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import com.festago.festago.R
+import com.festago.festago.databinding.ActivityHomeBinding
+import com.festago.festago.presentation.ui.home.festivallist.FestivalListFragment
+import com.festago.festago.presentation.ui.home.mypage.MyPageFragment
+import com.festago.festago.presentation.ui.home.ticketlist.TicketListFragment
+
+class HomeActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val binding = ActivityHomeBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.bnvHome.setOnItemSelectedListener {
+            when (getItemType(it.itemId)) {
+                HomeItemType.FESTIVAL_LIST -> changeFragment<FestivalListFragment>()
+                HomeItemType.TICKET_LIST -> changeFragment<TicketListFragment>()
+                HomeItemType.MY_PAGE -> changeFragment<MyPageFragment>()
+            }
+            true
+        }
+
+        changeFragment<FestivalListFragment>()
+    }
+
+    private fun getItemType(menuItemId: Int): HomeItemType {
+        return when (menuItemId) {
+            R.id.item_festival -> HomeItemType.FESTIVAL_LIST
+            R.id.item_mypage -> HomeItemType.MY_PAGE
+            R.id.item_ticket -> HomeItemType.TICKET_LIST
+            else -> throw IllegalArgumentException("menu item id not found")
+        }
+    }
+
+    private inline fun <reified T : Fragment> AppCompatActivity.changeFragment() {
+        val tag = T::class.java.name
+        val fragmentTransaction = supportFragmentManager.beginTransaction()
+
+        supportFragmentManager.fragments.forEach { fragment ->
+            fragmentTransaction.hide(fragment)
+        }
+
+        var targetFragment = supportFragmentManager.findFragmentByTag(tag)
+
+        if (targetFragment == null) {
+            targetFragment = T::class.java.newInstance()
+            fragmentTransaction.add(R.id.fcv_home_container, targetFragment, tag)
+        } else {
+            fragmentTransaction.show(targetFragment)
+        }
+
+        fragmentTransaction.commit()
+    }
+}

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/HomeActivity.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/HomeActivity.kt
@@ -37,7 +37,7 @@ class HomeActivity : AppCompatActivity() {
         }
     }
 
-    private inline fun <reified T : Fragment> AppCompatActivity.changeFragment() {
+    private inline fun <reified T : Fragment> changeFragment() {
         val tag = T::class.java.name
         val fragmentTransaction = supportFragmentManager.beginTransaction()
 

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/HomeItemType.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/HomeItemType.kt
@@ -1,0 +1,7 @@
+package com.festago.festago.presentation.ui.home
+
+enum class HomeItemType {
+    FESTIVAL_LIST,
+    TICKET_LIST,
+    MY_PAGE,
+}

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
@@ -9,12 +9,21 @@ import com.festago.festago.R
 import com.festago.festago.databinding.FragmentFestivalListBinding
 
 class FestivalListFragment : Fragment(R.layout.fragment_festival_list) {
+
+    private var _binding: FragmentFestivalListBinding? = null
+    private val binding get() = _binding!!
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        val binding = FragmentFestivalListBinding.inflate(inflater)
+        _binding = FragmentFestivalListBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 }

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
@@ -1,0 +1,20 @@
+package com.festago.festago.presentation.ui.home.festivallist
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.festago.festago.R
+import com.festago.festago.databinding.FragmentFestivalListBinding
+
+class FestivalListFragment : Fragment(R.layout.fragment_festival_list) {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val binding = FragmentFestivalListBinding.inflate(inflater)
+        return binding.root
+    }
+}

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/mypage/MyPageFragment.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/mypage/MyPageFragment.kt
@@ -1,0 +1,20 @@
+package com.festago.festago.presentation.ui.home.mypage
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.festago.festago.R
+import com.festago.festago.databinding.FragmentMyPageBinding
+
+class MyPageFragment : Fragment(R.layout.fragment_my_page) {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val binding = FragmentMyPageBinding.inflate(inflater)
+        return binding.root
+    }
+}

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/mypage/MyPageFragment.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/mypage/MyPageFragment.kt
@@ -9,12 +9,21 @@ import com.festago.festago.R
 import com.festago.festago.databinding.FragmentMyPageBinding
 
 class MyPageFragment : Fragment(R.layout.fragment_my_page) {
+
+    private var _binding: FragmentMyPageBinding? = null
+    private val binding get() = _binding!!
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        val binding = FragmentMyPageBinding.inflate(inflater)
+        _binding = FragmentMyPageBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 }

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/ticketlist/TicketListFragment.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/ticketlist/TicketListFragment.kt
@@ -9,12 +9,21 @@ import com.festago.festago.R
 import com.festago.festago.databinding.FragmentTicketListBinding
 
 class TicketListFragment : Fragment(R.layout.fragment_ticket_list) {
+
+    private var _binding: FragmentTicketListBinding? = null
+    private val binding get() = _binding!!
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        val binding = FragmentTicketListBinding.inflate(inflater)
+        _binding = FragmentTicketListBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 }

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/ticketlist/TicketListFragment.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/ticketlist/TicketListFragment.kt
@@ -1,0 +1,20 @@
+package com.festago.festago.presentation.ui.home.ticketlist
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.festago.festago.R
+import com.festago.festago.databinding.FragmentTicketListBinding
+
+class TicketListFragment : Fragment(R.layout.fragment_ticket_list) {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val binding = FragmentTicketListBinding.inflate(inflater)
+        return binding.root
+    }
+}

--- a/android/festago/app/src/main/res/drawable/ic_bottom_navigation_festival.xml
+++ b/android/festago/app/src/main/res/drawable/ic_bottom_navigation_festival.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M13,5.7l0,-1.7l3,0l-1,-1.49l1,-1.51l-5,0l0,4.7l-9,6.3l0,10l7,0l0,-5l3.03,-2l2.97,2l0,5l7,0l0,-10z"/>
+</vector>

--- a/android/festago/app/src/main/res/drawable/ic_bottom_navigation_user.xml
+++ b/android/festago/app/src/main/res/drawable/ic_bottom_navigation_user.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+</vector>

--- a/android/festago/app/src/main/res/layout/activity_home.xml
+++ b/android/festago/app/src/main/res/layout/activity_home.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.ui.home.HomeActivity">
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fcv_home_container"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/bnv_home"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.bottomnavigation.BottomNavigationView
+            android:id="@+id/bnv_home"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:labelVisibilityMode="unlabeled"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:menu="@menu/menu_bottom_navigation" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/festago/app/src/main/res/layout/fragment_festival_list.xml
+++ b/android/festago/app/src/main/res/layout/fragment_festival_list.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.ui.home.festivallist.FestivalListFragment">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="Festival List Fragment" />
+
+    </FrameLayout>
+</layout>

--- a/android/festago/app/src/main/res/layout/fragment_my_page.xml
+++ b/android/festago/app/src/main/res/layout/fragment_my_page.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.ui.home.mypage.MyPageFragment">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="My Page Fragment" />
+
+    </FrameLayout>
+</layout>

--- a/android/festago/app/src/main/res/layout/fragment_ticket_list.xml
+++ b/android/festago/app/src/main/res/layout/fragment_ticket_list.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.ui.home.ticketlist.TicketListFragment">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="Ticket List Fragment" />
+
+    </FrameLayout>
+</layout>

--- a/android/festago/app/src/main/res/menu/menu_bottom_navigation.xml
+++ b/android/festago/app/src/main/res/menu/menu_bottom_navigation.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/item_festival"
+        android:enabled="true"
+        android:icon="@drawable/ic_bottom_navigation_festival"
+        android:iconTint="@color/md_theme_light_secondary"
+        android:title="@string/home_bottom_navigation_festival" />
+    <item
+        android:id="@+id/item_ticket"
+        android:enabled="true"
+        android:icon="@drawable/ic_festago_logo_foreground"
+        android:iconTint="@color/md_theme_light_secondary"
+        android:title="@string/home_bottom_navigation_ticket" />
+    <item
+        android:id="@+id/item_mypage"
+        android:enabled="true"
+        android:icon="@drawable/ic_bottom_navigation_user"
+        android:iconTint="@color/md_theme_light_secondary"
+        android:title="@string/home_bottom_navigation_user" />
+</menu>

--- a/android/festago/app/src/main/res/values/strings.xml
+++ b/android/festago/app/src/main/res/values/strings.xml
@@ -21,6 +21,8 @@
     <string name="ticket_entry_tv_before_entry">입장 전</string>
     <string name="ticket_entry_tv_after_entry">입장 완료</string>
     <string name="ticket_entry_tv_away">외출중</string>
+
+    <!-- Strings related to home -->
     <string name="home_bottom_navigation_festival">축제 목록</string>
     <string name="home_bottom_navigation_ticket">티켓 목록</string>
     <string name="home_bottom_navigation_user">마이페이지</string>

--- a/android/festago/app/src/main/res/values/strings.xml
+++ b/android/festago/app/src/main/res/values/strings.xml
@@ -21,4 +21,7 @@
     <string name="ticket_entry_tv_before_entry">입장 전</string>
     <string name="ticket_entry_tv_after_entry">입장 완료</string>
     <string name="ticket_entry_tv_away">외출중</string>
+    <string name="home_bottom_navigation_festival">축제 목록</string>
+    <string name="home_bottom_navigation_ticket">티켓 목록</string>
+    <string name="home_bottom_navigation_user">마이페이지</string>
 </resources>


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #92 

## ✨ PR 세부 내용

- HomeActivity에서 바텀네비게이션으로 화면을 이동하도록 구현했습니다.
- FestivalListFragment / TicketListFragment / MyPageFramgent 로 이동합니다.
- 프래그먼트는 show / hide로 변경됩니다. 
- 디자인 작업 없이 빈 화면으로 이동하도록 구현했습니다.
- 앱 실행 시 HomeActivity로 launch 되도록 했습니다.
