### PR TITLE
[BE] feat: 티켓을 생성할 때 데이터베이스에 INSERT 되지 않는 버그 수정 (#151)

### DIFF
--- a/backend/src/main/java/com/festago/application/TicketService.java
+++ b/backend/src/main/java/com/festago/application/TicketService.java
@@ -34,7 +34,7 @@ public class TicketService {
         TicketType ticketType = request.ticketType();
 
         Ticket ticket = ticketRepository.findByTicketTypeAndStage(ticketType, stage)
-            .orElse(ticketRepository.save(new Ticket(stage, ticketType)));
+            .orElseGet(() -> ticketRepository.save(new Ticket(stage, ticketType)));
 
         ticket.addTicketEntryTime(request.entryTime(), request.amount());
 

--- a/backend/src/main/java/com/festago/application/TicketService.java
+++ b/backend/src/main/java/com/festago/application/TicketService.java
@@ -22,7 +22,8 @@ public class TicketService {
     private final StageRepository stageRepository;
     private final MemberTicketRepository memberTicketRepository;
 
-    public TicketService(TicketRepository ticketRepository, StageRepository stageRepository, MemberTicketRepository memberTicketRepository) {
+    public TicketService(TicketRepository ticketRepository, StageRepository stageRepository,
+                         MemberTicketRepository memberTicketRepository) {
         this.ticketRepository = ticketRepository;
         this.stageRepository = stageRepository;
         this.memberTicketRepository = memberTicketRepository;
@@ -33,7 +34,7 @@ public class TicketService {
         TicketType ticketType = request.ticketType();
 
         Ticket ticket = ticketRepository.findByTicketTypeAndStage(ticketType, stage)
-            .orElse(new Ticket(stage, ticketType));
+            .orElse(ticketRepository.save(new Ticket(stage, ticketType)));
 
         ticket.addTicketEntryTime(request.entryTime(), request.amount());
 

--- a/backend/src/main/java/com/festago/domain/Ticket.java
+++ b/backend/src/main/java/com/festago/domain/Ticket.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 @Entity
 public class Ticket {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -31,7 +32,7 @@ public class Ticket {
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     private TicketAmount ticketAmount = new TicketAmount();
 
-    @OneToMany
+    @OneToMany(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "ticket_id")
     private List<TicketEntryTime> ticketEntryTimes = new ArrayList<>();
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #151 

## ✨ PR 세부 내용

orElse() 사용 시, 값이 없더라도 해당 메소드를 호출하므로 중복된 데이터가 생성됩니다.
따라서 orElseGet()을 사용하여 값이 없을때만 새로운 Ticket을 영속하도록 수정했습니다.
