### PR TITLE
[AN/USER] feat: 축제 목록 화면 구현(#95)

### DIFF
--- a/android/festago/app/src/main/AndroidManifest.xml
+++ b/android/festago/app/src/main/AndroidManifest.xml
@@ -17,9 +17,6 @@
         tools:targetApi="31">
         <activity
             android:name=".presentation.ui.home.HomeActivity"
-            android:exported="true" />
-        <activity
-            android:name=".presentation.ui.ticketreserve.TicketReserveActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -27,6 +24,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".presentation.ui.ticketreserve.TicketReserveActivity"
+            android:exported="false" />
         <activity
             android:name=".presentation.ui.ticketentry.TicketEntryActivity"
             android:exported="false" />

--- a/android/festago/app/src/main/java/com/festago/festago/data/repository/FestivalDefaultRepository.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/data/repository/FestivalDefaultRepository.kt
@@ -1,0 +1,23 @@
+package com.festago.festago.data.repository
+
+import com.festago.festago.domain.model.Festival
+import com.festago.festago.domain.repository.FestivalRepository
+import kotlinx.coroutines.delay
+import java.time.LocalDate
+
+class FestivalDefaultRepository : FestivalRepository {
+    override suspend fun loadFestivals(): Result<List<Festival>> {
+        delay(1000)
+        return Result.success(
+            List(20) {
+                Festival(
+                    it.toLong(),
+                    "테코대학교 $it",
+                    LocalDate.of(2023, 5, 15),
+                    LocalDate.of(2023, 5, 19),
+                    "",
+                )
+            },
+        )
+    }
+}

--- a/android/festago/app/src/main/java/com/festago/festago/domain/model/Festival.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/domain/model/Festival.kt
@@ -1,0 +1,11 @@
+package com.festago.festago.domain.model
+
+import java.time.LocalDate
+
+data class Festival(
+    val id: Long,
+    val name: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val thumbnail: String,
+)

--- a/android/festago/app/src/main/java/com/festago/festago/domain/repository/FestivalRepository.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/domain/repository/FestivalRepository.kt
@@ -1,0 +1,7 @@
+package com.festago.festago.domain.repository
+
+import com.festago.festago.domain.model.Festival
+
+interface FestivalRepository {
+    suspend fun loadFestivals(): Result<List<Festival>>
+}

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/mapper/FestivalMapper.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/mapper/FestivalMapper.kt
@@ -5,3 +5,5 @@ import com.festago.festago.presentation.model.FestivalUiModel
 
 fun Festival.toPresentation(): FestivalUiModel =
     FestivalUiModel(id, name, startDate, endDate, thumbnail)
+
+fun List<Festival>.toPresentation(): List<FestivalUiModel> = this.map { it.toPresentation() }

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/mapper/FestivalMapper.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/mapper/FestivalMapper.kt
@@ -1,0 +1,7 @@
+package com.festago.festago.presentation.mapper
+
+import com.festago.festago.domain.model.Festival
+import com.festago.festago.presentation.model.FestivalUiModel
+
+fun Festival.toPresentation(): FestivalUiModel =
+    FestivalUiModel(id, name, startDate, endDate, thumbnail)

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/model/FestivalUiModel.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/model/FestivalUiModel.kt
@@ -1,0 +1,11 @@
+package com.festago.festago.presentation.model
+
+import java.time.LocalDate
+
+data class FestivalUiModel(
+    val id: Long,
+    val name: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val thumbnail: String,
+)

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/BindingAdapter.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/BindingAdapter.kt
@@ -1,9 +1,21 @@
 package com.festago.festago.presentation.ui
 
 import android.view.View
+import android.widget.ImageView
 import androidx.databinding.BindingAdapter
+import com.bumptech.glide.Glide
+import com.festago.festago.R
 
 @BindingAdapter("visibility")
 fun View.setVisibility(isVisible: Boolean) {
     this.visibility = if (isVisible) View.VISIBLE else View.GONE
+}
+
+@BindingAdapter("imageUrl")
+fun ImageView.setImage(imageUrl: String) {
+    Glide.with(context)
+        .load(imageUrl)
+        .error(R.drawable.ic_image_placeholder)
+        .fallback(R.drawable.ic_image_placeholder)
+        .into(this)
 }

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalItemViewHolder.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalItemViewHolder.kt
@@ -1,0 +1,27 @@
+package com.festago.festago.presentation.ui.home.festivallist
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.festago.festago.databinding.ItemFestivalBinding
+import com.festago.festago.presentation.model.FestivalUiModel
+
+class FestivalItemViewHolder(
+    private val binding: ItemFestivalBinding,
+) : RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(item: FestivalUiModel) {
+        binding.festival = item
+    }
+
+    companion object {
+        fun from(parent: ViewGroup): FestivalItemViewHolder {
+            val binding = ItemFestivalBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false,
+            )
+            return FestivalItemViewHolder(binding)
+        }
+    }
+}

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListAdapter.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListAdapter.kt
@@ -1,0 +1,35 @@
+package com.festago.festago.presentation.ui.home.festivallist
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.festago.festago.presentation.model.FestivalUiModel
+
+class FestivalListAdapter : ListAdapter<FestivalUiModel, FestivalItemViewHolder>(diffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FestivalItemViewHolder {
+        return FestivalItemViewHolder.from(parent)
+    }
+
+    override fun onBindViewHolder(holder: FestivalItemViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<FestivalUiModel>() {
+            override fun areItemsTheSame(
+                oldItem: FestivalUiModel,
+                newItem: FestivalUiModel,
+            ): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(
+                oldItem: FestivalUiModel,
+                newItem: FestivalUiModel,
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListBindingAdapter.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListBindingAdapter.kt
@@ -1,0 +1,17 @@
+package com.festago.festago.presentation.ui.home.festivallist
+
+import android.widget.TextView
+import androidx.databinding.BindingAdapter
+import com.festago.festago.R
+import com.festago.festago.presentation.model.FestivalUiModel
+import java.time.format.DateTimeFormatter
+
+@BindingAdapter("dateRange")
+fun TextView.setDateRange(festival: FestivalUiModel) {
+    val datePattern = context.getString(R.string.festival_list_tv_date_format)
+
+    this.text = context.getString(R.string.festival_list_tv_date_range_format).format(
+        festival.startDate.format(DateTimeFormatter.ofPattern(datePattern)),
+        festival.endDate.format(DateTimeFormatter.ofPattern(datePattern)),
+    )
+}

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
@@ -54,11 +54,11 @@ class FestivalListFragment : Fragment(R.layout.fragment_festival_list) {
 
     private fun updateUi(uiState: FestivalListUiState) {
         when (uiState) {
+            is FestivalListUiState.Loading, is FestivalListUiState.Error -> Unit
+
             is FestivalListUiState.Success -> {
                 adapter.submitList(uiState.festivals)
             }
-
-            is FestivalListUiState.Loading, is FestivalListUiState.Error -> Unit
         }
     }
 

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
@@ -5,13 +5,24 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.festago.festago.R
+import com.festago.festago.data.repository.FestivalDefaultRepository
 import com.festago.festago.databinding.FragmentFestivalListBinding
+import com.festago.festago.presentation.ui.home.festivallist.FestivalListViewModel.FestivalListViewModelFactory
 
 class FestivalListFragment : Fragment(R.layout.fragment_festival_list) {
 
     private var _binding: FragmentFestivalListBinding? = null
     private val binding get() = _binding!!
+
+    private val vm: FestivalListViewModel by viewModels {
+        FestivalListViewModelFactory(
+            FestivalDefaultRepository(),
+        )
+    }
+
+    private val adapter: FestivalListAdapter = FestivalListAdapter()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -20,6 +31,35 @@ class FestivalListFragment : Fragment(R.layout.fragment_festival_list) {
     ): View {
         _binding = FragmentFestivalListBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initObserve()
+        initView()
+    }
+
+    private fun initObserve() {
+        vm.uiState.observe(viewLifecycleOwner) {
+            binding.uiState = it
+            updateUi(it)
+        }
+    }
+
+    private fun initView() {
+        binding.rvFestivalList.adapter = adapter
+        vm.loadFestivals()
+    }
+
+    private fun updateUi(uiState: FestivalListUiState) {
+        when (uiState) {
+            is FestivalListUiState.Success -> {
+                adapter.submitList(uiState.festivals)
+            }
+
+            is FestivalListUiState.Loading, is FestivalListUiState.Error -> Unit
+        }
     }
 
     override fun onDestroyView() {

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListUiState.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListUiState.kt
@@ -1,0 +1,15 @@
+package com.festago.festago.presentation.ui.home.festivallist
+
+import com.festago.festago.presentation.model.FestivalUiModel
+
+sealed interface FestivalListUiState {
+    object Loading : FestivalListUiState
+
+    data class Success(val festivals: List<FestivalUiModel>) : FestivalListUiState
+
+    object Error : FestivalListUiState
+
+    val shouldShowSuccess get() = this is Success
+    val shouldShowLoading get() = this is Loading
+    val shouldShowError get() = this is Error
+}

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModel.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModel.kt
@@ -1,0 +1,46 @@
+package com.festago.festago.presentation.ui.home.festivallist
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.festago.festago.domain.repository.FestivalRepository
+import com.festago.festago.presentation.mapper.toPresentation
+import kotlinx.coroutines.launch
+
+class FestivalListViewModel(
+    private val festivalRepository: FestivalRepository,
+) : ViewModel() {
+    private val _uiState = MutableLiveData<FestivalListUiState>()
+    val uiState: LiveData<FestivalListUiState> = _uiState
+
+    fun loadFestivals() {
+        viewModelScope.launch {
+            _uiState.value = FestivalListUiState.Loading
+            festivalRepository.loadFestivals()
+                .onSuccess {
+                    _uiState.value = FestivalListUiState.Success(
+                        it.map { festival ->
+                            festival.toPresentation()
+                        },
+                    )
+                }.onFailure {
+                    _uiState.value = FestivalListUiState.Error
+                }
+        }
+    }
+
+    class FestivalListViewModelFactory(
+        private val festivalRepository: FestivalRepository,
+    ) : ViewModelProvider.Factory {
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(FestivalListViewModel::class.java)) {
+                return FestivalListViewModel(festivalRepository) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel Class")
+        }
+    }
+}

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModel.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModel.kt
@@ -20,11 +20,7 @@ class FestivalListViewModel(
             _uiState.value = FestivalListUiState.Loading
             festivalRepository.loadFestivals()
                 .onSuccess {
-                    _uiState.value = FestivalListUiState.Success(
-                        it.map { festival ->
-                            festival.toPresentation()
-                        },
-                    )
+                    _uiState.value = FestivalListUiState.Success(it.toPresentation())
                 }.onFailure {
                     _uiState.value = FestivalListUiState.Error
                 }

--- a/android/festago/app/src/main/res/drawable/ic_image_placeholder.xml
+++ b/android/festago/app/src/main/res/drawable/ic_image_placeholder.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="@color/md_theme_light_inversePrimary"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/md_theme_light_inversePrimary" android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+</vector>

--- a/android/festago/app/src/main/res/layout/fragment_festival_list.xml
+++ b/android/festago/app/src/main/res/layout/fragment_festival_list.xml
@@ -1,16 +1,76 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
+    <data>
+
+        <variable
+            name="uiState"
+            type="com.festago.festago.presentation.ui.home.festivallist.FestivalListUiState" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".presentation.ui.home.festivallist.FestivalListFragment">
 
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/cgFilterOption"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="16dp"
+            android:paddingTop="12dp"
+            app:checkedChip="@+id/chipOngoing"
+            app:layout_constraintTop_toTopOf="parent"
+            app:singleSelection="true">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chipOngoing"
+                style="@style/Widget.MaterialComponents.Chip.Choice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/festival_list_chip_ongoing" />
+
+            <com.google.android.material.chip.Chip
+                style="@style/Widget.MaterialComponents.Chip.Choice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/festival_list_chip_past" />
+        </com.google.android.material.chip.ChipGroup>
+
+        <ProgressBar
+            android:id="@+id/pbLoading"
+            visibility="@{uiState.shouldShowLoading}"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/cgFilterOption"
+            tools:visibility="gone" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvFestivalList"
+            visibility="@{uiState.shouldShowSuccess}"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:clipToPadding="false"
+            android:padding="8dp"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/cgFilterOption"
+            app:spanCount="2"
+            tools:listitem="@layout/item_festival" />
+
         <TextView
+            android:id="@+id/tvError"
+            visibility="@{uiState.shouldShowError}"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:text="Festival List Fragment" />
+            android:gravity="center"
+            android:text="@string/festival_list_tv_error"
+            tools:visibility="gone" />
 
-    </FrameLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/festago/app/src/main/res/layout/item_festival.xml
+++ b/android/festago/app/src/main/res/layout/item_festival.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <data>
+
+        <variable
+            name="festival"
+            type="com.festago.festago.presentation.model.FestivalUiModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="8dp">
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cv_festival_thumbnail"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:cardCornerRadius="8dp"
+            app:cardElevation="0dp"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/iv_festival_thumbnail"
+                imageUrl="@{festival.thumbnail}"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:importantForAccessibility="no"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:src="@drawable/ic_launcher_background" />
+
+        </androidx.cardview.widget.CardView>
+
+        <TextView
+            android:id="@+id/tv_festival_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@{festival.name}"
+            android:textColor="@color/md_theme_light_onBackground"
+            android:textSize="16sp"
+            app:layout_constraintTop_toBottomOf="@id/cv_festival_thumbnail"
+            tools:text="테코대학교" />
+
+        <TextView
+            android:id="@+id/tv_festival_schedule"
+            dateRange="@{festival}"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="8dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/md_theme_light_onBackground"
+            android:textSize="12sp"
+            app:layout_constraintTop_toBottomOf="@id/tv_festival_title"
+            tools:text="2023.07.03 - 2023.07.09" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/festago/app/src/main/res/values/strings.xml
+++ b/android/festago/app/src/main/res/values/strings.xml
@@ -40,4 +40,11 @@
     <string name="ticket_reserve_tv_auth_guide_student">⚠️ 재학생용 티켓예매를 위해 사전에 학교 인증이 필요합니다.</string>
     <string name="ticket_reserve_tv_error_page">예매 가능한 티켓이 없습니다.</string>
     <string name="ticket_reserve_btn_reserve_ticket">티켓 예매</string>
+
+    <!-- Strings related to festival list -->
+    <string name="festival_list_tv_date_format">yyyy.MM.dd</string>
+    <string name="festival_list_chip_ongoing">진행중</string>
+    <string name="festival_list_chip_past">지난축제</string>
+    <string name="festival_list_tv_error">조회된 축제가 없습니다.</string>
+    <string name="festival_list_tv_date_range_format">%s - %s</string>
 </resources>

--- a/android/festago/app/src/test/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModelTest.kt
+++ b/android/festago/app/src/test/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModelTest.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.SoftAssertions
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -64,14 +64,20 @@ class FestivalListViewModelTest {
         vm.loadFestivals()
 
         // then
-        assertThat(vm.uiState.value).isInstanceOf(FestivalListUiState.Success::class.java)
-        assertThat(vm.uiState.value?.shouldShowSuccess).isEqualTo(true)
-        assertThat(vm.uiState.value?.shouldShowLoading).isEqualTo(false)
-        assertThat(vm.uiState.value?.shouldShowError).isEqualTo(false)
+        val softly = SoftAssertions().apply {
+            assertThat(vm.uiState.value).isInstanceOf(FestivalListUiState.Success::class.java)
 
-        val actual = (vm.uiState.value as FestivalListUiState.Success).festivals
-        val expected = fakeFestivals.map { it.toPresentation() }
-        assertThat(actual).isEqualTo(expected)
+            // and
+            assertThat(vm.uiState.value?.shouldShowSuccess).isEqualTo(true)
+            assertThat(vm.uiState.value?.shouldShowLoading).isEqualTo(false)
+            assertThat(vm.uiState.value?.shouldShowError).isEqualTo(false)
+
+            // and
+            val actual = (vm.uiState.value as FestivalListUiState.Success).festivals
+            val expected = fakeFestivals.map { it.toPresentation() }
+            assertThat(actual).isEqualTo(expected)
+        }
+        softly.assertAll()
     }
 
     @Test
@@ -87,10 +93,15 @@ class FestivalListViewModelTest {
         vm.loadFestivals()
 
         // then
-        assertThat(vm.uiState.value).isInstanceOf(FestivalListUiState.Error::class.java)
-        assertThat(vm.uiState.value?.shouldShowSuccess).isEqualTo(false)
-        assertThat(vm.uiState.value?.shouldShowLoading).isEqualTo(false)
-        assertThat(vm.uiState.value?.shouldShowError).isEqualTo(true)
+        val softly = SoftAssertions().apply {
+            assertThat(vm.uiState.value).isInstanceOf(FestivalListUiState.Error::class.java)
+
+            // and
+            assertThat(vm.uiState.value?.shouldShowSuccess).isEqualTo(false)
+            assertThat(vm.uiState.value?.shouldShowLoading).isEqualTo(false)
+            assertThat(vm.uiState.value?.shouldShowError).isEqualTo(true)
+        }
+        softly.assertAll()
     }
 
     @Test
@@ -107,9 +118,14 @@ class FestivalListViewModelTest {
         vm.loadFestivals()
 
         // then
-        assertThat(vm.uiState.value).isInstanceOf(FestivalListUiState.Loading::class.java)
-        assertThat(vm.uiState.value?.shouldShowSuccess).isEqualTo(false)
-        assertThat(vm.uiState.value?.shouldShowLoading).isEqualTo(true)
-        assertThat(vm.uiState.value?.shouldShowError).isEqualTo(false)
+        val softly = SoftAssertions().apply {
+            assertThat(vm.uiState.value).isInstanceOf(FestivalListUiState.Loading::class.java)
+
+            // and
+            assertThat(vm.uiState.value?.shouldShowSuccess).isEqualTo(false)
+            assertThat(vm.uiState.value?.shouldShowLoading).isEqualTo(true)
+            assertThat(vm.uiState.value?.shouldShowError).isEqualTo(false)
+        }
+        softly.assertAll()
     }
 }

--- a/android/festago/app/src/test/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModelTest.kt
+++ b/android/festago/app/src/test/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModelTest.kt
@@ -1,0 +1,115 @@
+package com.festago.festago.presentation.ui.home.festivallist
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.festago.festago.domain.model.Festival
+import com.festago.festago.domain.repository.FestivalRepository
+import com.festago.festago.presentation.mapper.toPresentation
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.lang.Exception
+import java.time.LocalDate
+
+class FestivalListViewModelTest {
+    private lateinit var vm: FestivalListViewModel
+    private lateinit var festivalRepository: FestivalRepository
+
+    private val fakeFestivals = List(5) {
+        Festival(
+            it.toLong(),
+            "테코대학교 $it",
+            LocalDate.of(2023, 5, 15),
+            LocalDate.of(2023, 5, 19),
+            "",
+        )
+    }
+
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        festivalRepository = mockk()
+        vm = FestivalListViewModel(festivalRepository)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @After
+    fun finish() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `축제 목록 받아오기에 성공하면 성공 상태이고 축제 목록을 반환한다`() {
+        // given
+        coEvery {
+            festivalRepository.loadFestivals()
+        } answers {
+            Result.success(fakeFestivals)
+        }
+
+        // when
+        vm.loadFestivals()
+
+        // then
+        assertThat(vm.uiState.value).isInstanceOf(FestivalListUiState.Success::class.java)
+        assertThat(vm.uiState.value?.shouldShowSuccess).isEqualTo(true)
+        assertThat(vm.uiState.value?.shouldShowLoading).isEqualTo(false)
+        assertThat(vm.uiState.value?.shouldShowError).isEqualTo(false)
+
+        val actual = (vm.uiState.value as FestivalListUiState.Success).festivals
+        val expected = fakeFestivals.map { it.toPresentation() }
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `축제 목록 받아오기에 실패하면 에러 상태다`() {
+        // given
+        coEvery {
+            festivalRepository.loadFestivals()
+        } answers {
+            Result.failure(Exception())
+        }
+
+        // when
+        vm.loadFestivals()
+
+        // then
+        assertThat(vm.uiState.value).isInstanceOf(FestivalListUiState.Error::class.java)
+        assertThat(vm.uiState.value?.shouldShowSuccess).isEqualTo(false)
+        assertThat(vm.uiState.value?.shouldShowLoading).isEqualTo(false)
+        assertThat(vm.uiState.value?.shouldShowError).isEqualTo(true)
+    }
+
+    @Test
+    fun `축제 목록을 받아오는 중이면 로딩 상태다`() {
+        // given
+        coEvery {
+            festivalRepository.loadFestivals()
+        } coAnswers {
+            delay(1000)
+            Result.success(emptyList())
+        }
+
+        // when
+        vm.loadFestivals()
+
+        // then
+        assertThat(vm.uiState.value).isInstanceOf(FestivalListUiState.Loading::class.java)
+        assertThat(vm.uiState.value?.shouldShowSuccess).isEqualTo(false)
+        assertThat(vm.uiState.value?.shouldShowLoading).isEqualTo(true)
+        assertThat(vm.uiState.value?.shouldShowError).isEqualTo(false)
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #95 

## ✨ PR 세부 내용

- 축제 목록 화면 구현했습니다.
- 리포지토리에서 목 데이터 리턴하도록 했습니다. (로딩 상태를 확인할 수 있도록 delay()가 있습니다)
- 이미지에 사용되는 바인딩어댑터 추가했습니다(Glide). 이미지 바인딩할 때 사용해주세요.
- "진행중/지난축제" 칩은 아직 기획적으로 확정된 부분이 아니라서 임시로 구현했습니다.

![Jul-26-2023 21-47-26](https://github.com/woowacourse-teams/2023-festa-go/assets/67777523/05375cde-bf05-4469-8904-000434d76ba2)

