### PR TITLE
[BE] chore: Appender 상대 경로, 로그 저장 위치 변경 (#236)

### DIFF
--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -3,20 +3,22 @@
 <configuration>
   <property name="LOG_PATTERN"
     value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
-  <springProfile name="!prod">
-    <include resource="./console-appender.xml"/>
+  <property name="MOVE_TO_HOME_DIRECTORY" value="../../../.."/>
+
+  <springProfile name="local">
+    <include resource="console-appender.xml"/>
     <root level="INFO">
       <appender-ref ref="CONSOLE"/>
     </root>
   </springProfile>
 
   <springProfile name="dev">
-    <include resource="./logs/common/file-info-appender.xml"/>
-    <include resource="./logs/common/file-warn-appender.xml"/>
-    <include resource="./logs/common/file-error-appender.xml"/>
-    <include resource="./logs/error/file-info-appender.xml"/>
-    <include resource="./logs/error/file-warn-appender.xml"/>
-    <include resource="./logs/error/file-error-appender.xml"/>
+    <include resource="logs/common/file-info-appender.xml"/>
+    <include resource="logs/common/file-warn-appender.xml"/>
+    <include resource="logs/common/file-error-appender.xml"/>
+    <include resource="logs/error/file-info-appender.xml"/>
+    <include resource="logs/error/file-warn-appender.xml"/>
+    <include resource="logs/error/file-error-appender.xml"/>
 
     <logger additivity="false" level="INFO" name="ErrorLogger">
       <appender-ref ref="ERROR_ERROR"/>
@@ -32,12 +34,12 @@
   </springProfile>
 
   <springProfile name="prod">
-    <include resource="./logs/common/file-info-appender.xml"/>
-    <include resource="./logs/common/file-warn-appender.xml"/>
-    <include resource="./logs/common/file-error-appender.xml"/>
-    <include resource="./logs/error/file-info-appender.xml"/>
-    <include resource="./logs/error/file-warn-appender.xml"/>
-    <include resource="./logs/error/file-error-appender.xml"/>
+    <include resource="logs/common/file-info-appender.xml"/>
+    <include resource="logs/common/file-warn-appender.xml"/>
+    <include resource="logs/common/file-error-appender.xml"/>
+    <include resource="logs/error/file-info-appender.xml"/>
+    <include resource="logs/error/file-warn-appender.xml"/>
+    <include resource="logs/error/file-error-appender.xml"/>
 
     <logger additivity="false" level="INFO" name="ErrorLogger">
       <appender-ref ref="ERROR_ERROR"/>

--- a/backend/src/main/resources/logs/common/file-error-appender.xml
+++ b/backend/src/main/resources/logs/common/file-error-appender.xml
@@ -9,7 +9,8 @@
       <onMismatch>DENY</onMismatch>
     </filter>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./log/common/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>${MOVE_TO_HOME_DIRECTORY}/log/common/error/error-%d{yyyy-MM-dd}.%i.log
+      </fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>30</maxHistory>
       <totalSizeCap>3GB</totalSizeCap>

--- a/backend/src/main/resources/logs/common/file-info-appender.xml
+++ b/backend/src/main/resources/logs/common/file-info-appender.xml
@@ -9,7 +9,8 @@
       <onMismatch>DENY</onMismatch>
     </filter>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./log/common/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>${MOVE_TO_HOME_DIRECTORY}/log/common/info/info-%d{yyyy-MM-dd}.%i.log
+      </fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>30</maxHistory>
       <totalSizeCap>3GB</totalSizeCap>

--- a/backend/src/main/resources/logs/common/file-warn-appender.xml
+++ b/backend/src/main/resources/logs/common/file-warn-appender.xml
@@ -9,7 +9,8 @@
       <onMismatch>DENY</onMismatch>
     </filter>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./log/common/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>${MOVE_TO_HOME_DIRECTORY}/log/common/warn/warn-%d{yyyy-MM-dd}.%i.log
+      </fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>30</maxHistory>
       <totalSizeCap>3GB</totalSizeCap>

--- a/backend/src/main/resources/logs/error/file-error-appender.xml
+++ b/backend/src/main/resources/logs/error/file-error-appender.xml
@@ -9,7 +9,8 @@
       <onMismatch>DENY</onMismatch>
     </filter>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./log/error/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>${MOVE_TO_HOME_DIRECTORY}/log/error/error/error-%d{yyyy-MM-dd}.%i.log
+      </fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>100</maxHistory>
       <totalSizeCap>4GB</totalSizeCap>

--- a/backend/src/main/resources/logs/error/file-info-appender.xml
+++ b/backend/src/main/resources/logs/error/file-info-appender.xml
@@ -9,7 +9,8 @@
       <onMismatch>DENY</onMismatch>
     </filter>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./log/error/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>${MOVE_TO_HOME_DIRECTORY}/log/error/info/info-%d{yyyy-MM-dd}.%i.log
+      </fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>100</maxHistory>
       <totalSizeCap>4GB</totalSizeCap>

--- a/backend/src/main/resources/logs/error/file-warn-appender.xml
+++ b/backend/src/main/resources/logs/error/file-warn-appender.xml
@@ -9,7 +9,8 @@
       <onMismatch>DENY</onMismatch>
     </filter>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./log/error/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>${MOVE_TO_HOME_DIRECTORY}/log/error/warn/warn-%d{yyyy-MM-dd}.%i.log
+      </fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>100</maxHistory>
       <totalSizeCap>4GB</totalSizeCap>


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #236 

## ✨ PR 세부 내용

기존 Appender 의 경로가 
<img width="426" alt="image" src="https://github.com/woowacourse-teams/2023-festa-go/assets/103228463/9d34dfc8-bbe2-4f4f-84b8-e98953a6c1e9">

위와 같이 설정되어 있을 때 
```
nohup java -jar -Duser.timezone=Asia/Seoul festa-go-0.0.1-SNAPSHOT.jar --spring.profiles.active=dev 
```
해당 명령어를 실행 했을 때 Appender 를 찾지 못합니다.
반면 Intellij 에서 Run Application 을 실행했을 때는 Appender 를 발견합니다.
그래서 appender 파일 경로를 
<img width="401" alt="image" src="https://github.com/woowacourse-teams/2023-festa-go/assets/103228463/a6a2048f-45af-4f70-b577-80a098b7ae9b">
로 바꾸어 주니 log 파일이 
```
backend/build/libs/log/{fileName}
```
로 저장 되어서 해당 저장 경로를 홈 디렉토리에 저장하도록 변경하였습니다.
<img width="881" alt="image" src="https://github.com/woowacourse-teams/2023-festa-go/assets/103228463/ec5f4fb8-f30a-47ee-a9b4-d14b3fda1dc9">
 
<img width="647" alt="image" src="https://github.com/woowacourse-teams/2023-festa-go/assets/103228463/8b6be4ae-35a1-449b-8d3f-0a6506258bbe">
