### PR TITLE
[BE] feat: 회원 soft delete 탈퇴 기능 구현 (#268)

### DIFF
--- a/backend/src/main/java/com/festago/domain/Member.java
+++ b/backend/src/main/java/com/festago/domain/Member.java
@@ -7,8 +7,13 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
+@SQLDelete(sql = "UPDATE member SET deleted_at = now(), nickname = '탈퇴한 회원', profile_image = '' WHERE id=?")
+@Where(clause = "deleted_at is null")
 public class Member {
 
     @Id
@@ -23,6 +28,8 @@ public class Member {
     private String nickname;
 
     private String profileImage;
+
+    private LocalDateTime deletedAt = null;
 
     public Member() {
     }
@@ -61,5 +68,9 @@ public class Member {
 
     public String getProfileImage() {
         return profileImage;
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
     }
 }

--- a/backend/src/test/java/com/festago/application/integration/TicketServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/application/integration/TicketServiceIntegrationTest.java
@@ -11,6 +11,7 @@ import com.festago.domain.TicketType;
 import com.festago.dto.TicketCreateRequest;
 import com.festago.dto.TicketingRequest;
 import com.festago.exception.NotFoundException;
+import com.festago.support.DatabaseClearExtension;
 import java.time.LocalDateTime;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -18,10 +19,12 @@ import java.util.concurrent.Executors;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 
+@ExtendWith(DatabaseClearExtension.class)
 @SpringBootTest
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")

--- a/backend/src/test/java/com/festago/application/integration/TicketServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/application/integration/TicketServiceIntegrationTest.java
@@ -3,6 +3,8 @@ package com.festago.application.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.festago.application.FestivalService;
+import com.festago.application.StageService;
 import com.festago.application.TicketService;
 import com.festago.domain.Member;
 import com.festago.domain.MemberRepository;
@@ -37,16 +39,22 @@ class TicketServiceIntegrationTest {
     MemberRepository memberRepository;
 
     @Autowired
+    FestivalService festivalService;
+
+    @Autowired
+    StageService stageService;
+
+    @Autowired
     MemberTicketRepository memberTicketRepository;
 
     @Test
     void 공연이_없으면_예외() {
         // given
         String entryTime = "2023-07-26T18:00:00";
-        long invliadStageId = 0L;
+        long invalidStageId = 0L;
         int totalAmount = 100;
 
-        TicketCreateRequest request = new TicketCreateRequest(invliadStageId, TicketType.VISITOR,
+        TicketCreateRequest request = new TicketCreateRequest(invalidStageId, TicketType.VISITOR,
             totalAmount, LocalDateTime.parse(entryTime));
 
         // when && then

--- a/backend/src/test/java/com/festago/application/integration/TicketServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/application/integration/TicketServiceIntegrationTest.java
@@ -23,14 +23,14 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.context.jdbc.SqlConfig.TransactionMode;
 
 @ExtendWith(DatabaseClearExtension.class)
-@SpringBootTest
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class TicketServiceIntegrationTest {
+class TicketServiceIntegrationTest extends ApplicationIntegrationTest {
 
     @Autowired
     TicketService ticketService;
@@ -64,7 +64,8 @@ class TicketServiceIntegrationTest {
     }
 
     @Test
-    @Sql("/ticketing-test-data.sql")
+    @Sql(scripts = "/ticketing-test-data.sql",
+        config = @SqlConfig(transactionMode = TransactionMode.ISOLATED))
     void 예약() throws InterruptedException {
         // given
         Member member = memberRepository.findById(1L).get();
@@ -86,5 +87,4 @@ class TicketServiceIntegrationTest {
 
         assertThat(memberTicketRepository.count()).isEqualTo(100);
     }
-
 }

--- a/backend/src/test/java/com/festago/auth/application/integration/AuthServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/auth/application/integration/AuthServiceIntegrationTest.java
@@ -1,0 +1,44 @@
+package com.festago.auth.application.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.festago.auth.application.AuthService;
+import com.festago.auth.domain.SocialType;
+import com.festago.auth.dto.LoginRequest;
+import com.festago.domain.Member;
+import com.festago.domain.MemberRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class AuthServiceIntegrationTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    AuthService authService;
+
+    // TODO #267 이슈 Merge시 MemberService로 이동
+    @Test
+    void 회원이_탈퇴하고_재가입하면_새로운_계정으로_가입() {
+        // given
+        LoginRequest request = new LoginRequest(SocialType.FESTAGO, "1");
+        authService.login(request);
+        Member member = memberRepository.findBySocialIdAndSocialType("1", SocialType.FESTAGO).get();
+
+        // when
+        memberRepository.delete(member);
+        authService.login(request);
+
+        // then
+        assertThat(memberRepository.count()).isEqualTo(1);
+    }
+}

--- a/backend/src/test/java/com/festago/auth/application/integration/AuthServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/auth/application/integration/AuthServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package com.festago.auth.application.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.festago.application.integration.ApplicationIntegrationTest;
 import com.festago.auth.application.AuthService;
 import com.festago.auth.domain.SocialType;
 import com.festago.auth.dto.LoginRequest;
@@ -11,14 +12,10 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class AuthServiceIntegrationTest {
+class AuthServiceIntegrationTest extends ApplicationIntegrationTest {
 
     @Autowired
     MemberRepository memberRepository;

--- a/backend/src/test/java/com/festago/domain/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/festago/domain/MemberRepositoryTest.java
@@ -1,8 +1,10 @@
 package com.festago.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import com.festago.auth.domain.SocialType;
+import com.festago.support.MemberFixture;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -17,11 +19,15 @@ class MemberRepositoryTest {
     @Autowired
     MemberRepository memberRepository;
 
+    @Autowired
+    EntityManager em;
+
     @Test
     void 소셜_아이디와_소셜_타입으로_멤버를_찾는다() {
         // given
-        Member expected = memberRepository.save(
-            new Member("socialId", SocialType.KAKAO, "nickname", "www.iamgeurl.com"));
+        Member member = MemberFixture.member()
+            .build();
+        Member expected = memberRepository.save(member);
 
         // when
         Member actual = memberRepository.findBySocialIdAndSocialType(expected.getSocialId(), expected.getSocialType())
@@ -29,5 +35,26 @@ class MemberRepositoryTest {
 
         // then
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void 회원_삭제() {
+        // given
+        Member member = MemberFixture.member()
+            .build();
+        Member expected = memberRepository.save(member);
+
+        // when
+        memberRepository.delete(expected);
+        Member actual = (Member) em.createNativeQuery("select * from member where id = " + expected.getId(),
+                Member.class)
+            .getSingleResult();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(actual.isDeleted()).isTrue();
+            softly.assertThat(actual.getNickname()).isEqualTo("탈퇴한 회원");
+            softly.assertThat(actual.getProfileImage()).isEqualTo("");
+        });
     }
 }

--- a/backend/src/test/java/com/festago/domain/MemberTicketRepositoryTest.java
+++ b/backend/src/test/java/com/festago/domain/MemberTicketRepositoryTest.java
@@ -53,29 +53,4 @@ class MemberTicketRepositoryTest {
         // then
         assertThat(memberTickets).hasSize(2);
     }
-
-    // TODO
-    @Test
-    void 티켓_타입과_공연_아이디로_해당하는_회원_티켓의_갯수_조회() {
-        // given
-//        Member member = memberRepository.save(MemberFixture.member().build());
-//        Festival festival = festivalRepository.save(FestivalFixture.festival().build());
-//        Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
-//
-//        Ticket studentTicket = ticketRepository.save(
-//            TicketFixture.ticket().stage(stage).ticketType(TicketType.STUDENT).build());
-//        Ticket visitorTicket = ticketRepository.save(
-//            TicketFixture.ticket().stage(stage).ticketType(TicketType.VISITOR).build());
-//
-//        memberTicketRepository.save(MemberTicketFixture.memberTicket().owner(member).ticket(studentTicket).build());
-//        memberTicketRepository.save(MemberTicketFixture.memberTicket().owner(member).ticket(studentTicket).build());
-//        memberTicketRepository.save(MemberTicketFixture.memberTicket().owner(member).ticket(visitorTicket).build());
-//        memberTicketRepository.save(MemberTicketFixture.memberTicket().owner(member).ticket(visitorTicket).build());
-//
-//        // when
-//        Integer actual = memberTicketRepository.countByTicketTypeAndStageId(TicketType.STUDENT, stage.getId());
-//
-//        // then
-//        assertThat(actual).isEqualTo(2);
-    }
 }

--- a/backend/src/test/java/com/festago/support/DatabaseCleaner.java
+++ b/backend/src/test/java/com/festago/support/DatabaseCleaner.java
@@ -1,0 +1,42 @@
+package com.festago.support;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DatabaseCleaner {
+
+    private final List<String> tableNames = new ArrayList<>();
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @SuppressWarnings("unchecked")
+    @PostConstruct
+    private void findDatabaseTableNames() {
+        List<Object[]> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
+        for (Object[] tableInfo : tableInfos) {
+            String tableName = (String) tableInfo[0];
+            tableNames.add(tableName);
+        }
+    }
+
+    private void truncate() {
+        entityManager.createNativeQuery(String.format("SET FOREIGN_KEY_CHECKS %d", 0)).executeUpdate();
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery(String.format("TRUNCATE TABLE %s", tableName)).executeUpdate();
+        }
+        entityManager.createNativeQuery(String.format("SET FOREIGN_KEY_CHECKS %d", 1)).executeUpdate();
+    }
+
+    @Transactional
+    public void clear() {
+        entityManager.clear();
+        truncate();
+    }
+}

--- a/backend/src/test/java/com/festago/support/DatabaseClearExtension.java
+++ b/backend/src/test/java/com/festago/support/DatabaseClearExtension.java
@@ -1,0 +1,19 @@
+package com.festago.support;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseClearExtension implements AfterEachCallback {
+    
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        DatabaseCleaner databaseCleaner = getDataCleaner(context);
+        databaseCleaner.clear();
+    }
+
+    private DatabaseCleaner getDataCleaner(ExtensionContext extensionContext) {
+        return SpringExtension.getApplicationContext(extensionContext)
+            .getBean(DatabaseCleaner.class);
+    }
+}

--- a/backend/src/test/java/com/festago/support/DatabaseClearExtension.java
+++ b/backend/src/test/java/com/festago/support/DatabaseClearExtension.java
@@ -2,12 +2,19 @@ package com.festago.support;
 
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstanceFactoryContext;
+import org.junit.jupiter.api.extension.TestInstancePreConstructCallback;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-public class DatabaseClearExtension implements AfterEachCallback {
-    
+public class DatabaseClearExtension implements TestInstancePreConstructCallback, AfterEachCallback {
+
     @Override
-    public void afterEach(ExtensionContext context) throws Exception {
+    public void preConstructTestInstance(TestInstanceFactoryContext factoryContext, ExtensionContext context)
+        throws Exception {
+        clear(context);
+    }
+
+    private void clear(ExtensionContext context) {
         DatabaseCleaner databaseCleaner = getDataCleaner(context);
         databaseCleaner.clear();
     }
@@ -15,5 +22,10 @@ public class DatabaseClearExtension implements AfterEachCallback {
     private DatabaseCleaner getDataCleaner(ExtensionContext extensionContext) {
         return SpringExtension.getApplicationContext(extensionContext)
             .getBean(DatabaseCleaner.class);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clear(context);
     }
 }

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,4 +1,6 @@
 spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #268 

## ✨ PR 세부 내용

회원이 탈퇴할 때, 데이터베이스에서 삭제되는 것이 아니라, soft delete 처리를 하였습니다.
API는 추후 #267 이슈가 머지되면, MemberController에서 구현해야 할 듯 합니다.
