### PR TITLE
[BE] feat: 이메일 코드를 통한 학생 인증 기능을 추가 (#430)

### DIFF
--- a/backend/src/main/java/com/festago/application/StudentService.java
+++ b/backend/src/main/java/com/festago/application/StudentService.java
@@ -78,7 +78,7 @@ public class StudentService {
     public void verificate(Long memberId, StudentVerificateRequest request) {
         validateStudent(memberId);
         Member member = findMember(memberId);
-        StudentCode studentCode = studentCodeRepository.findByCode(new VerificationCode(request.code()))
+        StudentCode studentCode = studentCodeRepository.findByCodeAndMember(new VerificationCode(request.code()), member)
             .orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_STUDENT_VERIFICATION_CODE));
         studentRepository.save(new Student(member, studentCode.getSchool(), studentCode.getUsername()));
         studentCodeRepository.deleteByMember(member);

--- a/backend/src/main/java/com/festago/domain/School.java
+++ b/backend/src/main/java/com/festago/domain/School.java
@@ -27,6 +27,10 @@ public class School {
     protected School() {
     }
 
+    public School(String domain, String name) {
+        this(null, domain, name);
+    }
+
     public School(Long id, String domain, String name) {
         validate(domain, name);
         this.id = id;

--- a/backend/src/main/java/com/festago/domain/Student.java
+++ b/backend/src/main/java/com/festago/domain/Student.java
@@ -34,6 +34,10 @@ public class Student {
     protected Student() {
     }
 
+    public Student(Member member, School school, String username) {
+        this(null, member, school, username);
+    }
+
     public Student(Long id, Member member, School school, String username) {
         validate(member, school, username);
         this.id = id;

--- a/backend/src/main/java/com/festago/domain/StudentCode.java
+++ b/backend/src/main/java/com/festago/domain/StudentCode.java
@@ -1,5 +1,7 @@
 package com.festago.domain;
 
+import com.festago.exception.ErrorCode;
+import com.festago.exception.InternalServerException;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import org.springframework.util.StringUtils;
 
 @Entity
 public class StudentCode extends BaseTimeEntity {
@@ -25,18 +28,32 @@ public class StudentCode extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private Member member;
 
+    private String username;
+
     protected StudentCode() {
     }
 
-    public StudentCode(VerificationCode code, Member member, School school) {
-        this(null, code, member, school);
+    public StudentCode(VerificationCode code, School school, Member member, String username) {
+        this(null, code, school, member, username);
     }
 
-    public StudentCode(Long id, VerificationCode code, Member member, School school) {
+    public StudentCode(Long id, VerificationCode code, School school, Member member, String username) {
+        validate(username);
         this.id = id;
         this.code = code;
-        this.member = member;
         this.school = school;
+        this.member = member;
+        this.username = username;
+    }
+
+    private void validate(String username) {
+        if (!StringUtils.hasText(username)) {
+            throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        if (username.length() > 255) {
+            throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
     }
 
     public Long getId() {
@@ -53,5 +70,9 @@ public class StudentCode extends BaseTimeEntity {
 
     public Member getMember() {
         return member;
+    }
+
+    public String getUsername() {
+        return username;
     }
 }

--- a/backend/src/main/java/com/festago/domain/StudentCodeRepository.java
+++ b/backend/src/main/java/com/festago/domain/StudentCodeRepository.java
@@ -7,5 +7,5 @@ public interface StudentCodeRepository extends JpaRepository<StudentCode, Long> 
 
     void deleteByMember(Member member);
 
-    Optional<StudentCode> findByCode(VerificationCode code);
+    Optional<StudentCode> findByCodeAndMember(VerificationCode code, Member member);
 }

--- a/backend/src/main/java/com/festago/domain/StudentCodeRepository.java
+++ b/backend/src/main/java/com/festago/domain/StudentCodeRepository.java
@@ -1,8 +1,11 @@
 package com.festago.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudentCodeRepository extends JpaRepository<StudentCode, Long> {
 
     void deleteByMember(Member member);
+
+    Optional<StudentCode> findByCode(VerificationCode code);
 }

--- a/backend/src/main/java/com/festago/dto/StudentVerificateRequest.java
+++ b/backend/src/main/java/com/festago/dto/StudentVerificateRequest.java
@@ -1,0 +1,5 @@
+package com.festago.dto;
+
+public record StudentVerificateRequest(String code) {
+
+}

--- a/backend/src/main/java/com/festago/exception/ErrorCode.java
+++ b/backend/src/main/java/com/festago/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     ALREADY_STUDENT_VERIFIED("이미 학교 인증이 완료된 사용자입니다."),
     DUPLICATE_STUDENT_EMAIL("이미 인증된 이메일입니다."),
     TICKET_CANNOT_RESERVE_STAGE_START("공연의 시작 시간 이후로 예매할 수 없습니다."),
+    INVALID_STUDENT_VERIFICATION_CODE("존재하지 않는 학생 인증 코드입니다."),
 
     // 401
     EXPIRED_AUTH_TOKEN("만료된 로그인 토큰입니다."),

--- a/backend/src/main/java/com/festago/exception/ErrorCode.java
+++ b/backend/src/main/java/com/festago/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
     ALREADY_STUDENT_VERIFIED("이미 학교 인증이 완료된 사용자입니다."),
     DUPLICATE_STUDENT_EMAIL("이미 인증된 이메일입니다."),
     TICKET_CANNOT_RESERVE_STAGE_START("공연의 시작 시간 이후로 예매할 수 없습니다."),
-    INVALID_STUDENT_VERIFICATION_CODE("존재하지 않는 학생 인증 코드입니다."),
+    INVALID_STUDENT_VERIFICATION_CODE("올바르지 않은 학생 인증 코드입니다."),
 
     // 401
     EXPIRED_AUTH_TOKEN("만료된 로그인 토큰입니다."),

--- a/backend/src/main/java/com/festago/presentation/StudentController.java
+++ b/backend/src/main/java/com/festago/presentation/StudentController.java
@@ -3,6 +3,7 @@ package com.festago.presentation;
 import com.festago.application.StudentService;
 import com.festago.auth.annotation.Member;
 import com.festago.dto.StudentSendMailRequest;
+import com.festago.dto.StudentVerificateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +28,15 @@ public class StudentController {
     public ResponseEntity<Void> sendEmail(@Member Long memberId,
                                           @RequestBody StudentSendMailRequest request) {
         studentService.sendVerificationMail(memberId, request);
+        return ResponseEntity.ok()
+            .build();
+    }
+
+    @PostMapping("/verification")
+    @Operation(description = "학교 인증을 수행한다.", summary = "학생 인증 수행")
+    public ResponseEntity<Void> verificate(@Member Long memberId,
+                                           @RequestBody StudentVerificateRequest request) {
+        studentService.verificate(memberId, request);
         return ResponseEntity.ok()
             .build();
     }

--- a/backend/src/main/resources/db/migration/V2__student_code_add_username.sql
+++ b/backend/src/main/resources/db/migration/V2__student_code_add_username.sql
@@ -1,0 +1,2 @@
+alter table student_code
+    add column username varchar(255);

--- a/backend/src/test/java/com/festago/application/StudentServiceTest.java
+++ b/backend/src/test/java/com/festago/application/StudentServiceTest.java
@@ -197,13 +197,13 @@ class StudentServiceTest {
             StudentVerificateRequest request = new StudentVerificateRequest("123456");
             given(memberRepository.findById(anyLong()))
                 .willReturn(Optional.of(MemberFixture.member().build()));
-            given(studentCodeRepository.findByCode(any()))
+            given(studentCodeRepository.findByCodeAndMember(any(), any()))
                 .willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> studentService.verificate(memberId, request))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("존재하지 않는 학생 인증 코드입니다.");
+                .hasMessage("올바르지 않은 학생 인증 코드입니다.");
         }
 
         @Test
@@ -214,7 +214,7 @@ class StudentServiceTest {
             Member member = MemberFixture.member().build();
             given(memberRepository.findById(anyLong()))
                 .willReturn(Optional.of(member));
-            given(studentCodeRepository.findByCode(any()))
+            given(studentCodeRepository.findByCodeAndMember(any(), any()))
                 .willReturn(Optional.of(new StudentCode(
                     new VerificationCode("123456"),
                     new School("snu.ac.kr", "서울대학교"),

--- a/backend/src/test/java/com/festago/presentation/StudentControllerTest.java
+++ b/backend/src/test/java/com/festago/presentation/StudentControllerTest.java
@@ -6,10 +6,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.festago.application.StudentService;
 import com.festago.dto.StudentSendMailRequest;
+import com.festago.dto.StudentVerificateRequest;
 import com.festago.support.CustomWebMvcTest;
 import com.festago.support.WithMockAuth;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -31,30 +33,64 @@ class StudentControllerTest {
     @MockBean
     StudentService studentService;
 
-    @Test
-    void 인증이_되지_않으면_401() throws Exception {
-        // given
-        StudentSendMailRequest request = new StudentSendMailRequest("user", 1L);
+    @Nested
+    class 학생_인증_메일_전송 {
 
-        // when & then
-        mockMvc.perform(post("/students/send-verification")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isUnauthorized());
+        @Test
+        void 인증이_되지_않으면_401() throws Exception {
+            // given
+            StudentSendMailRequest request = new StudentSendMailRequest("user", 1L);
+
+            // when & then
+            mockMvc.perform(post("/students/send-verification")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @WithMockAuth
+        void 학교_인증_요청() throws Exception {
+            // given
+            StudentSendMailRequest request = new StudentSendMailRequest("user", 1L);
+
+            // when & then
+            mockMvc.perform(post("/students/send-verification")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer token")
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        }
     }
 
-    @Test
-    @WithMockAuth
-    void 학교_인증_요청() throws Exception {
-        // given
-        StudentSendMailRequest request = new StudentSendMailRequest("user", 1L);
+    @Nested
+    class 학생_인증 {
 
-        // when & then
-        mockMvc.perform(post("/students/send-verification")
-                .contentType(MediaType.APPLICATION_JSON)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer token")
-                .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isOk());
+        @Test
+        void 인증이_되지_않으면_401() throws Exception {
+            // given
+            StudentVerificateRequest request = new StudentVerificateRequest("123456");
 
+            // when & then
+            mockMvc.perform(post("/students/verification")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @WithMockAuth
+        void 학교_인증_요청() throws Exception {
+            // given
+            StudentVerificateRequest request = new StudentVerificateRequest("123456");
+
+            // when & then
+            mockMvc.perform(post("/students/verification")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer token")
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+        }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #430 

## ✨ PR 세부 내용

1. 학생 인증 기능을 추가하였습니다.

2. 기존 코드 변경 사항

학생 인증 완료후 Student 객체를 생성할 때 메일 요청시 요청했던, username이 필요합니다.
(ohs@knu.ac.kr에서 @ 앞부분이 username )

그런데 저희는 username을 어느 곳에서도 저장하지 않아서, Student 객체에 username을 넣어주지 못합니다.

따라서 메일 인증 요청때 생성하던 StudentCode 객체에 username 필드를 추가하였습니다.
