### PR TITLE
[BE] refactor: 티켓 목록 API에서 입장 시간 이전 티켓 모두 활성화되도록 수정 (#265)

### DIFF
--- a/backend/src/main/java/com/festago/application/MemberTicketService.java
+++ b/backend/src/main/java/com/festago/application/MemberTicketService.java
@@ -61,8 +61,8 @@ public class MemberTicketService {
     private List<MemberTicket> filterCurrentMemberTickets(List<MemberTicket> memberTickets) {
         LocalDateTime currentTime = LocalDateTime.now();
         return memberTickets.stream()
-            .filter(memberTicket -> memberTicket.isPending(currentTime) || memberTicket.canEntry(currentTime))
-            .sorted(comparing((MemberTicket memberTicket) -> memberTicket.isPending(currentTime))
+            .filter(memberTicket -> memberTicket.isBeforeEntry(currentTime) || memberTicket.canEntry(currentTime))
+            .sorted(comparing((MemberTicket memberTicket) -> memberTicket.isBeforeEntry(currentTime))
                 .thenComparing(memberTicket -> calculateTimeGap(memberTicket, currentTime)))
             .toList();
     }

--- a/backend/src/main/java/com/festago/domain/MemberTicket.java
+++ b/backend/src/main/java/com/festago/domain/MemberTicket.java
@@ -14,7 +14,6 @@ import java.util.Objects;
 @Entity
 public class MemberTicket extends BaseTimeEntity {
 
-    private static final long PENDING_LIMIT_HOUR = 12;
     private static final long ENTRY_LIMIT_HOUR = 24;
 
     @Id

--- a/backend/src/main/java/com/festago/domain/MemberTicket.java
+++ b/backend/src/main/java/com/festago/domain/MemberTicket.java
@@ -72,8 +72,7 @@ public class MemberTicket extends BaseTimeEntity {
     }
 
     public boolean isPending(LocalDateTime currentTime) {
-        return currentTime.isAfter(entryTime.minusHours(PENDING_LIMIT_HOUR))
-            && currentTime.isBefore(entryTime);
+        return currentTime.isBefore(entryTime);
     }
 
     public boolean canEntry(LocalDateTime currentTime) {

--- a/backend/src/main/java/com/festago/domain/MemberTicket.java
+++ b/backend/src/main/java/com/festago/domain/MemberTicket.java
@@ -70,7 +70,7 @@ public class MemberTicket extends BaseTimeEntity {
         return Objects.equals(owner.getId(), memberId);
     }
 
-    public boolean isPending(LocalDateTime currentTime) {
+    public boolean isBeforeEntry(LocalDateTime currentTime) {
         return currentTime.isBefore(entryTime);
     }
 

--- a/backend/src/test/java/com/festago/application/MemberTicketServiceTest.java
+++ b/backend/src/test/java/com/festago/application/MemberTicketServiceTest.java
@@ -113,27 +113,7 @@ class MemberTicketServiceTest {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 멤버입니다.");
         }
-
-        @Test
-        void 입장시간이_12시간이상_남은_티켓은_조회되지_않는다() {
-            // given
-            Long memberId = 1L;
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
-                .entryTime(LocalDateTime.now().plusHours(13))
-                .build();
-
-            given(memberTicketRepository.findAllByOwnerId(memberId))
-                .willReturn(List.of(memberTicket));
-            given(memberRepository.findById(memberId))
-                .willReturn(Optional.of(new Member(memberId)));
-
-            // when
-            MemberTicketsResponse response = memberTicketService.findCurrent(memberId);
-
-            // then
-            assertThat(response.memberTickets()).isEmpty();
-        }
-
+        
         @Test
         void 입장시간이_24시간_지난_티켓은_조회되지_않는다() {
             // given

--- a/backend/src/test/java/com/festago/domain/MemberTicketTest.java
+++ b/backend/src/test/java/com/festago/domain/MemberTicketTest.java
@@ -89,7 +89,7 @@ class MemberTicketTest {
                 .build();
 
             // when & then
-            assertThat(memberTicket.isPending(time)).isFalse();
+            assertThat(memberTicket.isBeforeEntry(time)).isFalse();
         }
 
         @Test
@@ -111,7 +111,7 @@ class MemberTicketTest {
                 .build();
 
             // when & then
-            assertThat(memberTicket.isPending(time)).isTrue();
+            assertThat(memberTicket.isBeforeEntry(time)).isTrue();
         }
     }
 

--- a/backend/src/test/java/com/festago/domain/MemberTicketTest.java
+++ b/backend/src/test/java/com/festago/domain/MemberTicketTest.java
@@ -79,10 +79,10 @@ class MemberTicketTest {
     class 대기상태_티켓_검사 {
 
         @Test
-        void 입장시간_12시간전이면_거짓() {
+        void 입장시간_이후이면_거짓() {
             // given
             LocalDateTime entryTime = LocalDateTime.now();
-            LocalDateTime time = entryTime.minusHours(12);
+            LocalDateTime time = entryTime.plusHours(1);
 
             MemberTicket memberTicket = MemberTicketFixture.memberTicket()
                 .entryTime(entryTime)
@@ -93,7 +93,7 @@ class MemberTicketTest {
         }
 
         @Test
-        void 대기_상태면_참() {
+        void 입장시간_이전이면_참() {
             // given
             LocalDateTime entryTime = LocalDateTime.now();
             LocalDateTime time = entryTime.minusHours(12).plusSeconds(1);


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #265 

## ✨ PR 세부 내용

티켓 목록 API에서 기존에 입장시간이 12시간 남은 티켓들만 노출이되었는데, 이제 입장 시간 이전의 티켓은 모두 활성화되도록 수정하였습니다.
