### PR TITLE
[AN/USER] 축제 예매 화면 오픈시간 전에 버튼 비활성화 (#220)

### DIFF
--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveActivity.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveActivity.kt
@@ -83,7 +83,7 @@ class TicketReserveActivity : AppCompatActivity() {
             ReservationCompleteActivity.getIntent(
                 this,
                 reservedTicket.toPresentation(),
-            ),
+            ).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
         )
     }
 

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/viewHolder/TicketReserveViewHolder.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/viewHolder/TicketReserveViewHolder.kt
@@ -7,6 +7,8 @@ import com.festago.festago.R
 import com.festago.festago.databinding.ItemTicketReserveBinding
 import com.festago.festago.presentation.model.ReservationStageUiModel
 import com.festago.festago.presentation.ui.ticketreserve.TicketReserveViewModel
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 class TicketReserveViewHolder(
     private val binding: ItemTicketReserveBinding,
@@ -18,6 +20,18 @@ class TicketReserveViewHolder(
 
     fun bind(item: ReservationStageUiModel) {
         binding.stage = item
+
+        if (LocalDateTime.now().isAfter(item.ticketOpenTime)) {
+            binding.btnReserveTicket.isEnabled = true
+            binding.btnReserveTicket.text =
+                binding.root.context.getString(R.string.ticket_reserve_tv_btn_reserve_ticket)
+        } else {
+            binding.btnReserveTicket.isEnabled = false
+            val pattern = DateTimeFormatter.ofPattern(
+                binding.root.context.getString(R.string.ticket_reserve_tv_btn_reserve_ticket_not_open),
+            )
+            binding.btnReserveTicket.text = item.ticketOpenTime.format(pattern)
+        }
 
         binding.tvTicketCount.text =
             item.reservationTickets.joinToString(binding.root.context.getString(R.string.ticket_reserve_tv_ticket_count_separator)) {

--- a/android/festago/app/src/main/res/layout/item_ticket_reserve.xml
+++ b/android/festago/app/src/main/res/layout/item_ticket_reserve.xml
@@ -52,29 +52,6 @@
             tools:text="07.03 (목) 17:00" />
 
         <TextView
-            android:id="@+id/tvOpenTimeTitle"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:text="@string/ticket_reserve_tv_open_time_title"
-            android:textSize="16sp"
-            android:textStyle="bold"
-            app:layout_constraintEnd_toEndOf="@id/endGuideLine"
-            app:layout_constraintStart_toStartOf="@id/startGuideline"
-
-            app:layout_constraintTop_toBottomOf="@id/tvDate" />
-
-        <TextView
-            android:id="@+id/tvOpenTime"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@{stage.ticketOpenTime.format(DateTimeFormatter.ofPattern(@string/ticket_reserve_tv_open_time))}"
-            android:textSize="16sp"
-            app:layout_constraintStart_toStartOf="@id/startGuideline"
-            app:layout_constraintTop_toBottomOf="@id/tvOpenTimeTitle"
-            tools:text="2023.07.04 14:00" />
-
-        <TextView
             android:id="@+id/tvLineUpTitle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -84,8 +61,7 @@
             android:textStyle="bold"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="@id/startGuideline"
-
-            app:layout_constraintTop_toBottomOf="@id/tvOpenTime" />
+            app:layout_constraintTop_toBottomOf="@id/tvDate" />
 
         <TextView
             android:id="@+id/tvLineUp"

--- a/android/festago/app/src/main/res/values/strings.xml
+++ b/android/festago/app/src/main/res/values/strings.xml
@@ -32,8 +32,6 @@
     <string name="ticket_reserve_tv_date_range">%1s ~ %1s</string>
     <string name="ticket_reserve_tv_date_range_format">yyyy.MM.dd</string>
     <string name="ticket_reserve_tv_start_time">MM.dd (E) HH:mm</string>
-    <string name="ticket_reserve_tv_open_time_title">[예매 오픈 시간]</string>
-    <string name="ticket_reserve_tv_open_time">yyyy.MM.dd HH:mm</string>
     <string name="ticket_reserve_tv_line_up_title">[라인업]</string>
     <string name="ticket_reserve_tv_ticket_count_title">[예매 가능 티켓]</string>
     <string name="ticket_reserve_tv_ticket_count">%1$s(%2$s/%3$s)</string>

--- a/android/festago/app/src/main/res/values/strings.xml
+++ b/android/festago/app/src/main/res/values/strings.xml
@@ -41,6 +41,8 @@
     <string name="ticket_reserve_btn_reserve_ticket">티켓 예매</string>
     <string name="ticket_reserve_tv_ticket_count_format">(%1$s/%2$s)</string>
     <string name="ticket_reserve_tv_btn_reserve_ticket">예매 하기</string>
+    <string name="ticket_reserve_tv_btn_reserve_ticket_not_open">MM월 dd일 HH:mm 오픈예정</string>
+
 
     <!-- Strings related to festival list -->
     <string name="festival_list_tv_date_format">yyyy.MM.dd</string>


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #220

## ✨ PR 세부 내용

- 기존 xml 티켓 오픈 예정 textView 삭제
- 예매 버튼 시간에 따라서 활성상태 변경
<img width="281" alt="스크린샷 2023-08-03 오후 6 03 02" src="https://github.com/woowacourse-teams/2023-festa-go/assets/37167652/98742b38-1aeb-486d-9cd4-be6ff01d3887">

<!-- 수정/추가한 내용을 적어주세요. -->
