### PR TITLE
[BE] feat: profileImage 기본값 추가 (#301)

### DIFF
--- a/backend/src/main/java/com/festago/auth/dto/KakaoUserInfo.java
+++ b/backend/src/main/java/com/festago/auth/dto/KakaoUserInfo.java
@@ -24,7 +24,8 @@ public record KakaoUserInfo(
 
         public record Profile(
             String nickname,
-            @JsonProperty("thumbnail_image_url") String thumbnailImageUrl
+            @JsonProperty(value = "thumbnail_image_url", defaultValue = "https://placehold.co/200")
+            String thumbnailImageUrl
         ) {
 
         }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #301 

## ✨ PR 세부 내용

카카오톡 OAuth 로그인 시, 프로필 이미지를 선택적으로 제공할 수 있습니다.
또한, 기본 프로필인 경우 이미지가 null 값으로 들어오게 됩니다.

따라서 프로필 이미지가 null인 경우, 기본 이미지 URL을 추가했습니다.

해당 부분을 지금처럼 DTO에서 기본 값을 설정할 지, 서비스, 도메인에서 할지 논의가 필요해 보입니다.
