### PR TITLE
[BE] refactor: Oauth2 카카오 서버의 4xx에러 발생할 경우 BadRequestException으로 수정 (#296)

### DIFF
--- a/backend/src/main/java/com/festago/auth/infrastructure/FestagoOAuth2Client.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/FestagoOAuth2Client.java
@@ -28,7 +28,7 @@ public class FestagoOAuth2Client implements OAuth2Client {
     @Override
     public UserInfo getUserInfo(String accessToken) {
         return userInfoMap.getOrDefault(accessToken, () -> {
-            throw new BadRequestException(ErrorCode.OAUTH2_INVALID_CODE);
+            throw new BadRequestException(ErrorCode.OAUTH2_INVALID_TOKEN);
         }).get();
     }
 

--- a/backend/src/main/java/com/festago/auth/infrastructure/KakaoOAuth2UserInfoErrorHandler.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/KakaoOAuth2UserInfoErrorHandler.java
@@ -1,5 +1,6 @@
 package com.festago.auth.infrastructure;
 
+import com.festago.exception.BadRequestException;
 import com.festago.exception.ErrorCode;
 import com.festago.exception.InternalServerException;
 import java.io.IOException;
@@ -19,7 +20,7 @@ public class KakaoOAuth2UserInfoErrorHandler extends DefaultResponseErrorHandler
 
     private void handle4xxError(HttpStatusCode statusCode) {
         if (statusCode.is4xxClientError()) {
-            throw new InternalServerException(ErrorCode.OAUTH2_INVALID_REQUEST);
+            throw new BadRequestException(ErrorCode.OAUTH2_INVALID_REQUEST);
         }
     }
 

--- a/backend/src/main/java/com/festago/auth/infrastructure/KakaoOAuth2UserInfoErrorHandler.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/KakaoOAuth2UserInfoErrorHandler.java
@@ -20,7 +20,7 @@ public class KakaoOAuth2UserInfoErrorHandler extends DefaultResponseErrorHandler
 
     private void handle4xxError(HttpStatusCode statusCode) {
         if (statusCode.is4xxClientError()) {
-            throw new BadRequestException(ErrorCode.OAUTH2_INVALID_REQUEST);
+            throw new BadRequestException(ErrorCode.OAUTH2_INVALID_TOKEN);
         }
     }
 

--- a/backend/src/main/java/com/festago/exception/ErrorCode.java
+++ b/backend/src/main/java/com/festago/exception/ErrorCode.java
@@ -16,7 +16,6 @@ public enum ErrorCode {
     INVALID_FESTIVAL_START_DATE("축제 시작 일자는 과거일 수 없습니다."),
     INVALID_FESTIVAL_DURATION("축제 시작 일자는 종료일자 이전이어야합니다."),
     INVALID_TICKET_CREATE_TIME("티켓 예매 시작 후 새롭게 티켓을 발급할 수 없습니다."),
-    OAUTH2_INVALID_CODE("잘못된 인가 코드 입니다."),
     OAUTH2_NOT_SUPPORTED_SOCIAL_TYPE("해당 OAuth2 제공자는 지원되지 않습니다."),
     OAUTH2_INVALID_TOKEN("잘못된 Oauth2 토큰입니다."),
 

--- a/backend/src/main/java/com/festago/exception/ErrorCode.java
+++ b/backend/src/main/java/com/festago/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     INVALID_TICKET_CREATE_TIME("티켓 예매 시작 후 새롭게 티켓을 발급할 수 없습니다."),
     OAUTH2_INVALID_CODE("잘못된 인가 코드 입니다."),
     OAUTH2_NOT_SUPPORTED_SOCIAL_TYPE("해당 OAuth2 제공자는 지원되지 않습니다."),
+    OAUTH2_INVALID_TOKEN("잘못된 Oauth2 토큰입니다."),
 
     // 401
     EXPIRED_AUTH_TOKEN("만료된 로그인 토큰입니다."),
@@ -41,7 +42,6 @@ public enum ErrorCode {
     INVALID_AUTH_TOKEN_PAYLOAD("유효하지 않은 로그인 토큰 payload 입니다."),
     DUPLICATE_SOCIAL_TYPE("중복된 OAuth2 제공자 입니다."),
     OAUTH2_PROVIDER_NOT_RESPONSE("OAuth2 제공자 서버에 문제가 발생했습니다."),
-    OAUTH2_INVALID_REQUEST("OAuth2 제공자 서버에 잘못된 요청이 발생했습니다."),
     INVALID_ENTRY_CODE_OFFSET("올바르지 않은 입장코드 오프셋입니다.");
 
     private final String message;

--- a/backend/src/test/java/com/festago/auth/infrastructure/KakaoOAuth2UserInfoClientTest.java
+++ b/backend/src/test/java/com/festago/auth/infrastructure/KakaoOAuth2UserInfoClientTest.java
@@ -49,7 +49,7 @@ class KakaoOAuth2UserInfoClientTest {
         // when & then
         assertThatThrownBy(() -> kakaoOAuth2UserInfoClient.getUserInfo("accessToken"))
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("OAuth2 제공자 서버에 잘못된 요청이 발생했습니다.");
+            .hasMessage("잘못된 Oauth2 토큰입니다.");
     }
 
     @Test
@@ -62,7 +62,7 @@ class KakaoOAuth2UserInfoClientTest {
         // when & then
         assertThatThrownBy(() -> kakaoOAuth2UserInfoClient.getUserInfo("accessToken"))
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("OAuth2 제공자 서버에 잘못된 요청이 발생했습니다.");
+            .hasMessage("잘못된 Oauth2 토큰입니다.");
     }
 
     @Test

--- a/backend/src/test/java/com/festago/auth/infrastructure/KakaoOAuth2UserInfoClientTest.java
+++ b/backend/src/test/java/com/festago/auth/infrastructure/KakaoOAuth2UserInfoClientTest.java
@@ -11,6 +11,7 @@ import com.festago.auth.domain.UserInfo;
 import com.festago.auth.dto.KakaoUserInfo;
 import com.festago.auth.dto.KakaoUserInfo.KakaoAccount;
 import com.festago.auth.dto.KakaoUserInfo.KakaoAccount.Profile;
+import com.festago.exception.BadRequestException;
 import com.festago.exception.InternalServerException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -47,7 +48,7 @@ class KakaoOAuth2UserInfoClientTest {
 
         // when & then
         assertThatThrownBy(() -> kakaoOAuth2UserInfoClient.getUserInfo("accessToken"))
-            .isInstanceOf(InternalServerException.class)
+            .isInstanceOf(BadRequestException.class)
             .hasMessage("OAuth2 제공자 서버에 잘못된 요청이 발생했습니다.");
     }
 
@@ -60,7 +61,7 @@ class KakaoOAuth2UserInfoClientTest {
 
         // when & then
         assertThatThrownBy(() -> kakaoOAuth2UserInfoClient.getUserInfo("accessToken"))
-            .isInstanceOf(InternalServerException.class)
+            .isInstanceOf(BadRequestException.class)
             .hasMessage("OAuth2 제공자 서버에 잘못된 요청이 발생했습니다.");
     }
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #296 

