### PR TITLE
[AN/USER] feat: 공연 목록 화면에서 로그인하지 않은 경우 처리(#315)

### DIFF
--- a/android/festago/app/src/main/java/com/festago/festago/presentation/mapper/ReservationStageMapper.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/mapper/ReservationStageMapper.kt
@@ -2,6 +2,7 @@ package com.festago.festago.presentation.mapper
 
 import com.festago.festago.domain.model.ReservationStage
 import com.festago.festago.presentation.model.ReservationStageUiModel
+import com.festago.festago.presentation.model.TicketReserveItemUiModel
 import java.time.LocalDateTime
 
 fun List<ReservationStage>.toPresentation() = map { it.toPresentation() }
@@ -21,4 +22,27 @@ fun ReservationStageUiModel.toDomain() = ReservationStage(
     reservationTickets = reservationTickets.map { it.toDomain() },
     startTime = startTime,
     ticketOpenTime = ticketOpenTime,
+)
+
+fun ReservationStageUiModel.toTicketReserveItem(isSigned: Boolean) = TicketReserveItemUiModel(
+    id = id,
+    lineUp = lineUp,
+    startTime = startTime,
+    ticketOpenTime = ticketOpenTime,
+    reservationTickets = reservationTickets,
+    canReserve = canReserve,
+    isSigned = isSigned,
+)
+
+fun List<ReservationStageUiModel>.toTicketReserveItem(isSigned: Boolean) = map {
+    it.toTicketReserveItem(isSigned)
+}
+
+fun TicketReserveItemUiModel.toPresentation() = ReservationStageUiModel(
+    id = id,
+    lineUp = lineUp,
+    startTime = startTime,
+    ticketOpenTime = ticketOpenTime,
+    reservationTickets = reservationTickets,
+    canReserve = canReserve,
 )

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/model/TicketReserveItemUiModel.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/model/TicketReserveItemUiModel.kt
@@ -1,0 +1,16 @@
+package com.festago.festago.presentation.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import java.time.LocalDateTime
+
+@Parcelize
+data class TicketReserveItemUiModel(
+    val id: Int,
+    val lineUp: String,
+    val startTime: LocalDateTime,
+    val ticketOpenTime: LocalDateTime,
+    val reservationTickets: List<ReservationTicketUiModel>,
+    val canReserve: Boolean,
+    val isSigned: Boolean,
+) : Parcelable

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveActivity.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveActivity.kt
@@ -21,9 +21,11 @@ import com.festago.festago.presentation.mapper.toTicketReserveItem
 import com.festago.festago.presentation.model.ReservationTicketUiModel
 import com.festago.festago.presentation.ui.customview.OkDialogFragment
 import com.festago.festago.presentation.ui.reservationcomplete.ReservationCompleteActivity
+import com.festago.festago.presentation.ui.signin.SignInActivity
 import com.festago.festago.presentation.ui.ticketreserve.TicketReserveEvent.ReserveTicketFailed
 import com.festago.festago.presentation.ui.ticketreserve.TicketReserveEvent.ReserveTicketSuccess
 import com.festago.festago.presentation.ui.ticketreserve.TicketReserveEvent.ShowTicketTypes
+import com.festago.festago.presentation.ui.ticketreserve.TicketReserveEvent.ShowSignIn
 import com.festago.festago.presentation.ui.ticketreserve.TicketReserveViewModel.Companion.TicketReservationViewModelFactory
 import com.festago.festago.presentation.ui.ticketreserve.adapter.TicketReserveAdapter
 import com.festago.festago.presentation.ui.ticketreserve.adapter.TicketReserveHeaderAdapter
@@ -85,6 +87,7 @@ class TicketReserveActivity : AppCompatActivity() {
         is ShowTicketTypes -> handleShowTicketTypes(event.stageId, event.tickets)
         is ReserveTicketSuccess -> handleReserveTicketSuccess(event.reservedTicket)
         is ReserveTicketFailed -> handleReserveTicketFailed()
+        is ShowSignIn -> handleShowSignIn()
     }
 
     private fun handleShowTicketTypes(stageId: Int, tickets: List<ReservationTicketUiModel>) {
@@ -104,6 +107,10 @@ class TicketReserveActivity : AppCompatActivity() {
     private fun handleReserveTicketFailed() {
         OkDialogFragment.newInstance("예약에 실패하였습니다.")
             .show(supportFragmentManager, OkDialogFragment::class.java.name)
+    }
+
+    private fun handleShowSignIn() {
+        startActivity(SignInActivity.getIntent(this))
     }
 
     private fun initView() {

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveActivity.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveActivity.kt
@@ -24,8 +24,8 @@ import com.festago.festago.presentation.ui.reservationcomplete.ReservationComple
 import com.festago.festago.presentation.ui.signin.SignInActivity
 import com.festago.festago.presentation.ui.ticketreserve.TicketReserveEvent.ReserveTicketFailed
 import com.festago.festago.presentation.ui.ticketreserve.TicketReserveEvent.ReserveTicketSuccess
-import com.festago.festago.presentation.ui.ticketreserve.TicketReserveEvent.ShowTicketTypes
 import com.festago.festago.presentation.ui.ticketreserve.TicketReserveEvent.ShowSignIn
+import com.festago.festago.presentation.ui.ticketreserve.TicketReserveEvent.ShowTicketTypes
 import com.festago.festago.presentation.ui.ticketreserve.TicketReserveViewModel.Companion.TicketReservationViewModelFactory
 import com.festago.festago.presentation.ui.ticketreserve.adapter.TicketReserveAdapter
 import com.festago.festago.presentation.ui.ticketreserve.adapter.TicketReserveHeaderAdapter

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveEvent.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveEvent.kt
@@ -4,7 +4,12 @@ import com.festago.festago.domain.model.ReservedTicket
 import com.festago.festago.presentation.model.ReservationTicketUiModel
 
 sealed interface TicketReserveEvent {
-    class ShowTicketTypes(val stageId: Int, val tickets: List<ReservationTicketUiModel>) : TicketReserveEvent
+    class ShowTicketTypes(
+        val stageId: Int,
+        val tickets: List<ReservationTicketUiModel>
+    ) : TicketReserveEvent
+
     class ReserveTicketSuccess(val reservedTicket: ReservedTicket) : TicketReserveEvent
     object ReserveTicketFailed : TicketReserveEvent
+    object ShowSignIn : TicketReserveEvent
 }

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveUiState.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveUiState.kt
@@ -4,7 +4,11 @@ import com.festago.festago.presentation.model.ReservationUiModel
 
 sealed interface TicketReserveUiState {
     object Loading : TicketReserveUiState
-    class Success(val reservation: ReservationUiModel) : TicketReserveUiState
+    class Success(
+        val reservation: ReservationUiModel,
+        val isSigned: Boolean,
+    ) : TicketReserveUiState
+
     object Error : TicketReserveUiState
 
     val shouldShowLoading: Boolean

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveViewModel.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveViewModel.kt
@@ -61,6 +61,8 @@ class TicketReserveViewModel(
                     }.onFailure {
                         _uiState.setValue(TicketReserveUiState.Error)
                     }
+            } else {
+                _event.setValue(TicketReserveEvent.ShowSignIn)
             }
         }
     }

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/adapter/TicketReserveAdapter.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/adapter/TicketReserveAdapter.kt
@@ -3,13 +3,13 @@ package com.festago.festago.presentation.ui.ticketreserve.adapter
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
-import com.festago.festago.presentation.model.ReservationStageUiModel
+import com.festago.festago.presentation.model.TicketReserveItemUiModel
 import com.festago.festago.presentation.ui.ticketreserve.TicketReserveViewModel
 import com.festago.festago.presentation.ui.ticketreserve.viewHolder.TicketReserveViewHolder
 
 class TicketReserveAdapter(
     private val vm: TicketReserveViewModel,
-) : ListAdapter<ReservationStageUiModel, TicketReserveViewHolder>(diffUtil) {
+) : ListAdapter<TicketReserveItemUiModel, TicketReserveViewHolder>(diffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TicketReserveViewHolder {
         return TicketReserveViewHolder.of(parent, vm)
@@ -20,15 +20,15 @@ class TicketReserveAdapter(
     }
 
     companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<ReservationStageUiModel>() {
+        val diffUtil = object : DiffUtil.ItemCallback<TicketReserveItemUiModel>() {
             override fun areContentsTheSame(
-                oldItem: ReservationStageUiModel,
-                newItem: ReservationStageUiModel,
+                oldItem: TicketReserveItemUiModel,
+                newItem: TicketReserveItemUiModel,
             ) = oldItem == newItem
 
             override fun areItemsTheSame(
-                oldItem: ReservationStageUiModel,
-                newItem: ReservationStageUiModel,
+                oldItem: TicketReserveItemUiModel,
+                newItem: TicketReserveItemUiModel,
             ) = oldItem.id == newItem.id
         }
     }

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/viewHolder/TicketReserveViewHolder.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/viewHolder/TicketReserveViewHolder.kt
@@ -5,7 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.festago.festago.R
 import com.festago.festago.databinding.ItemTicketReserveBinding
-import com.festago.festago.presentation.model.ReservationStageUiModel
+import com.festago.festago.presentation.model.TicketReserveItemUiModel
 import com.festago.festago.presentation.ui.ticketreserve.TicketReserveViewModel
 import java.time.format.DateTimeFormatter
 
@@ -17,10 +17,14 @@ class TicketReserveViewHolder(
         binding.vm = vm
     }
 
-    fun bind(item: ReservationStageUiModel) {
+    fun bind(item: TicketReserveItemUiModel) {
         binding.stage = item
 
-        if (item.canReserve) {
+        if (!item.isSigned) {
+            binding.btnReserveTicket.isEnabled = true
+            binding.btnReserveTicket.text =
+                binding.root.context.getString(R.string.ticket_reserve_tv_signin)
+        } else if (item.canReserve) {
             binding.btnReserveTicket.isEnabled = true
             binding.btnReserveTicket.text =
                 binding.root.context.getString(R.string.ticket_reserve_tv_btn_reserve_ticket)

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/viewHolder/TicketReserveViewHolder.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/viewHolder/TicketReserveViewHolder.kt
@@ -20,20 +20,26 @@ class TicketReserveViewHolder(
     fun bind(item: TicketReserveItemUiModel) {
         binding.stage = item
 
-        if (!item.isSigned) {
-            binding.btnReserveTicket.isEnabled = true
-            binding.btnReserveTicket.text =
-                binding.root.context.getString(R.string.ticket_reserve_tv_signin)
-        } else if (item.canReserve) {
-            binding.btnReserveTicket.isEnabled = true
-            binding.btnReserveTicket.text =
-                binding.root.context.getString(R.string.ticket_reserve_tv_btn_reserve_ticket)
-        } else {
-            binding.btnReserveTicket.isEnabled = false
-            val pattern = DateTimeFormatter.ofPattern(
-                binding.root.context.getString(R.string.ticket_reserve_tv_btn_reserve_ticket_not_open),
-            )
-            binding.btnReserveTicket.text = item.ticketOpenTime.format(pattern)
+        when {
+            !item.isSigned -> {
+                binding.btnReserveTicket.isEnabled = true
+                binding.btnReserveTicket.text =
+                    binding.root.context.getString(R.string.ticket_reserve_tv_signin)
+            }
+
+            item.canReserve -> {
+                binding.btnReserveTicket.isEnabled = true
+                binding.btnReserveTicket.text =
+                    binding.root.context.getString(R.string.ticket_reserve_tv_btn_reserve_ticket)
+            }
+
+            else -> {
+                binding.btnReserveTicket.isEnabled = false
+                val pattern = DateTimeFormatter.ofPattern(
+                    binding.root.context.getString(R.string.ticket_reserve_tv_btn_reserve_ticket_not_open),
+                )
+                binding.btnReserveTicket.text = item.ticketOpenTime.format(pattern)
+            }
         }
 
         binding.tvTicketCount.text =

--- a/android/festago/app/src/main/res/layout/item_ticket_reserve.xml
+++ b/android/festago/app/src/main/res/layout/item_ticket_reserve.xml
@@ -15,7 +15,7 @@
 
         <variable
             name="stage"
-            type="com.festago.festago.presentation.model.ReservationStageUiModel" />
+            type="com.festago.festago.presentation.model.TicketReserveItemUiModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/android/festago/app/src/main/res/values/strings.xml
+++ b/android/festago/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="ticket_reserve_tv_ticket_count_format">(%1$s/%2$s)</string>
     <string name="ticket_reserve_tv_btn_reserve_ticket">예매 하기</string>
     <string name="ticket_reserve_tv_btn_reserve_ticket_not_open">MM월 dd일 HH:mm 오픈예정</string>
+    <string name="ticket_reserve_tv_signin">로그인 후 예매</string>
 
 
     <!-- Strings related to festival list -->

--- a/android/festago/app/src/test/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveViewModelTest.kt
+++ b/android/festago/app/src/test/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveViewModelTest.kt
@@ -6,6 +6,7 @@ import com.festago.festago.domain.model.Reservation
 import com.festago.festago.domain.model.ReservationStage
 import com.festago.festago.domain.model.ReservationTicket
 import com.festago.festago.domain.model.ReservedTicket
+import com.festago.festago.domain.repository.AuthRepository
 import com.festago.festago.domain.repository.FestivalRepository
 import com.festago.festago.domain.repository.ReservationTicketRepository
 import com.festago.festago.domain.repository.TicketRepository
@@ -29,6 +30,7 @@ class TicketReserveViewModelTest {
     private lateinit var reservationTicketRepository: ReservationTicketRepository
     private lateinit var festivalRepository: FestivalRepository
     private lateinit var ticketRepository: TicketRepository
+    private lateinit var authRepository: AuthRepository
     private lateinit var analyticsHelper: AnalyticsHelper
 
     private val fakeReservationTickets = listOf(
@@ -68,11 +70,13 @@ class TicketReserveViewModelTest {
         reservationTicketRepository = mockk()
         festivalRepository = mockk()
         ticketRepository = mockk()
+        authRepository = mockk()
         analyticsHelper = mockk(relaxed = true)
         vm = TicketReserveViewModel(
             reservationTicketRepository,
             festivalRepository,
             ticketRepository,
+            authRepository,
             analyticsHelper,
         )
     }
@@ -84,6 +88,12 @@ class TicketReserveViewModelTest {
             festivalRepository.loadFestivalDetail(0)
         } answers {
             Result.success(fakeReservation)
+        }
+
+        coEvery {
+            authRepository.isSigned
+        } answers {
+            true
         }
 
         // when
@@ -135,6 +145,12 @@ class TicketReserveViewModelTest {
             Result.success(fakeReservationTickets)
         }
 
+        coEvery {
+            authRepository.isSigned
+        } answers {
+            true
+        }
+
         // when
         vm.showTicketTypes(1)
 
@@ -151,6 +167,12 @@ class TicketReserveViewModelTest {
         // given
         coEvery { reservationTicketRepository.loadTicketTypes(1) } returns Result.failure(Exception())
 
+        coEvery {
+            authRepository.isSigned
+        } answers {
+            true
+        }
+
         // when
         vm.showTicketTypes(1)
 
@@ -166,7 +188,6 @@ class TicketReserveViewModelTest {
         } answers {
             Result.success(fakeReservedTicket)
         }
-
         // when
         vm.reserveTicket(0)
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #315 

## ✨ PR 세부 내용

- 로그인하지 않았다면 버튼을 "로그인 후 예매"로 변경
- "로그인 후 예매" 클릭 시 로그인 화면으로 이동

![image](https://github.com/woowacourse-teams/2023-festa-go/assets/67777523/430d690b-8c02-4757-a805-17c48d52c9ff)
