### PR TITLE
[AN/USER] 축제 예매 화면 새로고침 기능 (#222)

### DIFF
--- a/android/festago/app/build.gradle.kts
+++ b/android/festago/app/build.gradle.kts
@@ -119,6 +119,9 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:32.2.0"))
     implementation("com.google.firebase:firebase-analytics-ktx")
     implementation("com.google.firebase:firebase-crashlytics-ktx")
+
+    // swiperefreshlayout
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
 }
 
 fun getSecretKey(propertyKey: String): String {

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveActivity.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveActivity.kt
@@ -108,7 +108,7 @@ class TicketReserveActivity : AppCompatActivity() {
     private fun updateUi(uiState: TicketReserveUiState) = when (uiState) {
         is TicketReserveUiState.Loading,
         is TicketReserveUiState.Error,
-        -> Unit
+        -> binding.srlTicketReserve.isRefreshing = false
 
         is TicketReserveUiState.Success -> updateSuccess(uiState.reservation)
     }

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveActivity.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveActivity.kt
@@ -96,6 +96,13 @@ class TicketReserveActivity : AppCompatActivity() {
         binding.rvTicketReserve.adapter = concatAdapter
 
         vm.loadReservation(intent.getLongExtra(KEY_FESTIVAL_ID, -1))
+
+        binding.srlTicketReserve.setOnRefreshListener {
+            vm.loadReservation(
+                festivalId = intent.getLongExtra(KEY_FESTIVAL_ID, -1),
+                refresh = true,
+            )
+        }
     }
 
     private fun updateUi(uiState: TicketReserveUiState) = when (uiState) {
@@ -109,6 +116,7 @@ class TicketReserveActivity : AppCompatActivity() {
     private fun updateSuccess(reservations: ReservationUiModel) {
         headerAdapter.submitList(listOf(reservations))
         contentsAdapter.submitList(reservations.reservationStages)
+        binding.srlTicketReserve.isRefreshing = false
     }
 
     companion object {

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveViewModel.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveViewModel.kt
@@ -17,7 +17,7 @@ class TicketReserveViewModel(
     private val reservationRepository: ReservationRepository,
     private val analyticsHelper: AnalyticsHelper,
 ) : ViewModel() {
-    private val _uiState = MutableLiveData<TicketReserveUiState>()
+    private val _uiState = MutableLiveData<TicketReserveUiState>(TicketReserveUiState.Loading)
     val uiState: LiveData<TicketReserveUiState> = _uiState
 
     private val _event = MutableSingleLiveData<TicketReserveEvent>()
@@ -26,7 +26,6 @@ class TicketReserveViewModel(
     fun loadReservation(festivalId: Long = 0, refresh: Boolean = false) {
         if (!refresh && uiState.value is TicketReserveUiState.Success) return
         viewModelScope.launch {
-            _uiState.value = TicketReserveUiState.Loading
             reservationRepository.loadReservation(festivalId)
                 .onSuccess {
                     _uiState.setValue(TicketReserveUiState.Success(it.toPresentation()))

--- a/android/festago/app/src/main/res/layout/activity_ticket_reserve.xml
+++ b/android/festago/app/src/main/res/layout/activity_ticket_reserve.xml
@@ -22,13 +22,18 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rvTicketReserve"
-            visibility="@{uiState.shouldShowSuccess}"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/srlTicketReserve"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            tools:listitem="@layout/item_ticket_reserve" />
+            android:layout_height="match_parent">
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvTicketReserve"
+                visibility="@{uiState.shouldShowSuccess}"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:listitem="@layout/item_ticket_reserve" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
         <TextView
             android:id="@+id/tvEmpty"


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #222

## ✨ PR 세부 내용
- swipe 라이브러리추가
- 축제 예매 화면 새로고침 기능 추가
[Screen_recording_20230803_193449.webm](https://github.com/woowacourse-teams/2023-festa-go/assets/37167652/c0af71b4-db7d-46c5-bb7d-b361447bea1e)


<!-- 수정/추가한 내용을 적어주세요. -->
