### PR TITLE
[BE] feat: 축제 상세 정보 조회 Api 구현(#119)

### DIFF
--- a/backend/src/main/java/com/festago/application/FestivalService.java
+++ b/backend/src/main/java/com/festago/application/FestivalService.java
@@ -2,12 +2,15 @@ package com.festago.application;
 
 import com.festago.domain.Festival;
 import com.festago.domain.FestivalRepository;
+import com.festago.domain.Stage;
+import com.festago.domain.StageRepository;
 import com.festago.dto.FestivalCreateRequest;
 import com.festago.dto.FestivalDetailResponse;
 import com.festago.dto.FestivalResponse;
 import com.festago.dto.FestivalsResponse;
 import com.festago.exception.ErrorCode;
 import com.festago.exception.NotFoundException;
+import java.util.Comparator;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,9 +20,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class FestivalService {
 
     private final FestivalRepository festivalRepository;
+    private final StageRepository stageRepository;
 
-    public FestivalService(FestivalRepository festivalRepository) {
+    public FestivalService(FestivalRepository festivalRepository, StageRepository stageRepository) {
         this.festivalRepository = festivalRepository;
+        this.stageRepository = stageRepository;
     }
 
     public FestivalResponse create(FestivalCreateRequest request) {
@@ -37,6 +42,9 @@ public class FestivalService {
     public FestivalDetailResponse findDetail(Long festivalId) {
         Festival festival = festivalRepository.findById(festivalId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.FESTIVAL_NOT_FOUND));
-        return FestivalDetailResponse.from(festival);
+        List<Stage> stages = stageRepository.findAllByFestival(festival).stream()
+            .sorted(Comparator.comparing(Stage::getStartTime))
+            .toList();
+        return FestivalDetailResponse.of(festival, stages);
     }
 }

--- a/backend/src/main/java/com/festago/application/FestivalService.java
+++ b/backend/src/main/java/com/festago/application/FestivalService.java
@@ -1,5 +1,7 @@
 package com.festago.application;
 
+import static java.util.Comparator.comparing;
+
 import com.festago.domain.Festival;
 import com.festago.domain.FestivalRepository;
 import com.festago.domain.Stage;
@@ -10,7 +12,6 @@ import com.festago.dto.FestivalResponse;
 import com.festago.dto.FestivalsResponse;
 import com.festago.exception.ErrorCode;
 import com.festago.exception.NotFoundException;
-import java.util.Comparator;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,8 +43,8 @@ public class FestivalService {
     public FestivalDetailResponse findDetail(Long festivalId) {
         Festival festival = festivalRepository.findById(festivalId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.FESTIVAL_NOT_FOUND));
-        List<Stage> stages = stageRepository.findAllByFestival(festival).stream()
-            .sorted(Comparator.comparing(Stage::getStartTime))
+        List<Stage> stages = stageRepository.findAllDetailByFestivalId(festivalId).stream()
+            .sorted(comparing(Stage::getStartTime))
             .toList();
         return FestivalDetailResponse.of(festival, stages);
     }

--- a/backend/src/main/java/com/festago/application/FestivalService.java
+++ b/backend/src/main/java/com/festago/application/FestivalService.java
@@ -3,8 +3,11 @@ package com.festago.application;
 import com.festago.domain.Festival;
 import com.festago.domain.FestivalRepository;
 import com.festago.dto.FestivalCreateRequest;
+import com.festago.dto.FestivalDetailResponse;
 import com.festago.dto.FestivalResponse;
 import com.festago.dto.FestivalsResponse;
+import com.festago.exception.ErrorCode;
+import com.festago.exception.NotFoundException;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,5 +31,12 @@ public class FestivalService {
     public FestivalsResponse findAll() {
         List<Festival> festivals = festivalRepository.findAll();
         return FestivalsResponse.from(festivals);
+    }
+
+    @Transactional(readOnly = true)
+    public FestivalDetailResponse findDetail(Long festivalId) {
+        Festival festival = festivalRepository.findById(festivalId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.FESTIVAL_NOT_FOUND));
+        return FestivalDetailResponse.from(festival);
     }
 }

--- a/backend/src/main/java/com/festago/domain/Festival.java
+++ b/backend/src/main/java/com/festago/domain/Festival.java
@@ -1,11 +1,14 @@
 package com.festago.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 public class Festival {
@@ -23,6 +26,9 @@ public class Festival {
     private LocalDate endDate;
 
     private String thumbnail;
+
+    @OneToMany(mappedBy = "festival", fetch = FetchType.LAZY)
+    private List<Stage> stages;
 
     protected Festival() {
     }
@@ -69,5 +75,9 @@ public class Festival {
 
     public String getThumbnail() {
         return thumbnail;
+    }
+
+    public List<Stage> getStages() {
+        return stages;
     }
 }

--- a/backend/src/main/java/com/festago/domain/Festival.java
+++ b/backend/src/main/java/com/festago/domain/Festival.java
@@ -1,14 +1,11 @@
 package com.festago.domain;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Entity
 public class Festival {
@@ -27,9 +24,6 @@ public class Festival {
 
     private String thumbnail;
 
-    @OneToMany(mappedBy = "festival", fetch = FetchType.LAZY)
-    private List<Stage> stages;
-
     protected Festival() {
     }
 
@@ -38,10 +32,7 @@ public class Festival {
     }
 
     public Festival(String name, LocalDate startDate, LocalDate endDate, String thumbnail) {
-        this.name = name;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.thumbnail = thumbnail;
+        this(null, name, startDate, endDate, thumbnail);
     }
 
     public Festival(Long id, String name, LocalDate startDate, LocalDate endDate, String thumbnail) {
@@ -75,9 +66,5 @@ public class Festival {
 
     public String getThumbnail() {
         return thumbnail;
-    }
-
-    public List<Stage> getStages() {
-        return stages;
     }
 }

--- a/backend/src/main/java/com/festago/domain/Stage.java
+++ b/backend/src/main/java/com/festago/domain/Stage.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -31,7 +32,7 @@ public class Stage {
     private Festival festival;
 
     @OneToMany(mappedBy = "stage", fetch = FetchType.LAZY)
-    private List<Ticket> tickets;
+    private List<Ticket> tickets = new ArrayList<>();
 
     protected Stage() {
     }

--- a/backend/src/main/java/com/festago/domain/Stage.java
+++ b/backend/src/main/java/com/festago/domain/Stage.java
@@ -9,7 +9,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 public class Stage {
@@ -27,6 +29,9 @@ public class Stage {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Festival festival;
+
+    @OneToMany(mappedBy = "stage", fetch = FetchType.LAZY)
+    private List<Ticket> tickets;
 
     protected Stage() {
     }
@@ -72,5 +77,9 @@ public class Stage {
 
     public Festival getFestival() {
         return festival;
+    }
+
+    public List<Ticket> getTickets() {
+        return tickets;
     }
 }

--- a/backend/src/main/java/com/festago/domain/StageRepository.java
+++ b/backend/src/main/java/com/festago/domain/StageRepository.java
@@ -2,8 +2,18 @@ package com.festago.domain;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StageRepository extends JpaRepository<Stage, Long> {
 
     List<Stage> findAllByFestival(Festival festival);
+
+    @Query("""
+        SELECT s FROM Stage s
+        JOIN FETCH s.tickets t
+        JOIN FETCH t.ticketAmount
+        WHERE s.festival.id = :festivalId
+        """)
+    List<Stage> findAllDetailByFestivalId(@Param("festivalId") Long festivalId);
 }

--- a/backend/src/main/java/com/festago/domain/StageRepository.java
+++ b/backend/src/main/java/com/festago/domain/StageRepository.java
@@ -1,7 +1,9 @@
 package com.festago.domain;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StageRepository extends JpaRepository<Stage, Long> {
 
+    List<Stage> findAllByFestival(Festival festival);
 }

--- a/backend/src/main/java/com/festago/domain/TicketAmount.java
+++ b/backend/src/main/java/com/festago/domain/TicketAmount.java
@@ -32,6 +32,10 @@ public class TicketAmount {
         totalAmount += amount;
     }
 
+    public int calculateRemainAmount() {
+        return totalAmount - reservedAmount;
+    }
+
     public Long getId() {
         return id;
     }

--- a/backend/src/main/java/com/festago/dto/FestivalDetailResponse.java
+++ b/backend/src/main/java/com/festago/dto/FestivalDetailResponse.java
@@ -1,0 +1,27 @@
+package com.festago.dto;
+
+import com.festago.domain.Festival;
+import java.time.LocalDate;
+import java.util.List;
+
+public record FestivalDetailResponse(Long id,
+                                     String name,
+                                     LocalDate startDate,
+                                     LocalDate endDate,
+                                     String thumbnail,
+                                     List<FestivalDetailStageResponse> stages) {
+
+    public static FestivalDetailResponse from(Festival festival) {
+        List<FestivalDetailStageResponse> stages = festival.getStages().stream()
+            .map(FestivalDetailStageResponse::from)
+            .toList();
+        return new FestivalDetailResponse(
+            festival.getId(),
+            festival.getName(),
+            festival.getStartDate(),
+            festival.getEndDate(),
+            festival.getThumbnail(),
+            stages
+        );
+    }
+}

--- a/backend/src/main/java/com/festago/dto/FestivalDetailResponse.java
+++ b/backend/src/main/java/com/festago/dto/FestivalDetailResponse.java
@@ -1,6 +1,7 @@
 package com.festago.dto;
 
 import com.festago.domain.Festival;
+import com.festago.domain.Stage;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -11,8 +12,8 @@ public record FestivalDetailResponse(Long id,
                                      String thumbnail,
                                      List<FestivalDetailStageResponse> stages) {
 
-    public static FestivalDetailResponse from(Festival festival) {
-        List<FestivalDetailStageResponse> stages = festival.getStages().stream()
+    public static FestivalDetailResponse of(Festival festival, List<Stage> stages) {
+        List<FestivalDetailStageResponse> stageResponses = stages.stream()
             .map(FestivalDetailStageResponse::from)
             .toList();
         return new FestivalDetailResponse(
@@ -21,7 +22,7 @@ public record FestivalDetailResponse(Long id,
             festival.getStartDate(),
             festival.getEndDate(),
             festival.getThumbnail(),
-            stages
+            stageResponses
         );
     }
 }

--- a/backend/src/main/java/com/festago/dto/FestivalDetailStageResponse.java
+++ b/backend/src/main/java/com/festago/dto/FestivalDetailStageResponse.java
@@ -1,0 +1,25 @@
+package com.festago.dto;
+
+import com.festago.domain.Stage;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record FestivalDetailStageResponse(Long id,
+                                          LocalDateTime startDate,
+                                          LocalDateTime ticketOpenTime,
+                                          String lineUp,
+                                          List<FestivalDetailTicketResponse> tickets) {
+
+    public static FestivalDetailStageResponse from(Stage stage) {
+        List<FestivalDetailTicketResponse> tickets = stage.getTickets().stream()
+            .map(FestivalDetailTicketResponse::from)
+            .toList();
+        return new FestivalDetailStageResponse(
+            stage.getId(),
+            stage.getStartTime(),
+            stage.getTicketOpenTime(),
+            stage.getLineUp(),
+            tickets
+        );
+    }
+}

--- a/backend/src/main/java/com/festago/dto/FestivalDetailTicketResponse.java
+++ b/backend/src/main/java/com/festago/dto/FestivalDetailTicketResponse.java
@@ -1,0 +1,21 @@
+package com.festago.dto;
+
+import com.festago.domain.Ticket;
+import com.festago.domain.TicketAmount;
+import com.festago.domain.TicketType;
+
+public record FestivalDetailTicketResponse(Long id,
+                                           TicketType ticketType,
+                                           Integer totalAmount,
+                                           Integer remainAmount) {
+
+    public static FestivalDetailTicketResponse from(Ticket ticket) {
+        TicketAmount ticketAmount = ticket.getTicketAmount();
+        return new FestivalDetailTicketResponse(
+            ticket.getId(),
+            ticket.getTicketType(),
+            ticketAmount.getTotalAmount(),
+            ticketAmount.calculateRemainAmount()
+        );
+    }
+}

--- a/backend/src/main/java/com/festago/presentation/FestivalController.java
+++ b/backend/src/main/java/com/festago/presentation/FestivalController.java
@@ -1,9 +1,11 @@
 package com.festago.presentation;
 
 import com.festago.application.FestivalService;
+import com.festago.dto.FestivalDetailResponse;
 import com.festago.dto.FestivalsResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +22,13 @@ public class FestivalController {
     @GetMapping
     public ResponseEntity<FestivalsResponse> findAll() {
         FestivalsResponse response = festivalService.findAll();
+        return ResponseEntity.ok()
+            .body(response);
+    }
+
+    @GetMapping("/{festivalId}")
+    public ResponseEntity<FestivalDetailResponse> findDetail(@PathVariable Long festivalId) {
+        FestivalDetailResponse response = festivalService.findDetail(festivalId);
         return ResponseEntity.ok()
             .body(response);
     }

--- a/backend/src/test/java/com/festago/application/FestivalServiceTest.java
+++ b/backend/src/test/java/com/festago/application/FestivalServiceTest.java
@@ -79,7 +79,7 @@ class FestivalServiceTest {
         @Test
         void 무대_시작시간순으로_정렬() {
             // given
-            long festivalId = 1L;
+            Long festivalId = 1L;
             Festival festival = FestivalFixture.festival().id(festivalId).build();
             LocalDateTime now = LocalDateTime.now();
             Stage stage1 = StageFixture.stage().id(1L).startTime(now).festival(festival).build();

--- a/backend/src/test/java/com/festago/application/FestivalServiceTest.java
+++ b/backend/src/test/java/com/festago/application/FestivalServiceTest.java
@@ -46,16 +46,13 @@ class FestivalServiceTest {
         // given
         Festival festival1 = FestivalFixture.festival().id(1L).build();
         Festival festival2 = FestivalFixture.festival().id(2L).build();
-        given(festivalRepository.findAll())
-            .willReturn(List.of(festival1, festival2));
+        given(festivalRepository.findAll()).willReturn(List.of(festival1, festival2));
 
         // when
         FestivalsResponse response = festivalService.findAll();
 
         // then
-        List<Long> festivalIds = response.festivals().stream()
-            .map(FestivalResponse::id)
-            .toList();
+        List<Long> festivalIds = response.festivals().stream().map(FestivalResponse::id).toList();
 
         assertThat(festivalIds).containsExactly(1L, 2L);
     }
@@ -67,12 +64,10 @@ class FestivalServiceTest {
         void 축제가_없다면_예외() {
             // given
             Long festivalId = 1L;
-            given(festivalRepository.findById(festivalId))
-                .willReturn(Optional.empty());
+            given(festivalRepository.findById(festivalId)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> festivalService.findDetail(festivalId))
-                .isInstanceOf(NotFoundException.class)
+            assertThatThrownBy(() -> festivalService.findDetail(festivalId)).isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 축제입니다.");
         }
 
@@ -85,18 +80,14 @@ class FestivalServiceTest {
             Stage stage1 = StageFixture.stage().id(1L).startTime(now).festival(festival).build();
             Stage stage2 = StageFixture.stage().id(2L).startTime(now.plusDays(1)).festival(festival).build();
 
-            given(festivalRepository.findById(festivalId))
-                .willReturn(Optional.of(festival));
-            given(stageRepository.findAllByFestival(festival))
-                .willReturn(List.of(stage2, stage1));
+            given(festivalRepository.findById(festivalId)).willReturn(Optional.of(festival));
+            given(stageRepository.findAllDetailByFestivalId(festival.getId())).willReturn(List.of(stage2, stage1));
 
             // when
             FestivalDetailResponse response = festivalService.findDetail(festivalId);
 
             // then
-            List<Long> stageIds = response.stages().stream()
-                .map(FestivalDetailStageResponse::id)
-                .toList();
+            List<Long> stageIds = response.stages().stream().map(FestivalDetailStageResponse::id).toList();
             assertThat(stageIds).containsExactly(1L, 2L);
         }
     }

--- a/backend/src/test/java/com/festago/application/FestivalServiceTest.java
+++ b/backend/src/test/java/com/festago/application/FestivalServiceTest.java
@@ -1,16 +1,20 @@
 package com.festago.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import com.festago.domain.Festival;
 import com.festago.domain.FestivalRepository;
 import com.festago.dto.FestivalResponse;
 import com.festago.dto.FestivalsResponse;
+import com.festago.exception.NotFoundException;
 import com.festago.support.FestivalFixture;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -45,5 +49,22 @@ class FestivalServiceTest {
             .toList();
 
         assertThat(festivalIds).containsExactly(1L, 2L);
+    }
+
+    @Nested
+    class 축제_상세_조회 {
+
+        @Test
+        void 축제가_없다면_예외() {
+            // given
+            Long festivalId = 1L;
+            given(festivalRepository.findById(festivalId))
+                .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> festivalService.findDetail(festivalId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 축제입니다.");
+        }
     }
 }

--- a/backend/src/test/java/com/festago/application/integration/FestivalServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/application/integration/FestivalServiceIntegrationTest.java
@@ -3,9 +3,26 @@ package com.festago.application.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.festago.application.FestivalService;
+import com.festago.domain.Festival;
+import com.festago.domain.FestivalRepository;
+import com.festago.domain.Stage;
+import com.festago.domain.StageRepository;
+import com.festago.domain.Ticket;
+import com.festago.domain.TicketRepository;
+import com.festago.domain.TicketType;
 import com.festago.dto.FestivalCreateRequest;
+import com.festago.dto.FestivalDetailResponse;
+import com.festago.dto.FestivalDetailStageResponse;
+import com.festago.dto.FestivalDetailTicketResponse;
 import com.festago.dto.FestivalResponse;
+import com.festago.support.FestivalFixture;
+import com.festago.support.StageFixture;
+import com.festago.support.TicketFixture;
+import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -18,6 +35,18 @@ class FestivalServiceIntegrationTest extends ApplicationIntegrationTest {
     @Autowired
     FestivalService festivalService;
 
+    @Autowired
+    FestivalRepository festivalRepository;
+
+    @Autowired
+    StageRepository stageRepository;
+
+    @Autowired
+    TicketRepository ticketRepository;
+
+    @Autowired
+    EntityManager entityManager;
+
     @Test
     void 축제를_생성한다() {
         // given
@@ -29,5 +58,34 @@ class FestivalServiceIntegrationTest extends ApplicationIntegrationTest {
 
         // then
         assertThat(festivalResponse).isNotNull();
+    }
+
+    @Test
+    void 축제_상세_정보를_조회한다() {
+        // given
+        Festival festival = festivalRepository.save(FestivalFixture.festival().build());
+        Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
+        Ticket ticket1 = ticketRepository.save(
+            TicketFixture.ticket().stage(stage).ticketType(TicketType.VISITOR).build());
+        ticket1.addTicketEntryTime(LocalDateTime.now().minusMinutes(10), 100);
+        Ticket ticket2 = ticketRepository.save(
+            TicketFixture.ticket().stage(stage).ticketType(TicketType.STUDENT).build());
+        ticket2.addTicketEntryTime(LocalDateTime.now().minusMinutes(10), 200);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        FestivalDetailResponse response = festivalService.findDetail(festival.getId());
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            List<FestivalDetailStageResponse> stages = response.stages();
+            softly.assertThat(response.id()).isEqualTo(festival.getId());
+            softly.assertThat(stages.stream().map(FestivalDetailStageResponse::id).toList())
+                .containsExactly(stage.getId());
+            softly.assertThat(stages.get(0).tickets().stream().map(FestivalDetailTicketResponse::id).toList())
+                .containsExactly(ticket1.getId(), ticket2.getId());
+        });
     }
 }

--- a/backend/src/test/java/com/festago/presentation/FestivalControllerTest.java
+++ b/backend/src/test/java/com/festago/presentation/FestivalControllerTest.java
@@ -1,6 +1,7 @@
 package com.festago.presentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -8,10 +9,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.festago.application.FestivalService;
+import com.festago.dto.FestivalDetailResponse;
 import com.festago.dto.FestivalResponse;
 import com.festago.dto.FestivalsResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -56,6 +59,27 @@ class FestivalControllerTest {
             .getResponse()
             .getContentAsString(StandardCharsets.UTF_8);
         FestivalsResponse actual = objectMapper.readValue(content, FestivalsResponse.class);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void 축제_정보_상세_조회() throws Exception {
+        // given
+        FestivalDetailResponse expected = new FestivalDetailResponse(1L, "테코 대학교", LocalDate.now(), LocalDate.now(),
+            "thumbnail.png", Collections.emptyList());
+
+        given(festivalService.findDetail(anyLong()))
+            .willReturn(expected);
+
+        // when & then
+        String content = mockMvc.perform(get("/festivals/{festivalId}", 1L)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(print())
+            .andReturn()
+            .getResponse()
+            .getContentAsString(StandardCharsets.UTF_8);
+        FestivalDetailResponse actual = objectMapper.readValue(content, FestivalDetailResponse.class);
         assertThat(actual).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #119 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

무대 정보는 무대 시작 시간 기준으로 정렬되도록 했습니다.

조회시 편의를 위해 Stage에 `@OneToMany List<Ticket>`를 추가했습니다.
(OneToMany관계를 걸지 않으면, for문을 돌면서 복잡한 연산을 수행해야하고, 이에 따라 DTO로 변환하는 과정이 상당히 복잡해집니다.)
