### PR TITLE
[AN/USER] 페스티벌 축제 화면 새로고침 기능 추가 (#228)

### DIFF
--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
@@ -58,16 +58,25 @@ class FestivalListFragment : Fragment(R.layout.fragment_festival_list) {
         adapter = FestivalListAdapter(vm)
         binding.rvFestivalList.adapter = adapter
         vm.loadFestivals()
+
+        binding.srlFestivalList.setOnRefreshListener {
+            vm.loadFestivals()
+        }
     }
 
     private fun updateUi(uiState: FestivalListUiState) {
         when (uiState) {
-            is FestivalListUiState.Loading, is FestivalListUiState.Error -> Unit
+            is FestivalListUiState.Loading,
+            is FestivalListUiState.Error,
+            -> binding.srlFestivalList.isRefreshing = false
 
-            is FestivalListUiState.Success -> {
-                adapter.submitList(uiState.festivals)
-            }
+            is FestivalListUiState.Success -> handleSuccess(uiState)
         }
+    }
+
+    private fun handleSuccess(uiState: FestivalListUiState.Success) {
+        adapter.submitList(uiState.festivals)
+        binding.srlFestivalList.isRefreshing = false
     }
 
     private fun handleEvent(event: FestivalListEvent) {

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModel.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModel.kt
@@ -18,7 +18,7 @@ class FestivalListViewModel(
     private val festivalRepository: FestivalRepository,
     private val analyticsHelper: AnalyticsHelper,
 ) : ViewModel() {
-    private val _uiState = MutableLiveData<FestivalListUiState>()
+    private val _uiState = MutableLiveData<FestivalListUiState>(FestivalListUiState.Loading)
     val uiState: LiveData<FestivalListUiState> = _uiState
 
     private val _event = MutableSingleLiveData<FestivalListEvent>()
@@ -26,7 +26,6 @@ class FestivalListViewModel(
 
     fun loadFestivals() {
         viewModelScope.launch {
-            _uiState.value = FestivalListUiState.Loading
             festivalRepository.loadFestivals()
                 .onSuccess {
                     _uiState.value = FestivalListUiState.Success(it.toPresentation())

--- a/android/festago/app/src/main/res/layout/fragment_festival_list.xml
+++ b/android/festago/app/src/main/res/layout/fragment_festival_list.xml
@@ -49,20 +49,26 @@
             app:layout_constraintTop_toBottomOf="@id/cgFilterOption"
             tools:visibility="gone" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rvFestivalList"
-            visibility="@{uiState.shouldShowSuccess}"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:clipToPadding="false"
-            android:padding="8dp"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/srlFestivalList"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cgFilterOption"
-            app:spanCount="2"
-            tools:listitem="@layout/item_festival_list" />
+            app:layout_constraintTop_toBottomOf="@id/cgFilterOption">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvFestivalList"
+                visibility="@{uiState.shouldShowSuccess}"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:clipToPadding="false"
+                android:padding="8dp"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:spanCount="2"
+                tools:listitem="@layout/item_festival_list" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
         <TextView
             android:id="@+id/tvErrorOrEmpty"


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #228

## ✨ PR 세부 내용

[Screen_recording_20230803_201034.webm](https://github.com/woowacourse-teams/2023-festa-go/assets/37167652/16573ff8-7ba7-4cdf-962a-06e5b363574f)

- 축제 목록 화면 새로고침 기능 추가
<!-- 수정/추가한 내용을 적어주세요. -->
