### PR TITLE
[BE] 학생 인증이 완료된 사용자만 재학생용 티켓을 발급 (#446)

### DIFF
--- a/backend/src/main/java/com/festago/admin/application/AdminService.java
+++ b/backend/src/main/java/com/festago/admin/application/AdminService.java
@@ -105,6 +105,7 @@ public class AdminService {
         return festivals.stream()
             .map(festival -> new AdminFestivalResponse(
                 festival.getId(),
+                festival.getSchool().getId(),
                 festival.getName(),
                 festival.getStartDate(),
                 festival.getEndDate(),

--- a/backend/src/main/java/com/festago/admin/application/AdminService.java
+++ b/backend/src/main/java/com/festago/admin/application/AdminService.java
@@ -2,10 +2,13 @@ package com.festago.admin.application;
 
 import com.festago.admin.dto.AdminFestivalResponse;
 import com.festago.admin.dto.AdminResponse;
+import com.festago.admin.dto.AdminSchoolResponse;
 import com.festago.admin.dto.AdminStageResponse;
 import com.festago.admin.dto.AdminTicketResponse;
 import com.festago.festival.domain.Festival;
 import com.festago.festival.repository.FestivalRepository;
+import com.festago.school.domain.School;
+import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
 import com.festago.ticket.domain.Ticket;
@@ -26,23 +29,34 @@ public class AdminService {
     private final FestivalRepository festivalRepository;
     private final StageRepository stageRepository;
     private final TicketRepository ticketRepository;
+    private final SchoolRepository schoolRepository;
 
     public AdminService(FestivalRepository festivalRepository, StageRepository stageRepository,
-                        TicketRepository ticketRepository) {
+                        TicketRepository ticketRepository,
+                        SchoolRepository schoolRepository) {
         this.festivalRepository = festivalRepository;
         this.stageRepository = stageRepository;
         this.ticketRepository = ticketRepository;
+        this.schoolRepository = schoolRepository;
     }
 
     @Transactional(readOnly = true)
     public AdminResponse getAdminResponse() {
+        List<School> allSchool = schoolRepository.findAll();
         List<Ticket> allTicket = ticketRepository.findAll();
         List<Stage> allStage = stageRepository.findAll();
         List<Festival> allFestival = festivalRepository.findAll();
         return new AdminResponse(
+            schoolResponses(allSchool),
             ticketResponses(allTicket),
             stageResponses(allStage),
             festivalResponses(allFestival));
+    }
+
+    private List<AdminSchoolResponse> schoolResponses(List<School> schools) {
+        return schools.stream()
+            .map(AdminSchoolResponse::from)
+            .toList();
     }
 
     private List<AdminTicketResponse> ticketResponses(List<Ticket> tickets) {

--- a/backend/src/main/java/com/festago/admin/dto/AdminFestivalResponse.java
+++ b/backend/src/main/java/com/festago/admin/dto/AdminFestivalResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 
 public record AdminFestivalResponse(
     Long id,
+    Long schoolId,
     String name,
     LocalDate startDate,
     LocalDate endDate,

--- a/backend/src/main/java/com/festago/admin/dto/AdminResponse.java
+++ b/backend/src/main/java/com/festago/admin/dto/AdminResponse.java
@@ -3,6 +3,9 @@ package com.festago.admin.dto;
 import java.util.List;
 
 public record AdminResponse(
+
+    List<AdminSchoolResponse> adminSchools,
+
     List<AdminTicketResponse> adminTickets,
     List<AdminStageResponse> adminStageResponse,
     List<AdminFestivalResponse> adminFestivalResponse) {

--- a/backend/src/main/java/com/festago/admin/dto/AdminResponse.java
+++ b/backend/src/main/java/com/festago/admin/dto/AdminResponse.java
@@ -3,9 +3,7 @@ package com.festago.admin.dto;
 import java.util.List;
 
 public record AdminResponse(
-
     List<AdminSchoolResponse> adminSchools,
-
     List<AdminTicketResponse> adminTickets,
     List<AdminStageResponse> adminStageResponse,
     List<AdminFestivalResponse> adminFestivalResponse) {

--- a/backend/src/main/java/com/festago/admin/dto/AdminSchoolResponse.java
+++ b/backend/src/main/java/com/festago/admin/dto/AdminSchoolResponse.java
@@ -1,0 +1,17 @@
+package com.festago.admin.dto;
+
+import com.festago.school.domain.School;
+
+public record AdminSchoolResponse(
+    Long id,
+    String domain,
+    String name) {
+
+    public static AdminSchoolResponse from(School school) {
+        return new AdminSchoolResponse(
+            school.getId(),
+            school.getDomain(),
+            school.getName()
+        );
+    }
+}

--- a/backend/src/main/java/com/festago/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/festago/common/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     NEED_AUTH_TOKEN("로그인이 필요한 서비스입니다."),
     INCORRECT_PASSWORD_OR_ACCOUNT("비밀번호가 틀렸거나, 해당 계정이 없습니다."),
     DUPLICATE_ACCOUNT_USERNAME("해당 계정이 존재합니다."),
+    DUPLICATE_SCHOOL("이미 존재하는 학교 정보입니다."),
 
     // 403
     NOT_ENOUGH_PERMISSION("해당 권한이 없습니다."),

--- a/backend/src/main/java/com/festago/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/festago/common/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     INVALID_TICKET_CREATE_TIME("티켓 예매 시작 후 새롭게 티켓을 발급할 수 없습니다."),
     OAUTH2_NOT_SUPPORTED_SOCIAL_TYPE("해당 OAuth2 제공자는 지원되지 않습니다."),
     RESERVE_TICKET_OVER_AMOUNT("예매 가능한 수량을 초과했습니다."),
+    NEED_STUDENT_VERIFICATION("학생 인증이 필요합니다."),
     OAUTH2_INVALID_TOKEN("잘못된 OAuth2 토큰입니다."),
     ALREADY_STUDENT_VERIFIED("이미 학교 인증이 완료된 사용자입니다."),
     DUPLICATE_STUDENT_EMAIL("이미 인증된 이메일입니다."),

--- a/backend/src/main/java/com/festago/festival/application/FestivalService.java
+++ b/backend/src/main/java/com/festago/festival/application/FestivalService.java
@@ -11,6 +11,8 @@ import com.festago.festival.dto.FestivalDetailResponse;
 import com.festago.festival.dto.FestivalResponse;
 import com.festago.festival.dto.FestivalsResponse;
 import com.festago.festival.repository.FestivalRepository;
+import com.festago.school.domain.School;
+import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
 import java.time.LocalDate;
@@ -24,14 +26,19 @@ public class FestivalService {
 
     private final FestivalRepository festivalRepository;
     private final StageRepository stageRepository;
+    private final SchoolRepository schoolRepository;
 
-    public FestivalService(FestivalRepository festivalRepository, StageRepository stageRepository) {
+    public FestivalService(FestivalRepository festivalRepository, StageRepository stageRepository,
+                           SchoolRepository schoolRepository) {
         this.festivalRepository = festivalRepository;
         this.stageRepository = stageRepository;
+        this.schoolRepository = schoolRepository;
     }
 
     public FestivalResponse create(FestivalCreateRequest request) {
-        Festival festival = request.toEntity();
+        School school = schoolRepository.findById(request.schoolId())
+            .orElseThrow(() -> new NotFoundException(ErrorCode.SCHOOL_NOT_FOUND));
+        Festival festival = request.toEntity(school);
         validate(festival);
         Festival newFestival = festivalRepository.save(festival);
         return FestivalResponse.from(newFestival);

--- a/backend/src/main/java/com/festago/festival/domain/Festival.java
+++ b/backend/src/main/java/com/festago/festival/domain/Festival.java
@@ -3,10 +3,13 @@ package com.festago.festival.domain;
 import com.festago.common.domain.BaseTimeEntity;
 import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.ErrorCode;
+import com.festago.school.domain.School;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
@@ -20,6 +23,7 @@ public class Festival extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
 
     @NotNull
     @Size(max = 50)
@@ -35,24 +39,29 @@ public class Festival extends BaseTimeEntity {
     @Size(max = 255)
     private String thumbnail;
 
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    private School school;
+
     protected Festival() {
     }
 
-    public Festival(String name, LocalDate startDate, LocalDate endDate) {
-        this(null, name, startDate, endDate, DEFAULT_THUMBNAIL);
+    public Festival(String name, LocalDate startDate, LocalDate endDate, School school) {
+        this(null, name, startDate, endDate, DEFAULT_THUMBNAIL, school);
     }
 
-    public Festival(String name, LocalDate startDate, LocalDate endDate, String thumbnail) {
-        this(null, name, startDate, endDate, thumbnail);
+    public Festival(String name, LocalDate startDate, LocalDate endDate, String thumbnail, School school) {
+        this(null, name, startDate, endDate, thumbnail, school);
     }
 
-    public Festival(Long id, String name, LocalDate startDate, LocalDate endDate, String thumbnail) {
+    public Festival(Long id, String name, LocalDate startDate, LocalDate endDate, String thumbnail, School school) {
         validate(name, startDate, endDate, thumbnail);
         this.id = id;
         this.name = name;
         this.startDate = startDate;
         this.endDate = endDate;
         this.thumbnail = thumbnail;
+        this.school = school;
     }
 
     private void validate(String name, LocalDate startDate, LocalDate endDate, String thumbnail) {
@@ -117,5 +126,9 @@ public class Festival extends BaseTimeEntity {
 
     public String getThumbnail() {
         return thumbnail;
+    }
+
+    public School getSchool() {
+        return school;
     }
 }

--- a/backend/src/main/java/com/festago/festival/dto/FestivalCreateRequest.java
+++ b/backend/src/main/java/com/festago/festival/dto/FestivalCreateRequest.java
@@ -1,6 +1,7 @@
 package com.festago.festival.dto;
 
 import com.festago.festival.domain.Festival;
+import com.festago.school.domain.School;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -10,12 +11,14 @@ public record FestivalCreateRequest(
     @NotNull(message = "name 은 null 일 수 없습니다.") String name,
     @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
     @DateTimeFormat(iso = ISO.DATE) LocalDate endDate,
-    String thumbnail) {
+    String thumbnail,
+    @NotNull(message = "schoolId는 null 일 수 없습니다.") Long schoolId
+) {
 
-    public Festival toEntity() {
+    public Festival toEntity(School school) {
         if (thumbnail == null || thumbnail.isBlank()) {
-            return new Festival(name, startDate, endDate);
+            return new Festival(name, startDate, endDate, school);
         }
-        return new Festival(name, startDate, endDate, thumbnail);
+        return new Festival(name, startDate, endDate, thumbnail, school);
     }
 }

--- a/backend/src/main/java/com/festago/presentation/AdminController.java
+++ b/backend/src/main/java/com/festago/presentation/AdminController.java
@@ -15,6 +15,9 @@ import com.festago.common.exception.UnauthorizedException;
 import com.festago.festival.application.FestivalService;
 import com.festago.festival.dto.FestivalCreateRequest;
 import com.festago.festival.dto.FestivalResponse;
+import com.festago.school.application.SchoolService;
+import com.festago.school.dto.SchoolCreateRequest;
+import com.festago.school.dto.SchoolResponse;
 import com.festago.stage.application.StageService;
 import com.festago.stage.dto.StageCreateRequest;
 import com.festago.stage.dto.StageResponse;
@@ -52,17 +55,26 @@ public class AdminController {
     private final TicketService ticketService;
     private final AdminService adminService;
     private final AdminAuthService adminAuthService;
+    private final SchoolService schoolService;
     private final Optional<BuildProperties> properties;
 
     public AdminController(FestivalService festivalService, StageService stageService, TicketService ticketService,
                            AdminService adminService, AdminAuthService adminAuthService,
-                           Optional<BuildProperties> buildProperties) {
+                           SchoolService schoolService, Optional<BuildProperties> buildProperties) {
         this.festivalService = festivalService;
         this.stageService = stageService;
         this.ticketService = ticketService;
         this.adminService = adminService;
         this.adminAuthService = adminAuthService;
+        this.schoolService = schoolService;
         this.properties = buildProperties;
+    }
+
+    @PostMapping("/schools")
+    public ResponseEntity<SchoolResponse> createSchool(@RequestBody @Valid SchoolCreateRequest request) {
+        SchoolResponse response = schoolService.create(request);
+        return ResponseEntity.ok()
+            .body(response);
     }
 
     @PostMapping("/festivals")

--- a/backend/src/main/java/com/festago/school/application/SchoolService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolService.java
@@ -1,5 +1,7 @@
 package com.festago.school.application;
 
+import com.festago.common.exception.BadRequestException;
+import com.festago.common.exception.ErrorCode;
 import com.festago.school.domain.School;
 import com.festago.school.dto.SchoolCreateRequest;
 import com.festago.school.dto.SchoolResponse;
@@ -17,11 +19,17 @@ public class SchoolService {
     public SchoolService(SchoolRepository schoolRepository) {
         this.schoolRepository = schoolRepository;
     }
-    
+
     public SchoolResponse create(SchoolCreateRequest request) {
-        // TODO: doamin, name 중복 예외?
+        validateSchool(request);
         School school = schoolRepository.save(new School(request.domain(), request.name()));
         return SchoolResponse.from(school);
+    }
+
+    private void validateSchool(SchoolCreateRequest request) {
+        if (schoolRepository.existsByDomainOrName(request.domain(), request.name())) {
+            throw new BadRequestException(ErrorCode.DUPLICATE_SCHOOL);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/festago/school/application/SchoolService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolService.java
@@ -1,5 +1,8 @@
 package com.festago.school.application;
 
+import com.festago.school.domain.School;
+import com.festago.school.dto.SchoolCreateRequest;
+import com.festago.school.dto.SchoolResponse;
 import com.festago.school.dto.SchoolsResponse;
 import com.festago.school.repository.SchoolRepository;
 import org.springframework.stereotype.Service;
@@ -13,6 +16,12 @@ public class SchoolService {
 
     public SchoolService(SchoolRepository schoolRepository) {
         this.schoolRepository = schoolRepository;
+    }
+    
+    public SchoolResponse create(SchoolCreateRequest request) {
+        // TODO: doamin, name 중복 예외?
+        School school = schoolRepository.save(new School(request.domain(), request.name()));
+        return SchoolResponse.from(school);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/festago/school/domain/School.java
+++ b/backend/src/main/java/com/festago/school/domain/School.java
@@ -3,6 +3,7 @@ package com.festago.school.domain;
 import com.festago.common.domain.BaseTimeEntity;
 import com.festago.common.exception.ErrorCode;
 import com.festago.common.exception.InternalServerException;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,10 +20,12 @@ public class School extends BaseTimeEntity {
 
     @NotNull
     @Size(max = 50)
+    @Column(unique = true)
     private String domain;
 
     @NotNull
     @Size(max = 255)
+    @Column(unique = true)
     private String name;
 
     protected School() {

--- a/backend/src/main/java/com/festago/school/dto/SchoolCreateRequest.java
+++ b/backend/src/main/java/com/festago/school/dto/SchoolCreateRequest.java
@@ -1,0 +1,10 @@
+package com.festago.school.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SchoolCreateRequest(
+    @NotNull(message = "name 은 null 일 수 없습니다.") String name,
+    @NotNull(message = "domain 은 null 일 수 없습니다.") String domain
+) {
+
+}

--- a/backend/src/main/java/com/festago/school/repository/SchoolRepository.java
+++ b/backend/src/main/java/com/festago/school/repository/SchoolRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SchoolRepository extends JpaRepository<School, Long> {
 
+    boolean existsByDomainOrName(String domain, String name);
+
 }

--- a/backend/src/main/java/com/festago/stage/repository/StageRepository.java
+++ b/backend/src/main/java/com/festago/stage/repository/StageRepository.java
@@ -2,6 +2,7 @@ package com.festago.stage.repository;
 
 import com.festago.stage.domain.Stage;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,4 +16,12 @@ public interface StageRepository extends JpaRepository<Stage, Long> {
         WHERE s.festival.id = :festivalId
         """)
     List<Stage> findAllDetailByFestivalId(@Param("festivalId") Long festivalId);
+
+    @Query("""
+        SELECT s FROM Stage s
+        LEFT JOIN s.festival f
+        LEFT JOIN f.school sc
+        WHERE s.id = :id
+        """)
+    Optional<Stage> findByIdWithFetch(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/festago/student/repository/StudentRepository.java
+++ b/backend/src/main/java/com/festago/student/repository/StudentRepository.java
@@ -1,9 +1,13 @@
 package com.festago.student.repository;
 
+import com.festago.member.domain.Member;
+import com.festago.school.domain.School;
 import com.festago.student.domain.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudentRepository extends JpaRepository<Student, Long> {
+
+    boolean existsByMemberAndSchool(Member member, School school);
 
     boolean existsByUsernameAndSchoolId(String username, Long id);
 

--- a/backend/src/main/java/com/festago/student/repository/StudentRepository.java
+++ b/backend/src/main/java/com/festago/student/repository/StudentRepository.java
@@ -1,13 +1,12 @@
 package com.festago.student.repository;
 
 import com.festago.member.domain.Member;
-import com.festago.school.domain.School;
 import com.festago.student.domain.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudentRepository extends JpaRepository<Student, Long> {
 
-    boolean existsByMemberAndSchool(Member member, School school);
+    boolean existsByMemberAndSchoolId(Member member, Long schoolId);
 
     boolean existsByUsernameAndSchoolId(String username, Long id);
 

--- a/backend/src/main/java/com/festago/ticket/application/TicketService.java
+++ b/backend/src/main/java/com/festago/ticket/application/TicketService.java
@@ -2,6 +2,7 @@ package com.festago.ticket.application;
 
 import com.festago.common.exception.ErrorCode;
 import com.festago.common.exception.NotFoundException;
+import com.festago.school.domain.School;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
 import com.festago.ticket.domain.Ticket;
@@ -32,9 +33,11 @@ public class TicketService {
     public TicketCreateResponse create(TicketCreateRequest request) {
         Stage stage = findStageById(request.stageId());
         TicketType ticketType = request.ticketType();
+        // TODO: n+1
+        School school = stage.getFestival().getSchool();
 
         Ticket ticket = ticketRepository.findByTicketTypeAndStage(ticketType, stage)
-            .orElseGet(() -> ticketRepository.save(new Ticket(stage, ticketType)));
+            .orElseGet(() -> ticketRepository.save(new Ticket(stage, ticketType, school)));
 
         ticket.addTicketEntryTime(LocalDateTime.now(clock), request.entryTime(), request.amount());
 

--- a/backend/src/main/java/com/festago/ticket/application/TicketService.java
+++ b/backend/src/main/java/com/festago/ticket/application/TicketService.java
@@ -33,7 +33,6 @@ public class TicketService {
     public TicketCreateResponse create(TicketCreateRequest request) {
         Stage stage = findStageById(request.stageId());
         TicketType ticketType = request.ticketType();
-        // TODO: n+1
         School school = stage.getFestival().getSchool();
 
         Ticket ticket = ticketRepository.findByTicketTypeAndStage(ticketType, stage)
@@ -45,7 +44,7 @@ public class TicketService {
     }
 
     private Stage findStageById(Long stageId) {
-        return stageRepository.findById(stageId)
+        return stageRepository.findByIdWithFetch(stageId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.STAGE_NOT_FOUND));
     }
 

--- a/backend/src/main/java/com/festago/ticket/domain/Ticket.java
+++ b/backend/src/main/java/com/festago/ticket/domain/Ticket.java
@@ -40,8 +40,8 @@ public class Ticket extends BaseTimeEntity {
     private Stage stage;
 
     @NotNull
-    @ManyToOne(fetch = FetchType.LAZY)
-    private School school;
+    private Long schoolId;
+
     @NotNull
     @Enumerated(EnumType.STRING)
     private TicketType ticketType;
@@ -61,13 +61,21 @@ public class Ticket extends BaseTimeEntity {
         this(null, stage, ticketType, school);
     }
 
+    public Ticket(Stage stage, TicketType ticketType, Long schoolId) {
+        this(null, stage, ticketType, schoolId);
+    }
+
     public Ticket(Long id, Stage stage, TicketType ticketType, School school) {
+        this(id, stage, ticketType, school.getId());
+    }
+
+    public Ticket(Long id, Stage stage, TicketType ticketType, Long schoolId) {
         validate(stage, ticketType);
         this.id = id;
         this.stage = stage;
         this.ticketType = ticketType;
         this.ticketAmount = new TicketAmount(this);
-        this.school = school;
+        this.schoolId = schoolId;
     }
 
     private void validate(Stage stage, TicketType ticketType) {
@@ -132,8 +140,8 @@ public class Ticket extends BaseTimeEntity {
         return stage;
     }
 
-    public School getSchool() {
-        return school;
+    public Long getSchoolId() {
+        return schoolId;
     }
 
     public TicketType getTicketType() {

--- a/backend/src/main/java/com/festago/ticket/domain/Ticket.java
+++ b/backend/src/main/java/com/festago/ticket/domain/Ticket.java
@@ -4,6 +4,7 @@ import com.festago.common.domain.BaseTimeEntity;
 import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.ErrorCode;
 import com.festago.member.domain.Member;
+import com.festago.school.domain.School;
 import com.festago.stage.domain.Stage;
 import com.festago.ticketing.domain.MemberTicket;
 import jakarta.persistence.CascadeType;
@@ -39,6 +40,9 @@ public class Ticket extends BaseTimeEntity {
     private Stage stage;
 
     @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    private School school;
+    @NotNull
     @Enumerated(EnumType.STRING)
     private TicketType ticketType;
 
@@ -53,16 +57,17 @@ public class Ticket extends BaseTimeEntity {
     protected Ticket() {
     }
 
-    public Ticket(Stage stage, TicketType ticketType) {
-        this(null, stage, ticketType);
+    public Ticket(Stage stage, TicketType ticketType, School school) {
+        this(null, stage, ticketType, school);
     }
 
-    public Ticket(Long id, Stage stage, TicketType ticketType) {
+    public Ticket(Long id, Stage stage, TicketType ticketType, School school) {
         validate(stage, ticketType);
         this.id = id;
         this.stage = stage;
         this.ticketType = ticketType;
         this.ticketAmount = new TicketAmount(this);
+        this.school = school;
     }
 
     private void validate(Stage stage, TicketType ticketType) {

--- a/backend/src/main/java/com/festago/ticket/domain/Ticket.java
+++ b/backend/src/main/java/com/festago/ticket/domain/Ticket.java
@@ -132,6 +132,10 @@ public class Ticket extends BaseTimeEntity {
         return stage;
     }
 
+    public School getSchool() {
+        return school;
+    }
+
     public TicketType getTicketType() {
         return ticketType;
     }

--- a/backend/src/main/java/com/festago/ticket/repository/TicketRepository.java
+++ b/backend/src/main/java/com/festago/ticket/repository/TicketRepository.java
@@ -19,7 +19,6 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
         SELECT t FROM Ticket t
         JOIN FETCH t.stage s
         JOIN FETCH t.ticketEntryTimes et
-        JOIN FETCH t.school sc
         WHERE t.id = :ticketId
         """)
     Optional<Ticket> findByIdWithFetch(@Param("ticketId") Long ticketId);

--- a/backend/src/main/java/com/festago/ticket/repository/TicketRepository.java
+++ b/backend/src/main/java/com/festago/ticket/repository/TicketRepository.java
@@ -19,6 +19,7 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
         SELECT t FROM Ticket t
         JOIN FETCH t.stage s
         JOIN FETCH t.ticketEntryTimes et
+        JOIN FETCH t.school sc
         WHERE t.id = :ticketId
         """)
     Optional<Ticket> findByIdWithFetch(@Param("ticketId") Long ticketId);

--- a/backend/src/main/java/com/festago/ticketing/application/TicketingService.java
+++ b/backend/src/main/java/com/festago/ticketing/application/TicketingService.java
@@ -5,8 +5,10 @@ import com.festago.common.exception.ErrorCode;
 import com.festago.common.exception.NotFoundException;
 import com.festago.member.domain.Member;
 import com.festago.member.repository.MemberRepository;
+import com.festago.student.repository.StudentRepository;
 import com.festago.ticket.domain.Ticket;
 import com.festago.ticket.domain.TicketAmount;
+import com.festago.ticket.domain.TicketType;
 import com.festago.ticket.repository.TicketAmountRepository;
 import com.festago.ticket.repository.TicketRepository;
 import com.festago.ticketing.domain.MemberTicket;
@@ -26,15 +28,18 @@ public class TicketingService {
     private final TicketAmountRepository ticketAmountRepository;
     private final TicketRepository ticketRepository;
     private final MemberRepository memberRepository;
+    private final StudentRepository studentRepository;
     private final Clock clock;
 
     public TicketingService(MemberTicketRepository memberTicketRepository,
                             TicketAmountRepository ticketAmountRepository,
-                            TicketRepository ticketRepository, MemberRepository memberRepository, Clock clock) {
+                            TicketRepository ticketRepository, MemberRepository memberRepository,
+                            StudentRepository studentRepository, Clock clock) {
         this.memberTicketRepository = memberTicketRepository;
         this.ticketAmountRepository = ticketAmountRepository;
         this.ticketRepository = ticketRepository;
         this.memberRepository = memberRepository;
+        this.studentRepository = studentRepository;
         this.clock = clock;
     }
 
@@ -42,10 +47,20 @@ public class TicketingService {
         Ticket ticket = findTicketById(request.ticketId());
         Member member = findMemberById(memberId);
         validateAlreadyReserved(member, ticket);
+        validateStudent(member, ticket);
         int reserveSequence = getReserveSequence(request.ticketId());
         MemberTicket memberTicket = ticket.createMemberTicket(member, reserveSequence, LocalDateTime.now(clock));
         memberTicketRepository.save(memberTicket);
         return TicketingResponse.from(memberTicket);
+    }
+
+    private void validateStudent(Member member, Ticket ticket) {
+        if (ticket.getTicketType() != TicketType.STUDENT) {
+            return;
+        }
+        if (!studentRepository.existsByMemberAndSchool(member, ticket.getSchool())) {
+            throw new BadRequestException(ErrorCode.NEED_STUDENT_VERIFICATION);
+        }
     }
 
     private Ticket findTicketById(Long ticketId) {

--- a/backend/src/main/java/com/festago/ticketing/application/TicketingService.java
+++ b/backend/src/main/java/com/festago/ticketing/application/TicketingService.java
@@ -58,7 +58,7 @@ public class TicketingService {
         if (ticket.getTicketType() != TicketType.STUDENT) {
             return;
         }
-        if (!studentRepository.existsByMemberAndSchool(member, ticket.getSchool())) {
+        if (!studentRepository.existsByMemberAndSchoolId(member, ticket.getSchoolId())) {
             throw new BadRequestException(ErrorCode.NEED_STUDENT_VERIFICATION);
         }
     }

--- a/backend/src/main/resources/db/migration/V4__add_school_fk.sql
+++ b/backend/src/main/resources/db/migration/V4__add_school_fk.sql
@@ -1,0 +1,15 @@
+alter table ticket
+    add column school_id bigint not null;
+
+alter table ticket
+    add constraint fk_ticket__school
+        foreign key (school_id)
+            references school (id);
+
+alter table festival
+    add column school_id bigint not null;
+
+alter table festival
+    add constraint fk_festival__school
+        foreign key (school_id)
+            references school (id);

--- a/backend/src/main/resources/static/css/admin/admin-page.css
+++ b/backend/src/main/resources/static/css/admin/admin-page.css
@@ -27,7 +27,7 @@
   margin: 10px; /* Add some margin around each form section */
   background-color: #fff;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  min-width: 300px; /* Set a minimum width for each form section to prevent them from becoming too narrow */
+  min-width: 230px; /* Set a minimum width for each form section to prevent them from becoming too narrow */
 }
 
 h2 {

--- a/backend/src/main/resources/static/js/admin/admin-page.js
+++ b/backend/src/main/resources/static/js/admin/admin-page.js
@@ -13,21 +13,28 @@ function fetchDataAndUpdateDataSection() {
     // Clear existing data before appending new data
     dataSection.innerHTML = "";
 
-    // 1. 축제 생성 요청 데이터 섹션
+    // 1. 학교 생성 요청 데이터 섹션
+    const schoolDataDiv = createDataSection(
+        "학교 목록",
+        data.adminSchools
+    );
+    dataSection.appendChild(schoolDataDiv);
+
+    // 2. 축제 생성 요청 데이터 섹션
     const festivalDataDiv = createDataSection(
         "축제 목록",
         data.adminFestivalResponse
     );
     dataSection.appendChild(festivalDataDiv);
 
-    // 2. 공연 생성 요청 데이터 섹션
+    // 3. 공연 생성 요청 데이터 섹션
     const stageDataDiv = createDataSection(
         "공연 목록",
         data.adminStageResponse
     );
     dataSection.appendChild(stageDataDiv);
 
-    // 3. 티켓 생성 요청 데이터 섹션
+    // 4. 티켓 생성 요청 데이터 섹션
     const ticketDataDiv = createDataSection(
         "티켓 목록",
         data.adminTickets
@@ -112,6 +119,44 @@ function formatEntryTimeAmount(entryTimeAmount) {
   return formattedString;
 }
 
+// 학교 생성 버튼 클릭 시 요청 보내기
+document.getElementById("createSchoolForm").addEventListener("submit",
+    function (event) {
+      event.preventDefault();
+      const formData = new FormData(event.target);
+      const festivalData = {
+        name: formData.get("schoolName"),
+        domain: formData.get("domain")
+      };
+
+      fetch("/admin/schools", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(festivalData)
+      })
+      .then(response => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          return response.json().then(data => {
+            throw new Error(data.message || "학교 생성에 실패하였습니다.");
+          });
+        }
+      })
+      .then(data => {
+        // 성공: 알림창 표시하고 폼 필드 초기화
+        alert("학교가 성공적으로 생성되었습니다!");
+        // Fetch data again and update dataSection
+        fetchDataAndUpdateDataSection();
+      })
+      .catch(error => {
+        // 오류: 알림창 표시
+        alert(error.message);
+      });
+    });
+
 // 축제 생성 버튼 클릭 시 요청 보내기
 document.getElementById("createFestivalForm").addEventListener("submit",
     function (event) {
@@ -121,7 +166,8 @@ document.getElementById("createFestivalForm").addEventListener("submit",
         name: formData.get("name"),
         startDate: formData.get("startDate"),
         endDate: formData.get("endDate"),
-        thumbnail: formData.get("thumbnail")
+        thumbnail: formData.get("thumbnail"),
+        schoolId: formData.get("schoolId")
       };
 
       fetch("/admin/festivals", {

--- a/backend/src/main/resources/templates/admin/admin-page.html
+++ b/backend/src/main/resources/templates/admin/admin-page.html
@@ -8,6 +8,19 @@
 <body>
 <div class="container">
   <div class="form-section">
+    <h2>학교 생성 요청</h2>
+    <form id="createSchoolForm" method="post" action="#">
+      <label for="schoolName">이름:</label>
+      <input id="schoolName" name="schoolName" required type="text"><br>
+
+      <label for="domain">도메인:</label>
+      <input id="domain" name="domain" required type="text"><br>
+
+      <button type="submit">학교 생성</button>
+    </form>
+  </div>
+
+  <div class="form-section">
     <h2>축제 생성 요청</h2>
     <form id="createFestivalForm" method="post" action="#">
       <label for="name">이름:</label>
@@ -21,6 +34,9 @@
 
       <label for="thumbnail">썸네일:</label>
       <input id="thumbnail" name="thumbnail" required type="text"><br>
+
+      <label for="schoolId">학교 ID:</label>
+      <input id="schoolId" name="schoolId" required type="text"><br>
 
       <button type="submit">축제 생성</button>
     </form>

--- a/backend/src/test/java/com/festago/application/integration/FestivalServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/application/integration/FestivalServiceIntegrationTest.java
@@ -72,11 +72,11 @@ class FestivalServiceIntegrationTest extends ApplicationIntegrationTest {
         Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
         Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
         Ticket ticket1 = ticketRepository.save(
-            TicketFixture.ticket().stage(stage).school(school).ticketType(TicketType.VISITOR).build());
+            TicketFixture.ticket().stage(stage).ticketType(TicketType.VISITOR).build());
         LocalDateTime ticketOpenTime = stage.getTicketOpenTime();
         ticket1.addTicketEntryTime(ticketOpenTime.minusHours(1), LocalDateTime.now().minusMinutes(10), 100);
         Ticket ticket2 = ticketRepository.save(
-            TicketFixture.ticket().stage(stage).school(school).ticketType(TicketType.STUDENT).build());
+            TicketFixture.ticket().stage(stage).ticketType(TicketType.STUDENT).build());
         ticket2.addTicketEntryTime(ticketOpenTime.minusHours(1), LocalDateTime.now().minusMinutes(10), 200);
 
         // when

--- a/backend/src/test/java/com/festago/application/integration/FestivalServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/application/integration/FestivalServiceIntegrationTest.java
@@ -10,9 +10,12 @@ import com.festago.festival.dto.FestivalDetailStageResponse;
 import com.festago.festival.dto.FestivalDetailTicketResponse;
 import com.festago.festival.dto.FestivalResponse;
 import com.festago.festival.repository.FestivalRepository;
+import com.festago.school.domain.School;
+import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
 import com.festago.support.FestivalFixture;
+import com.festago.support.SchoolFixture;
 import com.festago.support.StageFixture;
 import com.festago.support.TicketFixture;
 import com.festago.ticket.domain.Ticket;
@@ -43,12 +46,17 @@ class FestivalServiceIntegrationTest extends ApplicationIntegrationTest {
     @Autowired
     TicketRepository ticketRepository;
 
+    @Autowired
+    SchoolRepository schoolRepository;
+
+
     @Test
     void 축제를_생성한다() {
         // given
+        School school = schoolRepository.save(SchoolFixture.school().build());
         LocalDate today = LocalDate.now();
         FestivalCreateRequest request = new FestivalCreateRequest("테코 대학교 축제", today, today.plusDays(1),
-            "thumbnail.png");
+            "thumbnail.png", school.getId());
 
         // when
         FestivalResponse festivalResponse = festivalService.create(request);
@@ -60,14 +68,15 @@ class FestivalServiceIntegrationTest extends ApplicationIntegrationTest {
     @Test
     void 축제_상세_정보를_조회한다() {
         // given
-        Festival festival = festivalRepository.save(FestivalFixture.festival().build());
+        School school = schoolRepository.save(SchoolFixture.school().build());
+        Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
         Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
         Ticket ticket1 = ticketRepository.save(
-            TicketFixture.ticket().stage(stage).ticketType(TicketType.VISITOR).build());
+            TicketFixture.ticket().stage(stage).school(school).ticketType(TicketType.VISITOR).build());
         LocalDateTime ticketOpenTime = stage.getTicketOpenTime();
         ticket1.addTicketEntryTime(ticketOpenTime.minusHours(1), LocalDateTime.now().minusMinutes(10), 100);
         Ticket ticket2 = ticketRepository.save(
-            TicketFixture.ticket().stage(stage).ticketType(TicketType.STUDENT).build());
+            TicketFixture.ticket().stage(stage).school(school).ticketType(TicketType.STUDENT).build());
         ticket2.addTicketEntryTime(ticketOpenTime.minusHours(1), LocalDateTime.now().minusMinutes(10), 200);
 
         // when

--- a/backend/src/test/java/com/festago/application/integration/MemberTicketIntegrationTest.java
+++ b/backend/src/test/java/com/festago/application/integration/MemberTicketIntegrationTest.java
@@ -6,11 +6,14 @@ import com.festago.festival.domain.Festival;
 import com.festago.festival.repository.FestivalRepository;
 import com.festago.member.domain.Member;
 import com.festago.member.repository.MemberRepository;
+import com.festago.school.domain.School;
+import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
 import com.festago.support.FestivalFixture;
 import com.festago.support.MemberFixture;
 import com.festago.support.MemberTicketFixture;
+import com.festago.support.SchoolFixture;
 import com.festago.support.StageFixture;
 import com.festago.ticket.repository.TicketRepository;
 import com.festago.ticketing.application.MemberTicketService;
@@ -44,11 +47,15 @@ class MemberTicketIntegrationTest extends ApplicationIntegrationTest {
     @Autowired
     TicketRepository ticketRepository;
 
+    @Autowired
+    SchoolRepository schoolRepository;
+
     @Test
     void 예매한_티켓_조회시_Pageable_적용() {
         // given
+        School school = schoolRepository.save(SchoolFixture.school().build());
         Member member = memberRepository.save(MemberFixture.member().build());
-        Festival festival = festivalRepository.save(FestivalFixture.festival().build());
+        Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
         Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
         for (int i = 0; i < 20; i++) {
             memberTicketRepository.save(MemberTicketFixture.memberTicket()

--- a/backend/src/test/java/com/festago/application/integration/TicketServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/application/integration/TicketServiceIntegrationTest.java
@@ -7,9 +7,12 @@ import static org.mockito.Mockito.doReturn;
 import com.festago.common.exception.NotFoundException;
 import com.festago.festival.domain.Festival;
 import com.festago.festival.repository.FestivalRepository;
+import com.festago.school.domain.School;
+import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
 import com.festago.support.FestivalFixture;
+import com.festago.support.SchoolFixture;
 import com.festago.support.StageFixture;
 import com.festago.ticket.application.TicketService;
 import com.festago.ticket.domain.TicketAmount;
@@ -46,6 +49,9 @@ class TicketServiceIntegrationTest extends ApplicationIntegrationTest {
     @Autowired
     TicketAmountRepository ticketAmountRepository;
 
+    @Autowired
+    SchoolRepository schoolRepository;
+
     @SpyBean
     Clock clock;
 
@@ -72,7 +78,9 @@ class TicketServiceIntegrationTest extends ApplicationIntegrationTest {
         doReturn(stageStartTime.minusWeeks(1).toInstant(ZoneOffset.UTC))
             .when(clock)
             .instant();
+        School school = schoolRepository.save(SchoolFixture.school().build());
         Festival festival = festivalRepository.save(FestivalFixture.festival()
+            .school(school)
             .startDate(stageStartTime.toLocalDate())
             .endDate(stageStartTime.toLocalDate())
             .build());
@@ -99,7 +107,9 @@ class TicketServiceIntegrationTest extends ApplicationIntegrationTest {
         doReturn(stageStartTime.minusWeeks(1).toInstant(ZoneOffset.UTC))
             .when(clock)
             .instant();
+        School school = schoolRepository.save(SchoolFixture.school().build());
         Festival festival = festivalRepository.save(FestivalFixture.festival()
+            .school(school)
             .startDate(stageStartTime.toLocalDate())
             .endDate(stageStartTime.toLocalDate())
             .build());

--- a/backend/src/test/java/com/festago/application/integration/TicketingServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/application/integration/TicketingServiceIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doReturn;
 import com.festago.common.exception.BadRequestException;
 import com.festago.member.domain.Member;
 import com.festago.member.repository.MemberRepository;
+import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.support.MemberFixture;
 import com.festago.ticketing.application.TicketingService;
@@ -36,6 +37,9 @@ class TicketingServiceIntegrationTest extends ApplicationIntegrationTest {
 
     @Autowired
     TicketingService ticketingService;
+
+    @Autowired
+    SchoolRepository schoolRepository;
 
     @SpyBean
     MemberTicketRepository memberTicketRepository;

--- a/backend/src/test/java/com/festago/domain/FestivalTest.java
+++ b/backend/src/test/java/com/festago/domain/FestivalTest.java
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.festago.common.exception.BadRequestException;
 import com.festago.festival.domain.Festival;
+import com.festago.school.domain.School;
 import com.festago.support.FestivalFixture;
+import com.festago.support.SchoolFixture;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -21,9 +23,10 @@ class FestivalTest {
     void 시작일자가_종료일자_이전이면_예외() {
         // given
         LocalDate today = LocalDate.now();
+        School school = SchoolFixture.school().build();
 
         // when & then
-        assertThatThrownBy(() -> new Festival("테코대학교", today.plusDays(1), today))
+        assertThatThrownBy(() -> new Festival("테코대학교", today.plusDays(1), today, school))
             .isInstanceOf(BadRequestException.class)
             .hasMessage("축제 시작 일자는 종료일자 이전이어야합니다.");
     }

--- a/backend/src/test/java/com/festago/domain/MemberTicketRepositoryTest.java
+++ b/backend/src/test/java/com/festago/domain/MemberTicketRepositoryTest.java
@@ -8,11 +8,14 @@ import com.festago.festival.domain.Festival;
 import com.festago.festival.repository.FestivalRepository;
 import com.festago.member.domain.Member;
 import com.festago.member.repository.MemberRepository;
+import com.festago.school.domain.School;
+import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
 import com.festago.support.FestivalFixture;
 import com.festago.support.MemberFixture;
 import com.festago.support.MemberTicketFixture;
+import com.festago.support.SchoolFixture;
 import com.festago.support.StageFixture;
 import com.festago.ticket.repository.TicketRepository;
 import com.festago.ticketing.domain.MemberTicket;
@@ -52,6 +55,9 @@ class MemberTicketRepositoryTest {
     @Autowired
     FestivalRepository festivalRepository;
 
+    @Autowired
+    SchoolRepository schoolRepository;
+
     @Nested
     class 회원의_ID로_에매한_티켓을_모두_조회 {
 
@@ -61,7 +67,8 @@ class MemberTicketRepositoryTest {
             Member member1 = memberRepository.save(MemberFixture.member().socialId("abc").build());
             Member member2 = memberRepository.save(MemberFixture.member().socialId("def").build());
 
-            Festival festival = festivalRepository.save(FestivalFixture.festival().build());
+            School school = schoolRepository.save(SchoolFixture.school().build());
+            Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
             Stage stage1 = stageRepository.save(StageFixture.stage().festival(festival).build());
             Stage stage2 = stageRepository.save(StageFixture.stage().festival(festival).build());
 
@@ -83,7 +90,8 @@ class MemberTicketRepositoryTest {
             int expected = 10;
             Member member = memberRepository.save(MemberFixture.member().build());
 
-            Festival festival = festivalRepository.save(FestivalFixture.festival().build());
+            School school = schoolRepository.save(SchoolFixture.school().build());
+            Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
             Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
 
             for (int i = 0; i < 20; i++) {
@@ -103,7 +111,8 @@ class MemberTicketRepositoryTest {
             // given
             Member member = memberRepository.save(MemberFixture.member().build());
 
-            Festival festival = festivalRepository.save(FestivalFixture.festival().build());
+            School school = schoolRepository.save(SchoolFixture.school().build());
+            Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
             Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
 
             List<MemberTicket> memberTickets = new ArrayList<>();

--- a/backend/src/test/java/com/festago/domain/StageRepositoryTest.java
+++ b/backend/src/test/java/com/festago/domain/StageRepositoryTest.java
@@ -83,9 +83,9 @@ class StageRepositoryTest {
         Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
         Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
         Ticket ticket1 = ticketRepository.save(
-            TicketFixture.ticket().ticketType(TicketType.STUDENT).stage(stage).school(school).build());
+            TicketFixture.ticket().ticketType(TicketType.STUDENT).stage(stage).build());
         Ticket ticket2 = ticketRepository.save(
-            TicketFixture.ticket().ticketType(TicketType.VISITOR).stage(stage).school(school).build());
+            TicketFixture.ticket().ticketType(TicketType.VISITOR).stage(stage).build());
         ticket1.getTicketAmount().addTotalAmount(100);
         ticket2.getTicketAmount().addTotalAmount(200);
         entityManager.flush();

--- a/backend/src/test/java/com/festago/domain/StageRepositoryTest.java
+++ b/backend/src/test/java/com/festago/domain/StageRepositoryTest.java
@@ -5,9 +5,12 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.festago.festival.domain.Festival;
 import com.festago.festival.repository.FestivalRepository;
+import com.festago.school.domain.School;
+import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
 import com.festago.support.FestivalFixture;
+import com.festago.support.SchoolFixture;
 import com.festago.support.StageFixture;
 import com.festago.support.TicketFixture;
 import com.festago.ticket.domain.Ticket;
@@ -36,12 +39,16 @@ class StageRepositoryTest {
     TicketRepository ticketRepository;
 
     @Autowired
+    SchoolRepository schoolRepository;
+
+    @Autowired
     EntityManager entityManager;
 
     @Test
     void 티켓이_존재하지_않을때도_무대가_조회된다() {
         // given
-        Festival festival = festivalRepository.save(FestivalFixture.festival().build());
+        School school = schoolRepository.save(SchoolFixture.school().build());
+        Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
         Stage stage1 = stageRepository.save(StageFixture.stage().festival(festival).build());
         Stage stage2 = stageRepository.save(StageFixture.stage().festival(festival).build());
 
@@ -58,7 +65,8 @@ class StageRepositoryTest {
     @Test
     void 해당_축제의_무대가_모두_조회된다() {
         // given
-        Festival festival = festivalRepository.save(FestivalFixture.festival().build());
+        School school = schoolRepository.save(SchoolFixture.school().build());
+        Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
         stageRepository.save(StageFixture.stage().festival(festival).build());
 
         // when
@@ -71,12 +79,13 @@ class StageRepositoryTest {
     @Test
     void 티켓_정보까지_모두_조회된다() {
         // given
-        Festival festival = festivalRepository.save(FestivalFixture.festival().build());
+        School school = schoolRepository.save(SchoolFixture.school().build());
+        Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
         Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
         Ticket ticket1 = ticketRepository.save(
-            TicketFixture.ticket().ticketType(TicketType.STUDENT).stage(stage).build());
+            TicketFixture.ticket().ticketType(TicketType.STUDENT).stage(stage).school(school).build());
         Ticket ticket2 = ticketRepository.save(
-            TicketFixture.ticket().ticketType(TicketType.VISITOR).stage(stage).build());
+            TicketFixture.ticket().ticketType(TicketType.VISITOR).stage(stage).school(school).build());
         ticket1.getTicketAmount().addTotalAmount(100);
         ticket2.getTicketAmount().addTotalAmount(200);
         entityManager.flush();

--- a/backend/src/test/java/com/festago/domain/TicketRepositoryTest.java
+++ b/backend/src/test/java/com/festago/domain/TicketRepositoryTest.java
@@ -47,11 +47,9 @@ class TicketRepositoryTest {
         Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
         Stage otherStage = stageRepository.save(StageFixture.stage().festival(festival).build());
 
-        ticketRepository.save(
-            TicketFixture.ticket().stage(stage).school(school).ticketType(TicketType.STUDENT).build());
-        ticketRepository.save(
-            TicketFixture.ticket().stage(stage).school(school).ticketType(TicketType.VISITOR).build());
-        ticketRepository.save(TicketFixture.ticket().stage(otherStage).school(school).build());
+        ticketRepository.save(TicketFixture.ticket().stage(stage).ticketType(TicketType.STUDENT).build());
+        ticketRepository.save(TicketFixture.ticket().stage(stage).ticketType(TicketType.VISITOR).build());
+        ticketRepository.save(TicketFixture.ticket().stage(otherStage).build());
 
         // when
         List<Ticket> actual = ticketRepository.findAllByStageId(stage.getId());

--- a/backend/src/test/java/com/festago/domain/TicketRepositoryTest.java
+++ b/backend/src/test/java/com/festago/domain/TicketRepositoryTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.festago.festival.domain.Festival;
 import com.festago.festival.repository.FestivalRepository;
+import com.festago.school.domain.School;
+import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
 import com.festago.support.FestivalFixture;
+import com.festago.support.SchoolFixture;
 import com.festago.support.StageFixture;
 import com.festago.support.TicketFixture;
 import com.festago.ticket.domain.Ticket;
@@ -33,16 +36,22 @@ class TicketRepositoryTest {
     @Autowired
     StageRepository stageRepository;
 
+    @Autowired
+    SchoolRepository schoolRepository;
+
     @Test
     void 공연의_ID로_티켓을_모두_조회() {
         // given
-        Festival festival = festivalRepository.save(FestivalFixture.festival().build());
+        School school = schoolRepository.save(SchoolFixture.school().build());
+        Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
         Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
         Stage otherStage = stageRepository.save(StageFixture.stage().festival(festival).build());
 
-        ticketRepository.save(TicketFixture.ticket().stage(stage).ticketType(TicketType.STUDENT).build());
-        ticketRepository.save(TicketFixture.ticket().stage(stage).ticketType(TicketType.VISITOR).build());
-        ticketRepository.save(TicketFixture.ticket().stage(otherStage).build());
+        ticketRepository.save(
+            TicketFixture.ticket().stage(stage).school(school).ticketType(TicketType.STUDENT).build());
+        ticketRepository.save(
+            TicketFixture.ticket().stage(stage).school(school).ticketType(TicketType.VISITOR).build());
+        ticketRepository.save(TicketFixture.ticket().stage(otherStage).school(school).build());
 
         // when
         List<Ticket> actual = ticketRepository.findAllByStageId(stage.getId());

--- a/backend/src/test/java/com/festago/dto/FestivalCreateRequestTest.java
+++ b/backend/src/test/java/com/festago/dto/FestivalCreateRequestTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.festago.festival.domain.Festival;
 import com.festago.festival.dto.FestivalCreateRequest;
+import com.festago.school.domain.School;
+import com.festago.support.SchoolFixture;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -20,10 +22,12 @@ class FestivalCreateRequestTest {
             "name",
             LocalDate.now(),
             LocalDate.now().plusDays(2L),
-            "");
+            "",
+            1L);
+        School school = SchoolFixture.school().build();
 
         // when
-        Festival festival = request.toEntity();
+        Festival festival = request.toEntity(school);
 
         // then
         assertThat(festival.getThumbnail()).isEqualTo("https://picsum.photos/536/354");
@@ -36,10 +40,12 @@ class FestivalCreateRequestTest {
             "name",
             LocalDate.now(),
             LocalDate.now().plusDays(2L),
-            "img");
+            "img",
+            1L);
+        School school = SchoolFixture.school().build();
 
         // when
-        Festival festival = request.toEntity();
+        Festival festival = request.toEntity(school);
 
         // then
         assertThat(festival.getThumbnail()).isEqualTo("img");

--- a/backend/src/test/java/com/festago/presentation/AdminControllerTest.java
+++ b/backend/src/test/java/com/festago/presentation/AdminControllerTest.java
@@ -121,7 +121,8 @@ class AdminControllerTest {
             festivalName,
             LocalDate.parse(startDate),
             LocalDate.parse(endDate),
-            "");
+            "",
+            1L);
 
         FestivalResponse expected = new FestivalResponse(
             1L,

--- a/backend/src/test/java/com/festago/presentation/AdminControllerTest.java
+++ b/backend/src/test/java/com/festago/presentation/AdminControllerTest.java
@@ -21,6 +21,9 @@ import com.festago.common.exception.dto.ErrorResponse;
 import com.festago.festival.application.FestivalService;
 import com.festago.festival.dto.FestivalCreateRequest;
 import com.festago.festival.dto.FestivalResponse;
+import com.festago.school.application.SchoolService;
+import com.festago.school.dto.SchoolCreateRequest;
+import com.festago.school.dto.SchoolResponse;
 import com.festago.stage.application.StageService;
 import com.festago.stage.dto.StageCreateRequest;
 import com.festago.stage.dto.StageResponse;
@@ -69,6 +72,9 @@ class AdminControllerTest {
     @MockBean
     AdminAuthService adminAuthService;
 
+    @MockBean
+    SchoolService schoolService;
+
     @SpyBean
     AuthExtractor authExtractor;
 
@@ -106,6 +112,34 @@ class AdminControllerTest {
         mockMvc.perform(get("/admin/login")
                 .cookie(new Cookie("token", "token")))
             .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockAuth(role = Role.ADMIN)
+    void 학교_생성() throws Exception {
+        // given
+        String domain = "festago.com";
+        String name = "페스타고 대학교";
+
+        SchoolCreateRequest request = new SchoolCreateRequest(name, domain);
+
+        SchoolResponse expected = new SchoolResponse(1L, domain, name);
+
+        given(schoolService.create(any(SchoolCreateRequest.class)))
+            .willReturn(expected);
+
+        // when && then
+        String content = mockMvc.perform(post("/admin/schools")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+                .cookie(new Cookie("token", "token")))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString(StandardCharsets.UTF_8);
+        SchoolResponse actual = objectMapper.readValue(content, SchoolResponse.class);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/backend/src/test/java/com/festago/support/FestivalFixture.java
+++ b/backend/src/test/java/com/festago/support/FestivalFixture.java
@@ -1,6 +1,7 @@
 package com.festago.support;
 
 import com.festago.festival.domain.Festival;
+import com.festago.school.domain.School;
 import java.time.LocalDate;
 
 public class FestivalFixture {
@@ -10,6 +11,7 @@ public class FestivalFixture {
     private LocalDate startDate = LocalDate.now();
     private LocalDate endDate = LocalDate.now().plusDays(3L);
     private String thumbnail = "https://picsum.photos/536/354";
+    private School school = SchoolFixture.school().build();
 
     private FestivalFixture() {
     }
@@ -43,7 +45,12 @@ public class FestivalFixture {
         return this;
     }
 
+    public FestivalFixture school(School school) {
+        this.school = school;
+        return this;
+    }
+
     public Festival build() {
-        return new Festival(id, name, startDate, endDate, thumbnail);
+        return new Festival(id, name, startDate, endDate, thumbnail, school);
     }
 }

--- a/backend/src/test/java/com/festago/support/SchoolFixture.java
+++ b/backend/src/test/java/com/festago/support/SchoolFixture.java
@@ -1,0 +1,39 @@
+package com.festago.support;
+
+import com.festago.school.domain.School;
+
+public class SchoolFixture {
+
+    private Long id;
+
+    private String domain = "festago.com";
+
+    private String name = "페스타고 대학교";
+
+    private SchoolFixture() {
+    }
+
+    public static SchoolFixture school() {
+        return new SchoolFixture();
+    }
+
+    public SchoolFixture id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public SchoolFixture domain(String domain) {
+        this.domain = domain;
+        return this;
+    }
+
+    public SchoolFixture name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public School build() {
+        return new School(id, domain, name);
+    }
+
+}

--- a/backend/src/test/java/com/festago/support/TicketFixture.java
+++ b/backend/src/test/java/com/festago/support/TicketFixture.java
@@ -1,5 +1,6 @@
 package com.festago.support;
 
+import com.festago.school.domain.School;
 import com.festago.stage.domain.Stage;
 import com.festago.ticket.domain.Ticket;
 import com.festago.ticket.domain.TicketType;
@@ -9,6 +10,7 @@ public class TicketFixture {
     private Long id;
     private Stage stage = StageFixture.stage().build();
     private TicketType ticketType = TicketType.VISITOR;
+    private School school = SchoolFixture.school().build();
 
     private TicketFixture() {
     }
@@ -32,7 +34,12 @@ public class TicketFixture {
         return this;
     }
 
+    public TicketFixture school(School school) {
+        this.school = school;
+        return this;
+    }
+
     public Ticket build() {
-        return new Ticket(id, stage, ticketType);
+        return new Ticket(id, stage, ticketType, school);
     }
 }

--- a/backend/src/test/java/com/festago/support/TicketFixture.java
+++ b/backend/src/test/java/com/festago/support/TicketFixture.java
@@ -1,6 +1,5 @@
 package com.festago.support;
 
-import com.festago.school.domain.School;
 import com.festago.stage.domain.Stage;
 import com.festago.ticket.domain.Ticket;
 import com.festago.ticket.domain.TicketType;
@@ -10,7 +9,7 @@ public class TicketFixture {
     private Long id;
     private Stage stage = StageFixture.stage().build();
     private TicketType ticketType = TicketType.VISITOR;
-    private School school = SchoolFixture.school().build();
+    private Long schoolId = 1L;
 
     private TicketFixture() {
     }
@@ -34,12 +33,12 @@ public class TicketFixture {
         return this;
     }
 
-    public TicketFixture school(School school) {
-        this.school = school;
+    public TicketFixture schoolId(Long schoolId) {
+        this.schoolId = schoolId;
         return this;
     }
 
     public Ticket build() {
-        return new Ticket(id, stage, ticketType, school);
+        return new Ticket(id, stage, ticketType, schoolId);
     }
 }

--- a/backend/src/test/java/com/festago/ticketing/application/TicketingServiceTest.java
+++ b/backend/src/test/java/com/festago/ticketing/application/TicketingServiceTest.java
@@ -1,0 +1,83 @@
+package com.festago.ticketing.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.festago.common.exception.BadRequestException;
+import com.festago.member.domain.Member;
+import com.festago.member.repository.MemberRepository;
+import com.festago.school.domain.School;
+import com.festago.stage.domain.Stage;
+import com.festago.student.repository.StudentRepository;
+import com.festago.support.MemberFixture;
+import com.festago.support.TicketFixture;
+import com.festago.ticket.domain.TicketType;
+import com.festago.ticket.repository.TicketAmountRepository;
+import com.festago.ticket.repository.TicketRepository;
+import com.festago.ticketing.dto.TicketingRequest;
+import com.festago.ticketing.repository.MemberTicketRepository;
+import java.time.Clock;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class TicketingServiceTest {
+
+    @Mock
+    MemberTicketRepository memberTicketRepository;
+
+    @Mock
+    TicketAmountRepository ticketAmountRepository;
+
+    @Mock
+    TicketRepository ticketRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    StudentRepository studentRepository;
+
+    @Spy
+    Clock clock = Clock.systemDefaultZone();
+
+    @InjectMocks
+    TicketingService ticketingService;
+
+    @BeforeEach
+    void setUp() {
+
+    }
+
+    @Test
+    void 재학생용_티켓인데_학생인증이_되지_않았으면_예외() {
+        // given
+        TicketingRequest request = new TicketingRequest(1L);
+        given(memberRepository.findById(anyLong()))
+            .willReturn(Optional.of(MemberFixture.member().build()));
+        given(memberTicketRepository.existsByOwnerAndStage(any(Member.class), any(Stage.class)))
+            .willReturn(false);
+
+        given(ticketRepository.findByIdWithFetch(anyLong()))
+            .willReturn(Optional.of(TicketFixture.ticket().ticketType(TicketType.STUDENT).build()));
+        given(studentRepository.existsByMemberAndSchool(any(Member.class), any(School.class)))
+            .willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> ticketingService.ticketing(1L, request))
+            .isInstanceOf(BadRequestException.class)
+            .hasMessage("학생 인증이 필요합니다.");
+    }
+}

--- a/backend/src/test/java/com/festago/ticketing/application/TicketingServiceTest.java
+++ b/backend/src/test/java/com/festago/ticketing/application/TicketingServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.BDDMockito.given;
 import com.festago.common.exception.BadRequestException;
 import com.festago.member.domain.Member;
 import com.festago.member.repository.MemberRepository;
-import com.festago.school.domain.School;
 import com.festago.stage.domain.Stage;
 import com.festago.student.repository.StudentRepository;
 import com.festago.support.MemberFixture;
@@ -72,7 +71,7 @@ class TicketingServiceTest {
 
         given(ticketRepository.findByIdWithFetch(anyLong()))
             .willReturn(Optional.of(TicketFixture.ticket().ticketType(TicketType.STUDENT).build()));
-        given(studentRepository.existsByMemberAndSchool(any(Member.class), any(School.class)))
+        given(studentRepository.existsByMemberAndSchoolId(any(Member.class), anyLong()))
             .willReturn(false);
 
         // when & then

--- a/backend/src/test/resources/ticketing-test-data.sql
+++ b/backend/src/test/resources/ticketing-test-data.sql
@@ -1,11 +1,14 @@
-insert into festival (end_date, name, start_date, thumbnail)
-values ('2023-07-30', '테코 대학교', '2023-08-02', '');
+insert into school (domain, name)
+values ('festago.com', '페스타고 대학교');
+
+insert into festival (school_id, end_date, name, start_date, thumbnail)
+values (1, '2023-07-30', '테코 대학교', '2023-08-02', '');
 
 insert into stage (festival_id, line_up, start_time, ticket_open_time)
 values (1, '', '2023-07-30T03:21:31.964676', '2023-07-23T03:21:31.964676');
 
-insert into ticket (stage_id, ticket_type)
-values (1, 'VISITOR');
+insert into ticket (school_id, stage_id, ticket_type)
+values (1, 1, 'VISITOR');
 
 insert into ticket_amount (ticket_id, reserved_amount, total_amount)
 values (1, 0, 50);


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #446

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
Ticket -> Stage -> Festival -> School 로 가서 학교 정보를 가져오면 depth가 너무 깊어
Ticket에도 School을 가지도록 반정규화 했습니다.

School 등록시 name, domain UNIQUE 조건을 일단 추가하지 않았는데, 의견 부탁드립니다!