### PR TITLE
[AN/USER] fix: 재설치 크래시 버그 수정(#379)

### DIFF
--- a/android/festago/app/src/main/res/xml/backup_rules.xml
+++ b/android/festago/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older that API 31
-   See https://developer.android.com/about/versions/12/backup-restore
--->
+<?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+   <exclude domain="sharedpref" path="."/>
 </full-backup-content>

--- a/android/festago/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/festago/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
+<?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
-    <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+    <cloud-backup disableIfNoEncryptionCapabilities="true|false">
+        <exclude domain="sharedpref" path="." />
     </cloud-backup>
-    <!--
-    <device-transfer>
-        <include .../>
-        <exclude .../>
-    </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #379

## ✨ PR 세부 내용

오류 발생 과정
로그인 -> EncryptedSharedPreference 에 토큰 저장-> 앱 삭제 -> 재설치 -> 토큰 저장소 접근

Crashlytics 에서 원인 분석
Caused by android.security.KeyStoreException Signature/MAC verification failed

구글링 결과
https://github.com/google/tink/issues/535#issuecomment-912170221
https://github.com/google/tink/issues/535#issuecomment-1266799661

공식 문서
https://developer.android.com/guide/topics/data/autobackup#IncludingFiles

문제 인식
sharedPreference 가 default 로 backup 되는데 EncryptedSharedPreference 를 다시 불러올 때 암호화 할 때 사용한 키가 유효하지 않음.

해결 방법
allowBackup = “false” -> 문제는 데이터 백업 안됨 패스
try catch 로 잡고 EncryptedSharedPreference 재설정
EncryptedSharedPreference 가 Auto Backup 되지 않도록 제외
