### PR TITLE
[BE] refactor: LocalDateTime.now() 사용을 LocalDateTime.now(clock) 형식으로 변경 (#395)

### DIFF
--- a/backend/src/main/java/com/festago/application/EntryService.java
+++ b/backend/src/main/java/com/festago/application/EntryService.java
@@ -12,6 +12,7 @@ import com.festago.dto.TicketValidationResponse;
 import com.festago.exception.BadRequestException;
 import com.festago.exception.ErrorCode;
 import com.festago.exception.NotFoundException;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,12 +24,14 @@ public class EntryService {
     private final EntryCodeProvider entryCodeProvider;
     private final EntryCodeExtractor entryCodeExtractor;
     private final MemberTicketRepository memberTicketRepository;
+    private final Clock clock;
 
     public EntryService(EntryCodeProvider entryCodeProvider, EntryCodeExtractor entryCodeExtractor,
-                        MemberTicketRepository memberTicketRepository) {
+                        MemberTicketRepository memberTicketRepository, Clock clock) {
         this.entryCodeProvider = entryCodeProvider;
         this.entryCodeExtractor = entryCodeExtractor;
         this.memberTicketRepository = memberTicketRepository;
+        this.clock = clock;
     }
 
     public EntryCodeResponse createEntryCode(Long memberId, Long memberTicketId) {
@@ -36,7 +39,7 @@ public class EntryService {
         if (!memberTicket.isOwner(memberId)) {
             throw new BadRequestException(ErrorCode.NOT_MEMBER_TICKET_OWNER);
         }
-        if (!memberTicket.canEntry(LocalDateTime.now())) {
+        if (!memberTicket.canEntry(LocalDateTime.now(clock))) {
             throw new BadRequestException(ErrorCode.NOT_ENTRY_TIME);
         }
         EntryCode entryCode = EntryCode.create(entryCodeProvider, memberTicket);

--- a/backend/src/main/java/com/festago/application/MemberTicketService.java
+++ b/backend/src/main/java/com/festago/application/MemberTicketService.java
@@ -12,6 +12,7 @@ import com.festago.dto.MemberTicketsResponse;
 import com.festago.exception.BadRequestException;
 import com.festago.exception.ErrorCode;
 import com.festago.exception.NotFoundException;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -25,11 +26,13 @@ public class MemberTicketService {
 
     private final MemberTicketRepository memberTicketRepository;
     private final MemberRepository memberRepository;
+    private final Clock clock;
 
     public MemberTicketService(MemberTicketRepository memberTicketRepository,
-                               MemberRepository memberRepository) {
+                               MemberRepository memberRepository, Clock clock) {
         this.memberTicketRepository = memberTicketRepository;
         this.memberRepository = memberRepository;
+        this.clock = clock;
     }
 
     @Transactional(readOnly = true)
@@ -59,7 +62,7 @@ public class MemberTicketService {
     }
 
     private List<MemberTicket> filterCurrentMemberTickets(List<MemberTicket> memberTickets) {
-        LocalDateTime currentTime = LocalDateTime.now();
+        LocalDateTime currentTime = LocalDateTime.now(clock);
         return memberTickets.stream()
             .filter(memberTicket -> memberTicket.isBeforeEntry(currentTime) || memberTicket.canEntry(currentTime))
             .sorted(comparing((MemberTicket memberTicket) -> memberTicket.isBeforeEntry(currentTime))

--- a/backend/src/test/java/com/festago/application/EntryServiceTest.java
+++ b/backend/src/test/java/com/festago/application/EntryServiceTest.java
@@ -26,7 +26,10 @@ import com.festago.support.MemberFixture;
 import com.festago.support.MemberTicketFixture;
 import com.festago.support.StageFixture;
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -64,9 +67,16 @@ class EntryServiceTest {
         @Test
         void 입장_시간_전_요청하면_예외() {
             // given
-            LocalDateTime entryTime = LocalDateTime.now().plusMinutes(30);
+            LocalDateTime entryTime = LocalDateTime.parse("2023-07-30T16:00:00");
+            Instant now = Instant.from(ZonedDateTime.of(entryTime.minusHours(1), ZoneId.systemDefault()));
+            Festival festival = FestivalFixture.festival()
+                .startDate(entryTime.toLocalDate())
+                .endDate(entryTime.toLocalDate())
+                .build();
             Stage stage = StageFixture.stage()
-                .startTime(LocalDateTime.now().plusHours(1))
+                .festival(festival)
+                .startTime(entryTime.plusHours(2))
+                .ticketOpenTime(entryTime.minusHours(1))
                 .build();
             MemberTicket memberTicket = MemberTicketFixture.memberTicket()
                 .id(1L)
@@ -75,9 +85,10 @@ class EntryServiceTest {
                 .build();
             Long memberId = memberTicket.getOwner().getId();
             Long memberTicketId = memberTicket.getId();
-
             given(memberTicketRepository.findById(anyLong()))
                 .willReturn(Optional.of(memberTicket));
+            given(clock.instant())
+                .willReturn(now);
 
             // when & then
             assertThatThrownBy(() -> entryService.createEntryCode(memberId, memberTicketId))
@@ -88,15 +99,16 @@ class EntryServiceTest {
         @Test
         void 입장_시간이_24시간이_넘은_경우_예외() {
             // given
-            LocalDateTime stageStartTime = LocalDateTime.now().minusHours(24);
-            LocalDateTime entryTime = stageStartTime.minusSeconds(10);
+            LocalDateTime entryTime = LocalDateTime.parse("2023-07-30T16:00:00");
+            Instant now = Instant.from(ZonedDateTime.of(entryTime.plusHours(24), ZoneId.systemDefault()));
             Festival festival = FestivalFixture.festival()
-                .startDate(stageStartTime.toLocalDate())
-                .endDate(stageStartTime.toLocalDate())
+                .startDate(entryTime.toLocalDate())
+                .endDate(entryTime.toLocalDate())
                 .build();
             Stage stage = StageFixture.stage()
                 .festival(festival)
-                .startTime(stageStartTime)
+                .startTime(entryTime.plusHours(2))
+                .ticketOpenTime(entryTime.minusHours(1))
                 .build();
             MemberTicket memberTicket = MemberTicketFixture.memberTicket()
                 .id(1L)
@@ -105,9 +117,10 @@ class EntryServiceTest {
                 .build();
             Long memberId = memberTicket.getOwner().getId();
             Long memberTicketId = memberTicket.getId();
-
             given(memberTicketRepository.findById(anyLong()))
                 .willReturn(Optional.of(memberTicket));
+            given(clock.instant())
+                .willReturn(now);
 
             // when & then
             assertThatThrownBy(() -> entryService.createEntryCode(memberId, memberTicketId))
@@ -118,14 +131,12 @@ class EntryServiceTest {
         @Test
         void 자신의_티켓이_아니면_예외() {
             // given
-            LocalDateTime entryTime = LocalDateTime.now().minusMinutes(30);
             Long memberId = 1L;
             Member other = MemberFixture.member()
                 .id(2L)
                 .build();
             MemberTicket otherTicket = MemberTicketFixture.memberTicket()
                 .id(1L)
-                .entryTime(entryTime)
                 .owner(other)
                 .build();
             Long memberTicketId = otherTicket.getId();
@@ -155,8 +166,21 @@ class EntryServiceTest {
         @Test
         void 성공() {
             // given
+            LocalDateTime entryTime = LocalDateTime.parse("2023-07-30T16:00:00");
+            Instant now = Instant.from(ZonedDateTime.of(entryTime, ZoneId.systemDefault()));
+            Festival festival = FestivalFixture.festival()
+                .startDate(entryTime.toLocalDate())
+                .endDate(entryTime.toLocalDate())
+                .build();
+            Stage stage = StageFixture.stage()
+                .festival(festival)
+                .startTime(entryTime.plusHours(2))
+                .ticketOpenTime(entryTime.minusHours(1))
+                .build();
             MemberTicket memberTicket = MemberTicketFixture.memberTicket()
                 .id(1L)
+                .stage(stage)
+                .entryTime(entryTime)
                 .build();
             String code = "3112321312123";
             Long memberId = memberTicket.getOwner().getId();
@@ -166,6 +190,8 @@ class EntryServiceTest {
                 .willReturn(Optional.of(memberTicket));
             given(entryCodeProvider.provide(any(), any()))
                 .willReturn(code);
+            given(clock.instant())
+                .willReturn(now);
 
             // when
             EntryCodeResponse entryCode = entryService.createEntryCode(memberId, memberTicketId);

--- a/backend/src/test/java/com/festago/application/EntryServiceTest.java
+++ b/backend/src/test/java/com/festago/application/EntryServiceTest.java
@@ -1,5 +1,6 @@
 package com.festago.application;
 
+import static com.festago.support.TimeInstantProvider.setCurrentTime;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
@@ -68,7 +69,6 @@ class EntryServiceTest {
         void 입장_시간_전_요청하면_예외() {
             // given
             LocalDateTime entryTime = LocalDateTime.parse("2023-07-30T16:00:00");
-            Instant now = Instant.from(ZonedDateTime.of(entryTime.minusHours(1), ZoneId.systemDefault()));
             Festival festival = FestivalFixture.festival()
                 .startDate(entryTime.toLocalDate())
                 .endDate(entryTime.toLocalDate())
@@ -88,7 +88,7 @@ class EntryServiceTest {
             given(memberTicketRepository.findById(anyLong()))
                 .willReturn(Optional.of(memberTicket));
             given(clock.instant())
-                .willReturn(now);
+                .willReturn(setCurrentTime(entryTime.minusHours(1)));
 
             // when & then
             assertThatThrownBy(() -> entryService.createEntryCode(memberId, memberTicketId))
@@ -100,7 +100,6 @@ class EntryServiceTest {
         void 입장_시간이_24시간이_넘은_경우_예외() {
             // given
             LocalDateTime entryTime = LocalDateTime.parse("2023-07-30T16:00:00");
-            Instant now = Instant.from(ZonedDateTime.of(entryTime.plusHours(24), ZoneId.systemDefault()));
             Festival festival = FestivalFixture.festival()
                 .startDate(entryTime.toLocalDate())
                 .endDate(entryTime.toLocalDate())
@@ -120,7 +119,7 @@ class EntryServiceTest {
             given(memberTicketRepository.findById(anyLong()))
                 .willReturn(Optional.of(memberTicket));
             given(clock.instant())
-                .willReturn(now);
+                .willReturn(setCurrentTime(entryTime.plusHours(24)));
 
             // when & then
             assertThatThrownBy(() -> entryService.createEntryCode(memberId, memberTicketId))

--- a/backend/src/test/java/com/festago/application/EntryServiceTest.java
+++ b/backend/src/test/java/com/festago/application/EntryServiceTest.java
@@ -25,6 +25,7 @@ import com.festago.support.FestivalFixture;
 import com.festago.support.MemberFixture;
 import com.festago.support.MemberTicketFixture;
 import com.festago.support.StageFixture;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -49,6 +51,9 @@ class EntryServiceTest {
 
     @Mock
     MemberTicketRepository memberTicketRepository;
+
+    @Spy
+    Clock clock = Clock.systemDefaultZone();
 
     @InjectMocks
     EntryService entryService;

--- a/backend/src/test/java/com/festago/application/EntryServiceTest.java
+++ b/backend/src/test/java/com/festago/application/EntryServiceTest.java
@@ -1,6 +1,5 @@
 package com.festago.application;
 
-import static com.festago.support.TimeInstantProvider.setCurrentTime;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,6 +25,7 @@ import com.festago.support.FestivalFixture;
 import com.festago.support.MemberFixture;
 import com.festago.support.MemberTicketFixture;
 import com.festago.support.StageFixture;
+import com.festago.support.TimeInstantProvider;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -88,7 +88,7 @@ class EntryServiceTest {
             given(memberTicketRepository.findById(anyLong()))
                 .willReturn(Optional.of(memberTicket));
             given(clock.instant())
-                .willReturn(setCurrentTime(entryTime.minusHours(1)));
+                .willReturn(TimeInstantProvider.from(entryTime.minusHours(1)));
 
             // when & then
             assertThatThrownBy(() -> entryService.createEntryCode(memberId, memberTicketId))
@@ -119,7 +119,7 @@ class EntryServiceTest {
             given(memberTicketRepository.findById(anyLong()))
                 .willReturn(Optional.of(memberTicket));
             given(clock.instant())
-                .willReturn(setCurrentTime(entryTime.plusHours(24)));
+                .willReturn(TimeInstantProvider.from((entryTime.plusHours(24))));
 
             // when & then
             assertThatThrownBy(() -> entryService.createEntryCode(memberId, memberTicketId))

--- a/backend/src/test/java/com/festago/application/MemberTicketServiceTest.java
+++ b/backend/src/test/java/com/festago/application/MemberTicketServiceTest.java
@@ -19,6 +19,7 @@ import com.festago.exception.NotFoundException;
 import com.festago.support.MemberFixture;
 import com.festago.support.MemberTicketFixture;
 import com.festago.support.StageFixture;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -43,6 +45,9 @@ class MemberTicketServiceTest {
 
     @Mock
     MemberRepository memberRepository;
+
+    @Spy
+    Clock clock = Clock.systemDefaultZone();
 
     @InjectMocks
     MemberTicketService memberTicketService;

--- a/backend/src/test/java/com/festago/support/TimeInstantProvider.java
+++ b/backend/src/test/java/com/festago/support/TimeInstantProvider.java
@@ -7,7 +7,11 @@ import java.time.ZonedDateTime;
 
 public class TimeInstantProvider {
 
-    public static Instant setCurrentTime(LocalDateTime localDateTime) {
+    public static Instant from(String localDateTime) {
+        return from(LocalDateTime.parse(localDateTime));
+    }
+
+    public static Instant from(LocalDateTime localDateTime) {
         return Instant.from(ZonedDateTime.of(localDateTime, ZoneId.systemDefault()));
     }
 }

--- a/backend/src/test/java/com/festago/support/TimeInstantProvider.java
+++ b/backend/src/test/java/com/festago/support/TimeInstantProvider.java
@@ -1,0 +1,13 @@
+package com.festago.support;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class TimeInstantProvider {
+
+    public static Instant setCurrentTime(LocalDateTime localDateTime) {
+        return Instant.from(ZonedDateTime.of(localDateTime, ZoneId.systemDefault()));
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #395 
