### PR TITLE
[BE] refactor: 불필요한 oauth2 redirect용 API 삭제 (#291)

### DIFF
--- a/backend/src/main/java/com/festago/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/festago/auth/presentation/AuthController.java
@@ -1,15 +1,12 @@
 package com.festago.auth.presentation;
 
 import com.festago.auth.application.AuthService;
-import com.festago.auth.domain.SocialType;
 import com.festago.auth.dto.LoginRequest;
 import com.festago.auth.dto.LoginResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,13 +22,6 @@ public class AuthController {
     @PostMapping("/oauth2")
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
         LoginResponse response = authService.login(request);
-        return ResponseEntity.ok()
-            .body(response);
-    }
-
-    @GetMapping("/oauth2/kakao")
-    public ResponseEntity<LoginResponse> loginWithKakao(@RequestParam String accessToken) {
-        LoginResponse response = authService.login(new LoginRequest(SocialType.KAKAO, accessToken));
         return ResponseEntity.ok()
             .body(response);
     }

--- a/backend/src/test/java/com/festago/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/festago/auth/presentation/AuthControllerTest.java
@@ -3,7 +3,6 @@ package com.festago.auth.presentation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -51,26 +50,6 @@ class AuthControllerTest {
         String response = mockMvc.perform(post("/auth/oauth2")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isOk())
-            .andDo(print())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-        LoginResponse actual = objectMapper.readValue(response, LoginResponse.class);
-
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
-    void 카카오_OAuth2_로그인을_한다() throws Exception {
-        // given
-        LoginResponse expected = new LoginResponse("accesstoken", "nickname", true);
-        given(authService.login(any(LoginRequest.class)))
-            .willReturn(expected);
-
-        // when & then
-        String response = mockMvc.perform(get("/auth/oauth2/kakao")
-                .param("accessToken", "code"))
             .andExpect(status().isOk())
             .andDo(print())
             .andReturn()


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #291

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
기존 kakao oauth2 redirect용으로 열어두었던 GET /auth/oauth2/kakao?code=${code} API를 삭제했습니다.

