### PR TITLE
[BE] fix: 회원 가입시 프로필 사진을 권한을 주지 않으면 null로 저장되는 문제를 해결 (#358)

### DIFF
--- a/backend/src/main/java/com/festago/auth/dto/KakaoUserInfo.java
+++ b/backend/src/main/java/com/festago/auth/dto/KakaoUserInfo.java
@@ -24,7 +24,7 @@ public record KakaoUserInfo(
 
         public record Profile(
             String nickname,
-            @JsonProperty(value = "thumbnail_image_url", defaultValue = "https://placehold.co/200")
+            @JsonProperty("thumbnail_image_url")
             String thumbnailImageUrl
         ) {
 

--- a/backend/src/main/java/com/festago/domain/Member.java
+++ b/backend/src/main/java/com/festago/domain/Member.java
@@ -47,7 +47,7 @@ public class Member extends BaseTimeEntity {
         this.socialId = socialId;
         this.socialType = socialType;
         this.nickname = nickname;
-        this.profileImage = profileImage;
+        this.profileImage = (profileImage != null) ? profileImage : "https://example.com/default_profile.jpg";
     }
 
     public Long getId() {

--- a/backend/src/test/java/com/festago/domain/MemberTest.java
+++ b/backend/src/test/java/com/festago/domain/MemberTest.java
@@ -1,0 +1,24 @@
+package com.festago.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.festago.support.MemberFixture;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class MemberTest {
+
+    @Test
+    void 프로필_이미지가_null이면_기본값이_할당된다() {
+        // when
+        Member actual = MemberFixture.member()
+            .profileImage(null)
+            .build();
+
+        // then
+        assertThat(actual.getProfileImage()).isNotNull();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #358 

## ✨ PR 세부 내용

Member 주 생성자에서 null 값을 체크하여 null이면 기본값을 할당하도록 변경하였습니다.