### PR TITLE
[BE] feat: 티켓 목록 조회 API와 예매 목록 조회 API 분리 (#79)

### DIFF
--- a/backend/src/main/java/com/festago/application/MemberTicketService.java
+++ b/backend/src/main/java/com/festago/application/MemberTicketService.java
@@ -3,6 +3,7 @@ package com.festago.application;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.concat;
 
 import com.festago.domain.MemberTicket;
 import com.festago.domain.MemberTicketRepository;
@@ -14,7 +15,6 @@ import com.festago.exception.ErrorCode;
 import com.festago.exception.NotFoundException;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -85,9 +85,7 @@ public class MemberTicketService {
 
     private List<MemberTicket> mergeMemberTickets(List<MemberTicket> memberTickets1,
                                                   List<MemberTicket> memberTickets2) {
-        List<MemberTicket> mergedMemberTickets = new ArrayList<>(memberTickets1.size() + memberTickets2.size());
-        mergedMemberTickets.addAll(memberTickets1);
-        mergedMemberTickets.addAll(memberTickets2);
-        return mergedMemberTickets;
+        return concat(memberTickets1.stream(), memberTickets2.stream())
+            .toList();
     }
 }

--- a/backend/src/main/java/com/festago/application/MemberTicketService.java
+++ b/backend/src/main/java/com/festago/application/MemberTicketService.java
@@ -46,7 +46,7 @@ public class MemberTicketService {
     }
 
     @Transactional(readOnly = true)
-    public CurrentMemberTicketsResponse findCurrentMemberTickets(Long memberId) {
+    public CurrentMemberTicketsResponse findCurrent(Long memberId) {
         List<MemberTicket> memberTickets = memberTicketRepository.findAllByOwnerId(memberId);
         return memberTickets.stream()
             .filter(memberTicket -> memberTicket.isCurrent(LocalDateTime.now()))

--- a/backend/src/main/java/com/festago/application/MemberTicketService.java
+++ b/backend/src/main/java/com/festago/application/MemberTicketService.java
@@ -40,7 +40,9 @@ public class MemberTicketService {
     @Transactional(readOnly = true)
     public MemberTicketsResponse findAll(Long memberId) {
         List<MemberTicket> memberTickets = memberTicketRepository.findAllByOwnerId(memberId);
-        return MemberTicketsResponse.from(memberTickets);
+        return memberTickets.stream()
+            .sorted(Comparator.comparing(memberTicket -> memberTicket.getStage().getStartTime()))
+            .collect(collectingAndThen(toList(), MemberTicketsResponse::from));
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/festago/application/MemberTicketService.java
+++ b/backend/src/main/java/com/festago/application/MemberTicketService.java
@@ -1,5 +1,6 @@
 package com.festago.application;
 
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
 
@@ -11,9 +12,13 @@ import com.festago.dto.MemberTicketsResponse;
 import com.festago.exception.BadRequestException;
 import com.festago.exception.ErrorCode;
 import com.festago.exception.NotFoundException;
+import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Comparator;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,16 +46,37 @@ public class MemberTicketService {
     public MemberTicketsResponse findAll(Long memberId) {
         List<MemberTicket> memberTickets = memberTicketRepository.findAllByOwnerId(memberId);
         return memberTickets.stream()
-            .sorted(Comparator.comparing(memberTicket -> memberTicket.getStage().getStartTime()))
+            .sorted(comparing(memberTicket -> memberTicket.getStage().getStartTime()))
             .collect(collectingAndThen(toList(), MemberTicketsResponse::from));
     }
 
     @Transactional(readOnly = true)
     public CurrentMemberTicketsResponse findCurrent(Long memberId) {
         List<MemberTicket> memberTickets = memberTicketRepository.findAllByOwnerId(memberId);
+        Map<Boolean, List<MemberTicket>> currentMemberTickets = getCurrentMemberTickets(memberTickets);
+        List<MemberTicket> activateMemberTickets = currentMemberTickets.getOrDefault(true, Collections.emptyList());
+        List<MemberTicket> pendingMemberTickets = currentMemberTickets.getOrDefault(false, Collections.emptyList());
+        return CurrentMemberTicketsResponse.from(mergeMemberTickets(activateMemberTickets, pendingMemberTickets));
+    }
+
+    private Map<Boolean, List<MemberTicket>> getCurrentMemberTickets(List<MemberTicket> memberTickets) {
+        LocalDateTime now = LocalDateTime.now();
         return memberTickets.stream()
-            .filter(memberTicket -> memberTicket.isCurrent(LocalDateTime.now()))
-            .sorted(Comparator.comparing(MemberTicket::getEntryTime))
-            .collect(collectingAndThen(toList(), CurrentMemberTicketsResponse::from));
+            .filter(memberTicket -> memberTicket.isPending(now) || memberTicket.canEntry(now))
+            .sorted(comparing(this::getTimeGapFromNow))
+            .collect(Collectors.groupingBy(memberTicket -> memberTicket.canEntry(now)));
+    }
+
+    private long getTimeGapFromNow(MemberTicket memberTicket) {
+        LocalDateTime now = LocalDateTime.now();
+        return Math.abs(Duration.between(memberTicket.getEntryTime(), now).toMillis());
+    }
+
+    private List<MemberTicket> mergeMemberTickets(List<MemberTicket> memberTickets1,
+                                                  List<MemberTicket> memberTickets2) {
+        List<MemberTicket> mergedMemberTickets = new ArrayList<>(memberTickets1.size() + memberTickets2.size());
+        mergedMemberTickets.addAll(memberTickets1);
+        mergedMemberTickets.addAll(memberTickets2);
+        return mergedMemberTickets;
     }
 }

--- a/backend/src/main/java/com/festago/application/MemberTicketService.java
+++ b/backend/src/main/java/com/festago/application/MemberTicketService.java
@@ -3,7 +3,6 @@ package com.festago.application;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Stream.concat;
 
 import com.festago.domain.MemberTicket;
 import com.festago.domain.MemberTicketRepository;
@@ -50,42 +49,19 @@ public class MemberTicketService {
     @Transactional(readOnly = true)
     public CurrentMemberTicketsResponse findCurrent(Long memberId) {
         List<MemberTicket> memberTickets = memberTicketRepository.findAllByOwnerId(memberId);
-        LocalDateTime currentTime = LocalDateTime.now();
-        List<MemberTicket> currentMemberTickets = filterCurrentMemberTickets(memberTickets, currentTime);
-        List<MemberTicket> activateMemberTickets = filterActivateMemberTickets(currentMemberTickets, currentTime);
-        List<MemberTicket> pendingMemberTickets = filterPendingMemberTickets(currentMemberTickets, currentTime);
-        return CurrentMemberTicketsResponse.from(mergeMemberTickets(activateMemberTickets, pendingMemberTickets));
+        return CurrentMemberTicketsResponse.from(filterCurrentMemberTickets(memberTickets));
     }
 
-    private List<MemberTicket> filterCurrentMemberTickets(List<MemberTicket> memberTickets,
-                                                          LocalDateTime currentTime) {
+    private List<MemberTicket> filterCurrentMemberTickets(List<MemberTicket> memberTickets) {
+        LocalDateTime currentTime = LocalDateTime.now();
         return memberTickets.stream()
             .filter(memberTicket -> memberTicket.isPending(currentTime) || memberTicket.canEntry(currentTime))
-            .sorted(comparing(this::getTimeGapFromNow))
+            .sorted(comparing((MemberTicket memberTicket) -> memberTicket.isPending(currentTime))
+                .thenComparing(memberTicket -> calculateTimeGap(memberTicket, currentTime)))
             .toList();
     }
 
-    private List<MemberTicket> filterActivateMemberTickets(List<MemberTicket> memberTickets,
-                                                           LocalDateTime currentTime) {
-        return memberTickets.stream()
-            .filter(memberTicket -> memberTicket.canEntry(currentTime))
-            .toList();
-    }
-
-    private List<MemberTicket> filterPendingMemberTickets(List<MemberTicket> memberTickets, LocalDateTime currentTime) {
-        return memberTickets.stream()
-            .filter(memberTicket -> memberTicket.isPending(currentTime))
-            .toList();
-    }
-
-    private long getTimeGapFromNow(MemberTicket memberTicket) {
-        LocalDateTime now = LocalDateTime.now();
-        return Math.abs(Duration.between(memberTicket.getEntryTime(), now).toMillis());
-    }
-
-    private List<MemberTicket> mergeMemberTickets(List<MemberTicket> memberTickets1,
-                                                  List<MemberTicket> memberTickets2) {
-        return concat(memberTickets1.stream(), memberTickets2.stream())
-            .toList();
+    private Duration calculateTimeGap(MemberTicket memberTicket, LocalDateTime time) {
+        return Duration.between(memberTicket.getEntryTime(), time).abs();
     }
 }

--- a/backend/src/main/java/com/festago/domain/MemberTicket.java
+++ b/backend/src/main/java/com/festago/domain/MemberTicket.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 @Entity
 public class MemberTicket {
 
+    private static final long PENDING_LIMIT_HOUR = 12;
     private static final long ENTRY_LIMIT_HOUR = 24;
 
     @Id
@@ -68,6 +69,15 @@ public class MemberTicket {
 
     public boolean isOwner(Long memberId) {
         return Objects.equals(owner.getId(), memberId);
+    }
+
+    public boolean isCurrent(LocalDateTime time) {
+        return isPending(time) || canEntry(time);
+    }
+
+    private boolean isPending(LocalDateTime time) {
+        return time.isAfter(entryTime.minusHours(PENDING_LIMIT_HOUR))
+            && time.isBefore(entryTime);
     }
 
     public boolean canEntry(LocalDateTime time) {

--- a/backend/src/main/java/com/festago/domain/MemberTicket.java
+++ b/backend/src/main/java/com/festago/domain/MemberTicket.java
@@ -71,11 +71,7 @@ public class MemberTicket {
         return Objects.equals(owner.getId(), memberId);
     }
 
-    public boolean isCurrent(LocalDateTime time) {
-        return isPending(time) || canEntry(time);
-    }
-
-    private boolean isPending(LocalDateTime time) {
+    public boolean isPending(LocalDateTime time) {
         return time.isAfter(entryTime.minusHours(PENDING_LIMIT_HOUR))
             && time.isBefore(entryTime);
     }

--- a/backend/src/main/java/com/festago/domain/MemberTicket.java
+++ b/backend/src/main/java/com/festago/domain/MemberTicket.java
@@ -71,14 +71,14 @@ public class MemberTicket {
         return Objects.equals(owner.getId(), memberId);
     }
 
-    public boolean isPending(LocalDateTime time) {
-        return time.isAfter(entryTime.minusHours(PENDING_LIMIT_HOUR))
-            && time.isBefore(entryTime);
+    public boolean isPending(LocalDateTime currentTime) {
+        return currentTime.isAfter(entryTime.minusHours(PENDING_LIMIT_HOUR))
+            && currentTime.isBefore(entryTime);
     }
 
-    public boolean canEntry(LocalDateTime time) {
-        return (time.isEqual(entryTime) || time.isAfter(entryTime))
-            && time.isBefore(entryTime.plusHours(ENTRY_LIMIT_HOUR));
+    public boolean canEntry(LocalDateTime currentTime) {
+        return (currentTime.isEqual(entryTime) || currentTime.isAfter(entryTime))
+            && currentTime.isBefore(entryTime.plusHours(ENTRY_LIMIT_HOUR));
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/festago/dto/CurrentFestivalResponse.java
+++ b/backend/src/main/java/com/festago/dto/CurrentFestivalResponse.java
@@ -1,0 +1,16 @@
+package com.festago.dto;
+
+import com.festago.domain.Festival;
+
+public record CurrentFestivalResponse(Long id,
+                                      String name,
+                                      String thumbnail) {
+
+    public static CurrentFestivalResponse from(Festival festival) {
+        return new CurrentFestivalResponse(
+            festival.getId(),
+            festival.getName(),
+            festival.getThumbnail()
+        );
+    }
+}

--- a/backend/src/main/java/com/festago/dto/CurrentMemberTicketResponse.java
+++ b/backend/src/main/java/com/festago/dto/CurrentMemberTicketResponse.java
@@ -1,0 +1,27 @@
+package com.festago.dto;
+
+import com.festago.domain.EntryState;
+import com.festago.domain.MemberTicket;
+import com.festago.domain.Stage;
+import java.time.LocalDateTime;
+
+public record CurrentMemberTicketResponse(Long id,
+                                          Integer number,
+                                          LocalDateTime entryTime,
+                                          EntryState state,
+                                          CurrentStageResponse stage,
+                                          CurrentFestivalResponse festival
+) {
+
+    public static CurrentMemberTicketResponse from(MemberTicket memberTicket) {
+        Stage stage = memberTicket.getStage();
+        return new CurrentMemberTicketResponse(
+            memberTicket.getId(),
+            memberTicket.getNumber(),
+            memberTicket.getEntryTime(),
+            memberTicket.getEntryState(),
+            CurrentStageResponse.from(stage),
+            CurrentFestivalResponse.from(stage.getFestival())
+        );
+    }
+}

--- a/backend/src/main/java/com/festago/dto/CurrentMemberTicketsResponse.java
+++ b/backend/src/main/java/com/festago/dto/CurrentMemberTicketsResponse.java
@@ -1,0 +1,16 @@
+package com.festago.dto;
+
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+
+import com.festago.domain.MemberTicket;
+import java.util.List;
+
+public record CurrentMemberTicketsResponse(List<CurrentMemberTicketResponse> memberTickets) {
+
+    public static CurrentMemberTicketsResponse from(List<MemberTicket> memberTickets) {
+        return memberTickets.stream()
+            .map(CurrentMemberTicketResponse::from)
+            .collect(collectingAndThen(toList(), CurrentMemberTicketsResponse::new));
+    }
+}

--- a/backend/src/main/java/com/festago/dto/CurrentStageResponse.java
+++ b/backend/src/main/java/com/festago/dto/CurrentStageResponse.java
@@ -1,0 +1,15 @@
+package com.festago.dto;
+
+import com.festago.domain.Stage;
+import java.time.LocalDateTime;
+
+public record CurrentStageResponse(Long id,
+                                   LocalDateTime startTime) {
+
+    public static CurrentStageResponse from(Stage stage) {
+        return new CurrentStageResponse(
+            stage.getId(),
+            stage.getStartTime()
+        );
+    }
+}

--- a/backend/src/main/java/com/festago/dto/MemberTicketResponse.java
+++ b/backend/src/main/java/com/festago/dto/MemberTicketResponse.java
@@ -1,12 +1,14 @@
 package com.festago.dto;
 
-import com.festago.domain.EntryState;
 import com.festago.domain.MemberTicket;
 import com.festago.domain.Stage;
 import java.time.LocalDateTime;
 
-public record MemberTicketResponse(Long id, Integer number, LocalDateTime entryTime, EntryState state,
-                                   LocalDateTime reservedAt, StageResponse stage,
+public record MemberTicketResponse(Long id,
+                                   Integer number,
+                                   LocalDateTime entryTime,
+                                   LocalDateTime reservedAt,
+                                   StageResponse stage,
                                    MemberTicketFestivalResponse festival) {
 
     // TODO: FestivalResponse
@@ -16,7 +18,6 @@ public record MemberTicketResponse(Long id, Integer number, LocalDateTime entryT
             memberTicket.getId(),
             memberTicket.getNumber(),
             memberTicket.getEntryTime(),
-            memberTicket.getEntryState(),
             LocalDateTime.now(), // TODO
             StageResponse.from(stage),
             MemberTicketFestivalResponse.from(stage.getFestival()));

--- a/backend/src/main/java/com/festago/dto/MemberTicketsResponse.java
+++ b/backend/src/main/java/com/festago/dto/MemberTicketsResponse.java
@@ -6,7 +6,7 @@ import static java.util.stream.Collectors.toList;
 import com.festago.domain.MemberTicket;
 import java.util.List;
 
-public record MemberTicketsResponse(List<MemberTicketResponse> tickets) {
+public record MemberTicketsResponse(List<MemberTicketResponse> memberTickets) {
 
     public static MemberTicketsResponse from(List<MemberTicket> memberTickets) {
         return memberTickets.stream()

--- a/backend/src/main/java/com/festago/presentation/MemberTicketController.java
+++ b/backend/src/main/java/com/festago/presentation/MemberTicketController.java
@@ -2,6 +2,7 @@ package com.festago.presentation;
 
 import com.festago.application.EntryService;
 import com.festago.application.MemberTicketService;
+import com.festago.dto.CurrentMemberTicketsResponse;
 import com.festago.dto.EntryCodeResponse;
 import com.festago.dto.MemberTicketResponse;
 import com.festago.dto.MemberTicketsResponse;
@@ -41,6 +42,13 @@ public class MemberTicketController {
     @GetMapping
     public ResponseEntity<MemberTicketsResponse> findAll() {
         MemberTicketsResponse response = memberTicketService.findAll(1L);// TODO
+        return ResponseEntity.ok()
+            .body(response);
+    }
+
+    @GetMapping("/current")
+    public ResponseEntity<CurrentMemberTicketsResponse> findCurrent() {
+        CurrentMemberTicketsResponse response = memberTicketService.findCurrent(1L);// TODO
         return ResponseEntity.ok()
             .body(response);
     }

--- a/backend/src/test/java/com/festago/application/MemberTicketServiceTest.java
+++ b/backend/src/test/java/com/festago/application/MemberTicketServiceTest.java
@@ -11,6 +11,7 @@ import com.festago.domain.Stage;
 import com.festago.dto.CurrentMemberTicketResponse;
 import com.festago.dto.CurrentMemberTicketsResponse;
 import com.festago.dto.MemberTicketResponse;
+import com.festago.dto.MemberTicketsResponse;
 import com.festago.exception.BadRequestException;
 import com.festago.exception.NotFoundException;
 import com.festago.support.MemberFixture;
@@ -38,6 +39,40 @@ class MemberTicketServiceTest {
 
     @InjectMocks
     MemberTicketService memberTicketService;
+
+    @Test
+    void 사용자의_멤버티켓_전체_조회시_공연시작시간이_빠른순으로_정렬된다() {
+        // given
+        long memberId = 1L;
+        LocalDateTime now = LocalDateTime.now();
+        Stage stage1 = StageFixture.stage().build();
+        Stage stage2 = StageFixture.stage().startTime(now.plusDays(1)).build();
+        Stage stage3 = StageFixture.stage().startTime(now.plusDays(2)).build();
+        MemberTicket memberTicket1 = MemberTicketFixture.memberTicket()
+            .id(1L)
+            .entryTime(stage1.getStartTime().minusHours(1))
+            .build();
+        MemberTicket memberTicket2 = MemberTicketFixture.memberTicket()
+            .id(2L)
+            .entryTime(stage2.getStartTime().minusHours(1))
+            .build();
+        MemberTicket memberTicket3 = MemberTicketFixture.memberTicket()
+            .id(3L)
+            .entryTime(stage3.getStartTime().minusHours(1))
+            .build();
+
+        given(memberTicketRepository.findAllByOwnerId(memberId))
+            .willReturn(List.of(memberTicket2, memberTicket1, memberTicket3));
+
+        // when
+        MemberTicketsResponse response = memberTicketService.findAll(memberId);
+
+        // then
+        List<Long> memberTicketIds = response.memberTickets().stream()
+            .map(MemberTicketResponse::id)
+            .toList();
+        assertThat(memberTicketIds).containsExactly(1L, 2L, 3L);
+    }
 
     @Test
     void 현재_활성화된_티켓리스트_조회시_입장시간이_빠른순으로_정렬된다() {

--- a/backend/src/test/java/com/festago/application/MemberTicketServiceTest.java
+++ b/backend/src/test/java/com/festago/application/MemberTicketServiceTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -37,68 +38,6 @@ class MemberTicketServiceTest {
 
     @InjectMocks
     MemberTicketService memberTicketService;
-
-    @Test
-    void 사용자의_티켓이_없으면_예외() {
-        // given
-        Long memberId = 1L;
-        Long memberTicketId = 1L;
-        given(memberTicketRepository.findById(memberTicketId))
-            .willReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> memberTicketService.findById(memberId, memberTicketId))
-            .isInstanceOf(NotFoundException.class)
-            .hasMessage("존재하지 않은 멤버 티켓입니다.");
-    }
-
-    @Test
-    void 사용자가_티켓의_주인이_아니면_예외() {
-        // given
-        Long memberId = 1L;
-        Member other = MemberFixture.member()
-            .id(2L)
-            .build();
-
-        MemberTicket otherMemberTicket = MemberTicketFixture.memberTicket()
-            .owner(other)
-            .build();
-
-        Long otherTicketId = otherMemberTicket.getId();
-
-        given(memberTicketRepository.findById(otherTicketId))
-            .willReturn(Optional.of(otherMemberTicket));
-
-        // when & then
-        assertThatThrownBy(() -> memberTicketService.findById(memberId, otherTicketId))
-            .isInstanceOf(BadRequestException.class)
-            .hasMessage("해당 예매 티켓의 주인이 아닙니다.");
-    }
-
-    @Test
-    void 사용자의_티켓_단건_조회() {
-        // given
-        Member member = MemberFixture.member()
-            .id(2L)
-            .build();
-        Stage stage = StageFixture.stage()
-            .build();
-        Long memberTicketId = 1L;
-        MemberTicket memberTicket = MemberTicketFixture.memberTicket()
-            .id(1L)
-            .owner(member)
-            .stage(stage)
-            .build();
-
-        given(memberTicketRepository.findById(memberTicketId))
-            .willReturn(Optional.of(memberTicket));
-
-        // when
-        MemberTicketResponse response = memberTicketService.findById(member.getId(), memberTicketId);
-
-        // then
-        assertThat(response.id()).isEqualTo(memberTicketId);
-    }
 
     @Test
     void 현재_활성화된_티켓리스트_조회시_입장시간이_빠른순으로_정렬된다() {
@@ -134,5 +73,71 @@ class MemberTicketServiceTest {
             .toList();
         assertThat(memberTicketIds)
             .containsExactly(4L, 2L);
+    }
+
+    @Nested
+    class 멤버_티켓_아이디로_단건_조회 {
+
+        @Test
+        void 사용자의_티켓이_없으면_예외() {
+            // given
+            Long memberId = 1L;
+            Long memberTicketId = 1L;
+            given(memberTicketRepository.findById(memberTicketId))
+                .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberTicketService.findById(memberId, memberTicketId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않은 멤버 티켓입니다.");
+        }
+
+        @Test
+        void 사용자가_티켓의_주인이_아니면_예외() {
+            // given
+            Long memberId = 1L;
+            Member other = MemberFixture.member()
+                .id(2L)
+                .build();
+
+            MemberTicket otherMemberTicket = MemberTicketFixture.memberTicket()
+                .owner(other)
+                .build();
+
+            Long otherTicketId = otherMemberTicket.getId();
+
+            given(memberTicketRepository.findById(otherTicketId))
+                .willReturn(Optional.of(otherMemberTicket));
+
+            // when & then
+            assertThatThrownBy(() -> memberTicketService.findById(memberId, otherTicketId))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("해당 예매 티켓의 주인이 아닙니다.");
+        }
+
+        @Test
+        void 성공() {
+            // given
+            Member member = MemberFixture.member()
+                .id(2L)
+                .build();
+            Stage stage = StageFixture.stage()
+                .build();
+            Long memberTicketId = 1L;
+            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+                .id(1L)
+                .owner(member)
+                .stage(stage)
+                .build();
+
+            given(memberTicketRepository.findById(memberTicketId))
+                .willReturn(Optional.of(memberTicket));
+
+            // when
+            MemberTicketResponse response = memberTicketService.findById(member.getId(), memberTicketId);
+
+            // then
+            assertThat(response.id()).isEqualTo(memberTicketId);
+        }
     }
 }

--- a/backend/src/test/java/com/festago/application/MemberTicketServiceTest.java
+++ b/backend/src/test/java/com/festago/application/MemberTicketServiceTest.java
@@ -100,7 +100,7 @@ class MemberTicketServiceTest {
             .willReturn(List.of(beforePendingMemberTicket, pendingMemberTicket, oldMemberTicket, canEntryMemberTicket));
 
         // when
-        CurrentMemberTicketsResponse response = memberTicketService.findCurrentMemberTickets(memberId);
+        CurrentMemberTicketsResponse response = memberTicketService.findCurrent(memberId);
 
         // then
         List<Long> memberTicketIds = response.memberTickets().stream()

--- a/backend/src/test/java/com/festago/domain/MemberTicketTest.java
+++ b/backend/src/test/java/com/festago/domain/MemberTicketTest.java
@@ -29,7 +29,7 @@ class MemberTicketTest {
             LocalDateTime entryTime = LocalDateTime.now();
             LocalDateTime time = entryTime.minusMinutes(10);
 
-            MemberTicket memberTicket =  MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
                 .entryTime(entryTime)
                 .build();
 
@@ -43,7 +43,7 @@ class MemberTicketTest {
             LocalDateTime entryTime = LocalDateTime.now();
             LocalDateTime time = entryTime.plusHours(24);
 
-            MemberTicket memberTicket =  MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
                 .entryTime(entryTime)
                 .build();
 
@@ -64,13 +64,89 @@ class MemberTicketTest {
                 .startTime(entryTime.plusHours(4))
                 .festival(festival)
                 .build();
-            MemberTicket memberTicket =  MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
                 .stage(stage)
                 .entryTime(entryTime)
                 .build();
 
             // when && then
             assertThat(memberTicket.canEntry(time)).isTrue();
+        }
+    }
+
+    @Nested
+    class 현재_활성화_검사 {
+
+        @Test
+        void 입장_가능시간이_지나면_거짓() {
+            // given
+            LocalDateTime entryTime = LocalDateTime.now();
+            LocalDateTime time = entryTime.plusHours(24);
+
+            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+                .entryTime(entryTime)
+                .build();
+
+            // when & then
+            assertThat(memberTicket.isCurrent(time)).isFalse();
+        }
+
+        @Test
+        void 입장시간_12시간전이면_거짓() {
+            // given
+            LocalDateTime entryTime = LocalDateTime.now();
+            LocalDateTime time = entryTime.minusHours(12);
+
+            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+                .entryTime(entryTime)
+                .build();
+
+            // when & then
+            assertThat(memberTicket.isCurrent(time)).isFalse();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"2023-07-28T17:59:59", "2023-07-27T18:00:00"})
+        void 입장_가능하면_참(LocalDateTime time) {
+            // given
+            LocalDateTime entryTime = LocalDateTime.parse("2023-07-27T18:00:00");
+            Festival festival = FestivalFixture.festival()
+                .startDate(entryTime.toLocalDate())
+                .endDate(entryTime.plusDays(4).toLocalDate())
+                .build();
+            Stage stage = StageFixture.stage()
+                .startTime(entryTime.plusHours(4))
+                .festival(festival)
+                .build();
+            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+                .stage(stage)
+                .entryTime(entryTime)
+                .build();
+
+            // when & then
+            assertThat(memberTicket.isCurrent(time)).isTrue();
+        }
+
+        @Test
+        void 대기_상태면_참() {
+            // given
+            LocalDateTime entryTime = LocalDateTime.now();
+            LocalDateTime time = entryTime.minusHours(12).plusSeconds(1);
+            Festival festival = FestivalFixture.festival()
+                .startDate(entryTime.toLocalDate())
+                .endDate(entryTime.plusDays(4).toLocalDate())
+                .build();
+            Stage stage = StageFixture.stage()
+                .startTime(entryTime.plusHours(4))
+                .festival(festival)
+                .build();
+            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+                .stage(stage)
+                .entryTime(entryTime)
+                .build();
+
+            // when & then
+            assertThat(memberTicket.isCurrent(time)).isTrue();
         }
     }
 

--- a/backend/src/test/java/com/festago/domain/MemberTicketTest.java
+++ b/backend/src/test/java/com/festago/domain/MemberTicketTest.java
@@ -75,21 +75,7 @@ class MemberTicketTest {
     }
 
     @Nested
-    class 현재_활성화_검사 {
-
-        @Test
-        void 입장_가능시간이_지나면_거짓() {
-            // given
-            LocalDateTime entryTime = LocalDateTime.now();
-            LocalDateTime time = entryTime.plusHours(24);
-
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
-                .entryTime(entryTime)
-                .build();
-
-            // when & then
-            assertThat(memberTicket.isCurrent(time)).isFalse();
-        }
+    class 대기상태_티켓_검사 {
 
         @Test
         void 입장시간_12시간전이면_거짓() {
@@ -102,29 +88,7 @@ class MemberTicketTest {
                 .build();
 
             // when & then
-            assertThat(memberTicket.isCurrent(time)).isFalse();
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {"2023-07-28T17:59:59", "2023-07-27T18:00:00"})
-        void 입장_가능하면_참(LocalDateTime time) {
-            // given
-            LocalDateTime entryTime = LocalDateTime.parse("2023-07-27T18:00:00");
-            Festival festival = FestivalFixture.festival()
-                .startDate(entryTime.toLocalDate())
-                .endDate(entryTime.plusDays(4).toLocalDate())
-                .build();
-            Stage stage = StageFixture.stage()
-                .startTime(entryTime.plusHours(4))
-                .festival(festival)
-                .build();
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
-                .stage(stage)
-                .entryTime(entryTime)
-                .build();
-
-            // when & then
-            assertThat(memberTicket.isCurrent(time)).isTrue();
+            assertThat(memberTicket.isPending(time)).isFalse();
         }
 
         @Test
@@ -146,7 +110,7 @@ class MemberTicketTest {
                 .build();
 
             // when & then
-            assertThat(memberTicket.isCurrent(time)).isTrue();
+            assertThat(memberTicket.isPending(time)).isTrue();
         }
     }
 

--- a/backend/src/test/java/com/festago/presentation/MemberTicketControllerTest.java
+++ b/backend/src/test/java/com/festago/presentation/MemberTicketControllerTest.java
@@ -8,13 +8,11 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.festago.application.EntryService;
 import com.festago.application.MemberTicketService;
-import com.festago.domain.EntryState;
 import com.festago.dto.EntryCodeResponse;
 import com.festago.dto.MemberTicketFestivalResponse;
 import com.festago.dto.MemberTicketResponse;
@@ -81,7 +79,7 @@ class MemberTicketControllerTest {
         MemberTicketFestivalResponse festivalResponse = new MemberTicketFestivalResponse(1L, "테코대학교",
             "https://image.png");
         MemberTicketResponse expected = new MemberTicketResponse(memberTicketId, 1, LocalDateTime.now(),
-            EntryState.BEFORE_ENTRY, LocalDateTime.now(), stageResponse, festivalResponse);
+            LocalDateTime.now(), stageResponse, festivalResponse);
         given(memberTicketService.findById(memberId, memberTicketId))
             .willReturn(expected);
 
@@ -106,8 +104,8 @@ class MemberTicketControllerTest {
             "https://image.png");
         MemberTicketsResponse expected = LongStream.range(0, 10L)
             .mapToObj(
-                it -> new MemberTicketResponse(it, 1, LocalDateTime.now(), EntryState.BEFORE_ENTRY, LocalDateTime.now(),
-                    stageResponse, festivalResponse))
+                it -> new MemberTicketResponse(it, 1, LocalDateTime.now(), LocalDateTime.now(), stageResponse,
+                    festivalResponse))
             .collect(collectingAndThen(toList(), MemberTicketsResponse::new));
         given(memberTicketService.findAll(memberId))
             .willReturn(expected);


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #79 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
### 🎟️ 티켓 목록 (GET /member-tickets/current)
- 티켓은 입장시간 12시간 이전부터 노출됩니다.
- 티켓은 입장시간 24시간 이후까지 노출됩니다.
- 티켓은 (활성화) -> (비활성화) 순으로 정렬됩니다.
- (활성화) 및 (비활성화) 내에서는 입장시간이 현재 시간과 가까운 순으로 정렬됩니다.
```
현재시간) 5시

[활성화] 4시 입장
[활성화] 3시 입장
[비활성화] 6시 입장
[비활성화] 7시 입장
```
<img src="https://github.com/woowacourse-teams/2023-festa-go/assets/71129059/44197483-9f16-4897-9acf-7a9c6039f56e" width = 300>

<br>

### 🎟️ 예매 목록 (GET /member-tickets)
- 티켓은 무대 시작시간이 최신순으로 정렬됩니다.
<img src="https://github.com/woowacourse-teams/2023-festa-go/assets/71129059/41f6011c-e429-4824-b35b-80e588219c08" width = 300>



---
### 🧨 코드리뷰 부탁

226db9a5d072e809ddbdd7dbf0c2231f6518b7d8 해당 커밋에서 기존에 Map으로 반환하던 메서드를 List를 반환하도록 수정했습니다.
[전자] stream도는 횟수가 적습니다. 하지만 가독성이 좋지 않습니다.
[후자] stream을 2번 더 돕니다. 하지만 가독성이 좋습니다.

한 멤버의 현재 활성화된 티켓 개수(`currentMemberTickets`) 사이즈가 크지 않아, stream을 2번 더 돈다고 큰 성능상의 차이가 없기에 가독성을 챙기는게 좋을 것 같다는 @BGuga 의 의견을 반영했습니다!
해당 부분 코드리뷰 부탁드립니다 🙇🏻‍♀️