### PR TITLE
[BE] refactor: FestaGoException이 상속하는 예외 클래스를 NestedRuntimeException으로 변경 (#171)

### DIFF
--- a/backend/src/main/java/com/festago/exception/FestaGoException.java
+++ b/backend/src/main/java/com/festago/exception/FestaGoException.java
@@ -11,6 +11,11 @@ public abstract class FestaGoException extends NestedRuntimeException {
         this.errorCode = errorCode;
     }
 
+    protected FestaGoException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
     public ErrorCode getErrorCode() {
         return errorCode;
     }

--- a/backend/src/main/java/com/festago/exception/FestaGoException.java
+++ b/backend/src/main/java/com/festago/exception/FestaGoException.java
@@ -1,6 +1,8 @@
 package com.festago.exception;
 
-public abstract class FestaGoException extends RuntimeException {
+import org.springframework.core.NestedRuntimeException;
+
+public abstract class FestaGoException extends NestedRuntimeException {
 
     private final ErrorCode errorCode;
 

--- a/backend/src/main/java/com/festago/exception/InternalServerException.java
+++ b/backend/src/main/java/com/festago/exception/InternalServerException.java
@@ -5,4 +5,8 @@ public class InternalServerException extends FestaGoException {
     public InternalServerException(ErrorCode errorCode) {
         super(errorCode);
     }
+
+    public InternalServerException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/backend/src/test/java/com/festago/exception/FestaGoExceptionTest.java
+++ b/backend/src/test/java/com/festago/exception/FestaGoExceptionTest.java
@@ -1,0 +1,75 @@
+package com.festago.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class FestaGoExceptionTest {
+
+    @Test
+    void cause_예외가_있을때_getCause를_호출하면_null이_아니다() {
+        // given
+        FestaGoException exception = new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR,
+            new IllegalArgumentException("예외"));
+
+        // when & then
+        assertThat(exception.getCause())
+            .isNotNull();
+    }
+
+    @Test
+    void casue_예외가_없을때_getCause를_호출하면_null이다() {
+        // given
+        FestaGoException exception = new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+
+        // when & then
+        assertThat(exception.getCause())
+            .isNull();
+    }
+
+    @Test
+    void cause_예외가_있을때_getRootCause를_호출하면_null이_아니다() {
+        // given
+        FestaGoException exception = new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR,
+            new IllegalArgumentException("예외"));
+
+        // when & then
+        assertThat(exception.getRootCause())
+            .isNotNull();
+    }
+
+    @Test
+    void casue_예외가_없을때_getRootCause를_호출하면_null이다() {
+        // given
+        FestaGoException exception = new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+
+        // when & then
+        assertThat(exception.getRootCause())
+            .isNull();
+    }
+
+    @Test
+    void cause_예외가_있을때_getMostSpecificCause를_호출하면_null이_아니다() {
+        // given
+        FestaGoException exception = new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR,
+            new IllegalArgumentException("예외"));
+
+        // when & then
+        assertThat(exception.getMostSpecificCause())
+            .isNotNull();
+    }
+
+    @Test
+    void casue_예외가_없을때_getMostSpecificCause를_호출하면_null이_아니다() {
+        // given
+        FestaGoException exception = new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+
+        // when & then
+        assertThat(exception.getMostSpecificCause())
+            .isNotNull();
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #171
