### PR TITLE
[BE] refactor: assertThatThrownBy.hasMessage()에서 ErrorCode를 활용하도록 수정 (#476)

### DIFF
--- a/backend/src/test/java/com/festago/application/EntryServiceTest.java
+++ b/backend/src/test/java/com/festago/application/EntryServiceTest.java
@@ -1,5 +1,8 @@
 package com.festago.application;
 
+import static com.festago.common.exception.ErrorCode.MEMBER_TICKET_NOT_FOUND;
+import static com.festago.common.exception.ErrorCode.NOT_ENTRY_TIME;
+import static com.festago.common.exception.ErrorCode.NOT_MEMBER_TICKET_OWNER;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
@@ -98,7 +101,7 @@ class EntryServiceTest {
             // when & then
             assertThatThrownBy(() -> entryService.createEntryCode(memberId, memberTicketId))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("입장 가능한 시간이 아닙니다.");
+                .hasMessage(NOT_ENTRY_TIME.getMessage());
         }
 
         @Test
@@ -129,7 +132,7 @@ class EntryServiceTest {
             // when & then
             assertThatThrownBy(() -> entryService.createEntryCode(memberId, memberTicketId))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("입장 가능한 시간이 아닙니다.");
+                .hasMessage(NOT_ENTRY_TIME.getMessage());
         }
 
         @Test
@@ -151,7 +154,7 @@ class EntryServiceTest {
             // when & then
             assertThatThrownBy(() -> entryService.createEntryCode(memberId, memberTicketId))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("해당 예매 티켓의 주인이 아닙니다.");
+                .hasMessage(NOT_MEMBER_TICKET_OWNER.getMessage());
         }
 
         @Test
@@ -164,7 +167,7 @@ class EntryServiceTest {
             // when & then
             assertThatThrownBy(() -> entryService.createEntryCode(1L, memberTicketId))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않은 멤버 티켓입니다.");
+                .hasMessage(MEMBER_TICKET_NOT_FOUND.getMessage());
         }
 
         @Test

--- a/backend/src/test/java/com/festago/application/FestivalServiceTest.java
+++ b/backend/src/test/java/com/festago/application/FestivalServiceTest.java
@@ -1,5 +1,7 @@
 package com.festago.application;
 
+import static com.festago.common.exception.ErrorCode.INVALID_FESTIVAL_START_DATE;
+import static com.festago.common.exception.ErrorCode.SCHOOL_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -85,7 +87,7 @@ class FestivalServiceTest {
             // when & then
             assertThatThrownBy(() -> festivalService.create(request))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 학교입니다.");
+                .hasMessage(SCHOOL_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -101,7 +103,7 @@ class FestivalServiceTest {
             // when & then
             assertThatThrownBy(() -> festivalService.create(request))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("축제 시작 일자는 과거일 수 없습니다.");
+                .hasMessage(INVALID_FESTIVAL_START_DATE.getMessage());
         }
 
         @Test
@@ -140,7 +142,7 @@ class FestivalServiceTest {
 
             // when & then
             assertThatThrownBy(() -> festivalService.findDetail(festivalId)).isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 축제입니다.");
+                .hasMessage(SCHOOL_NOT_FOUND.getMessage());
         }
 
         @Test

--- a/backend/src/test/java/com/festago/application/FestivalServiceTest.java
+++ b/backend/src/test/java/com/festago/application/FestivalServiceTest.java
@@ -1,5 +1,6 @@
 package com.festago.application;
 
+import static com.festago.common.exception.ErrorCode.FESTIVAL_NOT_FOUND;
 import static com.festago.common.exception.ErrorCode.INVALID_FESTIVAL_START_DATE;
 import static com.festago.common.exception.ErrorCode.SCHOOL_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -142,7 +143,7 @@ class FestivalServiceTest {
 
             // when & then
             assertThatThrownBy(() -> festivalService.findDetail(festivalId)).isInstanceOf(NotFoundException.class)
-                .hasMessage(SCHOOL_NOT_FOUND.getMessage());
+                .hasMessage(FESTIVAL_NOT_FOUND.getMessage());
         }
 
         @Test

--- a/backend/src/test/java/com/festago/application/MemberTicketServiceTest.java
+++ b/backend/src/test/java/com/festago/application/MemberTicketServiceTest.java
@@ -1,5 +1,8 @@
 package com.festago.application;
 
+import static com.festago.common.exception.ErrorCode.MEMBER_NOT_FOUND;
+import static com.festago.common.exception.ErrorCode.MEMBER_TICKET_NOT_FOUND;
+import static com.festago.common.exception.ErrorCode.NOT_MEMBER_TICKET_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -67,7 +70,7 @@ class MemberTicketServiceTest {
             // when & then
             assertThatThrownBy(() -> memberTicketService.findAll(memberId, PageRequest.ofSize(1)))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 멤버입니다.");
+                .hasMessage(MEMBER_NOT_FOUND.getMessage());
         }
     }
 
@@ -85,7 +88,7 @@ class MemberTicketServiceTest {
             // when & then
             assertThatThrownBy(() -> memberTicketService.findCurrent(memberId, Pageable.ofSize(10)))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 멤버입니다.");
+                .hasMessage(MEMBER_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -188,7 +191,7 @@ class MemberTicketServiceTest {
             // when & then
             assertThatThrownBy(() -> memberTicketService.findById(memberId, 1L))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 멤버입니다.");
+                .hasMessage(MEMBER_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -205,7 +208,7 @@ class MemberTicketServiceTest {
             // when & then
             assertThatThrownBy(() -> memberTicketService.findById(memberId, memberTicketId))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않은 멤버 티켓입니다.");
+                .hasMessage(MEMBER_TICKET_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -230,7 +233,7 @@ class MemberTicketServiceTest {
             // when & then
             assertThatThrownBy(() -> memberTicketService.findById(memberId, otherTicketId))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("해당 예매 티켓의 주인이 아닙니다.");
+                .hasMessage(NOT_MEMBER_TICKET_OWNER.getMessage());
         }
 
         @Test

--- a/backend/src/test/java/com/festago/application/StudentServiceTest.java
+++ b/backend/src/test/java/com/festago/application/StudentServiceTest.java
@@ -1,5 +1,10 @@
 package com.festago.application;
 
+import static com.festago.common.exception.ErrorCode.ALREADY_STUDENT_VERIFIED;
+import static com.festago.common.exception.ErrorCode.DUPLICATE_STUDENT_EMAIL;
+import static com.festago.common.exception.ErrorCode.INVALID_STUDENT_VERIFICATION_CODE;
+import static com.festago.common.exception.ErrorCode.MEMBER_NOT_FOUND;
+import static com.festago.common.exception.ErrorCode.SCHOOL_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -74,7 +79,7 @@ class StudentServiceTest {
             // when & then
             assertThatThrownBy(() -> studentService.sendVerificationMail(memberId, request))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("이미 학교 인증이 완료된 사용자입니다.");
+                .hasMessage(ALREADY_STUDENT_VERIFIED.getMessage());
         }
 
         @Test
@@ -93,7 +98,7 @@ class StudentServiceTest {
             // when & then
             assertThatThrownBy(() -> studentService.sendVerificationMail(memberId, request))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("이미 인증된 이메일입니다.");
+                .hasMessage(DUPLICATE_STUDENT_EMAIL.getMessage());
         }
 
         @Test
@@ -114,7 +119,7 @@ class StudentServiceTest {
             // when & then
             assertThatThrownBy(() -> studentService.sendVerificationMail(memberId, request))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 멤버입니다.");
+                .hasMessage(MEMBER_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -142,7 +147,7 @@ class StudentServiceTest {
             // when & then
             assertThatThrownBy(() -> studentService.sendVerificationMail(memberId, request))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 학교입니다.");
+                .hasMessage(SCHOOL_NOT_FOUND.getMessage());
         }
 
 
@@ -188,7 +193,7 @@ class StudentServiceTest {
             // when & then
             assertThatThrownBy(() -> studentService.verificate(memberId, request))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("이미 학교 인증이 완료된 사용자입니다.");
+                .hasMessage(ALREADY_STUDENT_VERIFIED.getMessage());
         }
 
         @Test
@@ -204,7 +209,7 @@ class StudentServiceTest {
             // when & then
             assertThatThrownBy(() -> studentService.verificate(memberId, request))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("올바르지 않은 학생 인증 코드입니다.");
+                .hasMessage(INVALID_STUDENT_VERIFICATION_CODE.getMessage());
         }
 
         @Test

--- a/backend/src/test/java/com/festago/application/integration/StageServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/application/integration/StageServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.festago.application.integration;
 
+import static com.festago.common.exception.ErrorCode.FESTIVAL_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.festago.common.exception.NotFoundException;
@@ -37,6 +38,6 @@ class StageServiceIntegrationTest extends ApplicationIntegrationTest {
         // when && then
         assertThatThrownBy(() -> stageService.create(request))
             .isInstanceOf(NotFoundException.class)
-            .hasMessage("존재하지 않는 축제입니다.");
+            .hasMessage(FESTIVAL_NOT_FOUND.getMessage());
     }
 }

--- a/backend/src/test/java/com/festago/application/integration/TicketServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/application/integration/TicketServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.festago.application.integration;
 
+import static com.festago.common.exception.ErrorCode.STAGE_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
@@ -68,7 +69,7 @@ class TicketServiceIntegrationTest extends ApplicationIntegrationTest {
         // when && then
         assertThatThrownBy(() -> ticketService.create(request))
             .isInstanceOf(NotFoundException.class)
-            .hasMessage("존재하지 않은 공연입니다.");
+            .hasMessage(STAGE_NOT_FOUND.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/festago/application/integration/TicketingServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/application/integration/TicketingServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.festago.application.integration;
 
+import static com.festago.common.exception.ErrorCode.RESERVE_TICKET_OVER_AMOUNT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -90,6 +91,6 @@ class TicketingServiceIntegrationTest extends ApplicationIntegrationTest {
         // when & then
         assertThatThrownBy(() -> ticketingService.ticketing(memberId, request))
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("예매 가능한 수량을 초과했습니다.");
+            .hasMessage(RESERVE_TICKET_OVER_AMOUNT.getMessage());
     }
 }

--- a/backend/src/test/java/com/festago/auth/application/AdminAuthServiceTest.java
+++ b/backend/src/test/java/com/festago/auth/application/AdminAuthServiceTest.java
@@ -1,5 +1,8 @@
 package com.festago.auth.application;
 
+import static com.festago.common.exception.ErrorCode.DUPLICATE_ACCOUNT_USERNAME;
+import static com.festago.common.exception.ErrorCode.INCORRECT_PASSWORD_OR_ACCOUNT;
+import static com.festago.common.exception.ErrorCode.NOT_ENOUGH_PERMISSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.any;
@@ -52,7 +55,7 @@ class AdminAuthServiceTest {
             // when & then
             assertThatThrownBy(() -> adminAuthService.login(request))
                 .isInstanceOf(UnauthorizedException.class)
-                .hasMessage("비밀번호가 틀렸거나, 해당 계정이 없습니다.");
+                .hasMessage(INCORRECT_PASSWORD_OR_ACCOUNT.getMessage());
         }
 
         @Test
@@ -66,7 +69,7 @@ class AdminAuthServiceTest {
             // when & then
             assertThatThrownBy(() -> adminAuthService.login(request))
                 .isInstanceOf(UnauthorizedException.class)
-                .hasMessage("비밀번호가 틀렸거나, 해당 계정이 없습니다.");
+                .hasMessage(INCORRECT_PASSWORD_OR_ACCOUNT.getMessage());
         }
 
         @Test
@@ -102,7 +105,7 @@ class AdminAuthServiceTest {
             // when & then
             assertThatThrownBy(() -> adminAuthService.signup(1L, request))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("해당 계정이 존재합니다.");
+                .hasMessage(DUPLICATE_ACCOUNT_USERNAME.getMessage());
         }
 
         @Test
@@ -115,7 +118,7 @@ class AdminAuthServiceTest {
             // when & then
             assertThatThrownBy(() -> adminAuthService.signup(1L, request))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("해당 권한이 없습니다.");
+                .hasMessage(NOT_ENOUGH_PERMISSION.getMessage());
         }
 
         @Test

--- a/backend/src/test/java/com/festago/auth/application/AdminAuthServiceTest.java
+++ b/backend/src/test/java/com/festago/auth/application/AdminAuthServiceTest.java
@@ -28,7 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 @ExtendWith(MockitoExtension.class)
-class AdminAuthFacadeServiceTest {
+class AdminAuthServiceTest {
 
     @Mock
     AuthProvider authProvider;

--- a/backend/src/test/java/com/festago/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/festago/auth/application/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.festago.auth.application;
 
+import static com.festago.common.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -92,7 +93,7 @@ class AuthServiceTest {
             // then
             assertThatThrownBy(() -> authService.deleteMember(memberId))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 멤버입니다.");
+                .hasMessage(MEMBER_NOT_FOUND.getMessage());
         }
 
         @Test

--- a/backend/src/test/java/com/festago/auth/domain/OAuth2ClientsTest.java
+++ b/backend/src/test/java/com/festago/auth/domain/OAuth2ClientsTest.java
@@ -1,5 +1,7 @@
 package com.festago.auth.domain;
 
+import static com.festago.common.exception.ErrorCode.DUPLICATE_SOCIAL_TYPE;
+import static com.festago.common.exception.ErrorCode.OAUTH2_NOT_SUPPORTED_SOCIAL_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -32,7 +34,7 @@ class OAuth2ClientsTest {
         // when & then
         assertThatThrownBy(() -> builder.add(new FestagoOAuth2Client()))
             .isInstanceOf(InternalServerException.class)
-            .hasMessage("중복된 OAuth2 제공자 입니다.");
+            .hasMessage(DUPLICATE_SOCIAL_TYPE.getMessage());
     }
 
     @Test
@@ -44,7 +46,7 @@ class OAuth2ClientsTest {
         // when & then
         assertThatThrownBy(() -> oAuth2Clients.getClient(SocialType.FESTAGO))
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("해당 OAuth2 제공자는 지원되지 않습니다.");
+            .hasMessage(OAUTH2_NOT_SUPPORTED_SOCIAL_TYPE.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/festago/auth/infrastructure/HeaderTokenExtractorTest.java
+++ b/backend/src/test/java/com/festago/auth/infrastructure/HeaderTokenExtractorTest.java
@@ -1,5 +1,6 @@
 package com.festago.auth.infrastructure;
 
+import static com.festago.common.exception.ErrorCode.NOT_BEARER_TOKEN_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -43,7 +44,7 @@ class HeaderTokenExtractorTest {
         // when & then
         assertThatThrownBy(() -> headerTokenExtractor.extract(request))
             .isInstanceOf(UnauthorizedException.class)
-            .hasMessage("Bearer 타입의 토큰이 아닙니다.");
+            .hasMessage(NOT_BEARER_TOKEN_TYPE.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/festago/auth/infrastructure/JwtAuthExtractorTest.java
+++ b/backend/src/test/java/com/festago/auth/infrastructure/JwtAuthExtractorTest.java
@@ -1,5 +1,8 @@
 package com.festago.auth.infrastructure;
 
+import static com.festago.common.exception.ErrorCode.EXPIRED_AUTH_TOKEN;
+import static com.festago.common.exception.ErrorCode.INVALID_AUTH_TOKEN;
+import static com.festago.common.exception.ErrorCode.INVALID_ROLE_NAME;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.festago.auth.domain.AuthPayload;
@@ -36,7 +39,7 @@ class JwtAuthExtractorTest {
         // when & then
         assertThatThrownBy(() -> jwtAuthExtractor.extract(token))
             .isInstanceOf(UnauthorizedException.class)
-            .hasMessage("올바르지 않은 로그인 토큰입니다.");
+            .hasMessage(INVALID_AUTH_TOKEN.getMessage());
     }
 
     @Test
@@ -51,7 +54,7 @@ class JwtAuthExtractorTest {
         // when & then
         assertThatThrownBy(() -> jwtAuthExtractor.extract(token))
             .isInstanceOf(UnauthorizedException.class)
-            .hasMessage("만료된 로그인 토큰입니다.");
+            .hasMessage(EXPIRED_AUTH_TOKEN.getMessage());
     }
 
     @Test
@@ -68,7 +71,7 @@ class JwtAuthExtractorTest {
         // when & then
         assertThatThrownBy(() -> jwtAuthExtractor.extract(token))
             .isInstanceOf(UnauthorizedException.class)
-            .hasMessage("올바르지 않은 로그인 토큰입니다.");
+            .hasMessage(INVALID_AUTH_TOKEN.getMessage());
     }
 
     @Test
@@ -83,7 +86,7 @@ class JwtAuthExtractorTest {
         // when & then
         assertThatThrownBy(() -> jwtAuthExtractor.extract(token))
             .isInstanceOf(InternalServerException.class)
-            .hasMessage("해당하는 Role이 없습니다.");
+            .hasMessage(INVALID_ROLE_NAME.getMessage());
     }
 
     @Test
@@ -91,7 +94,7 @@ class JwtAuthExtractorTest {
         // when & then
         assertThatThrownBy(() -> jwtAuthExtractor.extract(null))
             .isInstanceOf(UnauthorizedException.class)
-            .hasMessage("올바르지 않은 로그인 토큰입니다.");
+            .hasMessage(INVALID_AUTH_TOKEN.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/festago/auth/infrastructure/KakaoOAuth2UserInfoClientTest.java
+++ b/backend/src/test/java/com/festago/auth/infrastructure/KakaoOAuth2UserInfoClientTest.java
@@ -1,5 +1,7 @@
 package com.festago.auth.infrastructure;
 
+import static com.festago.common.exception.ErrorCode.OAUTH2_INVALID_TOKEN;
+import static com.festago.common.exception.ErrorCode.OAUTH2_PROVIDER_NOT_RESPONSE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
@@ -49,7 +51,7 @@ class KakaoOAuth2UserInfoClientTest {
         // when & then
         assertThatThrownBy(() -> kakaoOAuth2UserInfoClient.getUserInfo("accessToken"))
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("잘못된 OAuth2 토큰입니다.");
+            .hasMessage(OAUTH2_INVALID_TOKEN.getMessage());
     }
 
     @Test
@@ -62,7 +64,7 @@ class KakaoOAuth2UserInfoClientTest {
         // when & then
         assertThatThrownBy(() -> kakaoOAuth2UserInfoClient.getUserInfo("accessToken"))
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("잘못된 OAuth2 토큰입니다.");
+            .hasMessage(OAUTH2_INVALID_TOKEN.getMessage());
     }
 
     @Test
@@ -75,7 +77,7 @@ class KakaoOAuth2UserInfoClientTest {
         // when & then
         assertThatThrownBy(() -> kakaoOAuth2UserInfoClient.getUserInfo("accessToken"))
             .isInstanceOf(InternalServerException.class)
-            .hasMessage("OAuth2 제공자 서버에 문제가 발생했습니다.");
+            .hasMessage(OAUTH2_PROVIDER_NOT_RESPONSE.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/festago/auth/presentation/RoleArgumentResolverTest.java
+++ b/backend/src/test/java/com/festago/auth/presentation/RoleArgumentResolverTest.java
@@ -1,5 +1,6 @@
 package com.festago.auth.presentation;
 
+import static com.festago.common.exception.ErrorCode.NOT_ENOUGH_PERMISSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -37,7 +38,7 @@ class RoleArgumentResolverTest {
         // when & then
         assertThatThrownBy(() -> roleArgumentResolver.resolveArgument(null, null, null, null))
             .isInstanceOf(ForbiddenException.class)
-            .hasMessage("해당 권한이 없습니다.");
+            .hasMessage(NOT_ENOUGH_PERMISSION.getMessage());
     }
 
     @Test
@@ -63,7 +64,7 @@ class RoleArgumentResolverTest {
         // when & then
         assertThatThrownBy(() -> roleArgumentResolver.resolveArgument(null, null, null, null))
             .isInstanceOf(ForbiddenException.class)
-            .hasMessage("해당 권한이 없습니다.");
+            .hasMessage(NOT_ENOUGH_PERMISSION.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/festago/domain/EntryCodeTest.java
+++ b/backend/src/test/java/com/festago/domain/EntryCodeTest.java
@@ -1,5 +1,7 @@
 package com.festago.domain;
 
+import static com.festago.common.exception.ErrorCode.INVALID_ENTRY_CODE_OFFSET;
+import static com.festago.common.exception.ErrorCode.INVALID_ENTRY_CODE_PERIOD;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -21,7 +23,7 @@ class EntryCodeTest {
         // when & then
         assertThatThrownBy(() -> new EntryCode("code", period, 0))
             .isInstanceOf(InternalServerException.class)
-            .hasMessage("올바르지 않은 입장코드 유효기간입니다.");
+            .hasMessage(INVALID_ENTRY_CODE_PERIOD.getMessage());
     }
 
     @Test
@@ -29,7 +31,7 @@ class EntryCodeTest {
         // when & tehn
         assertThatThrownBy(() -> new EntryCode("code", 30, -1))
             .isInstanceOf(InternalServerException.class)
-            .hasMessage("올바르지 않은 입장코드 오프셋입니다.");
+            .hasMessage(INVALID_ENTRY_CODE_OFFSET.getMessage());
     }
 
     @ParameterizedTest

--- a/backend/src/test/java/com/festago/domain/EntryStateTest.java
+++ b/backend/src/test/java/com/festago/domain/EntryStateTest.java
@@ -1,5 +1,6 @@
 package com.festago.domain;
 
+import static com.festago.common.exception.ErrorCode.INVALID_ENTRY_STATE_INDEX;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -21,7 +22,7 @@ class EntryStateTest {
         // when & then
         assertThatThrownBy(() -> EntryState.from(index))
             .isInstanceOf(InternalServerException.class)
-            .hasMessage("올바르지 않은 입장상태 인덱스입니다.");
+            .hasMessage(INVALID_ENTRY_STATE_INDEX.getMessage());
     }
 
     @Test
@@ -29,7 +30,7 @@ class EntryStateTest {
         // when & then
         assertThatThrownBy(() -> EntryState.from(null))
             .isInstanceOf(InternalServerException.class)
-            .hasMessage("올바르지 않은 입장상태 인덱스입니다.");
+            .hasMessage(INVALID_ENTRY_STATE_INDEX.getMessage());
     }
 
     @ParameterizedTest

--- a/backend/src/test/java/com/festago/domain/FestivalTest.java
+++ b/backend/src/test/java/com/festago/domain/FestivalTest.java
@@ -1,5 +1,6 @@
 package com.festago.domain;
 
+import static com.festago.common.exception.ErrorCode.INVALID_FESTIVAL_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -28,7 +29,7 @@ class FestivalTest {
         // when & then
         assertThatThrownBy(() -> new Festival("테코대학교", today.plusDays(1), today, school))
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("축제 시작 일자는 종료일자 이전이어야합니다.");
+            .hasMessage(INVALID_FESTIVAL_DURATION.getMessage());
     }
 
     @Nested

--- a/backend/src/test/java/com/festago/domain/StageTest.java
+++ b/backend/src/test/java/com/festago/domain/StageTest.java
@@ -1,5 +1,7 @@
 package com.festago.domain;
 
+import static com.festago.common.exception.ErrorCode.INVALID_STAGE_START_TIME;
+import static com.festago.common.exception.ErrorCode.INVALID_TICKET_OPEN_TIME;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -36,7 +38,7 @@ class StageTest {
             .build()
         )
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("공연은 축제 기간 중에만 진행될 수 있습니다.");
+            .hasMessage(INVALID_STAGE_START_TIME.getMessage());
     }
 
     @Test
@@ -57,7 +59,7 @@ class StageTest {
             .build()
         )
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("공연은 축제 기간 중에만 진행될 수 있습니다.");
+            .hasMessage(INVALID_STAGE_START_TIME.getMessage());
     }
 
     @ParameterizedTest
@@ -78,7 +80,7 @@ class StageTest {
             .build()
         )
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("티켓은 공연 시작 전에 오픈되어야 합니다.");
+            .hasMessage(INVALID_TICKET_OPEN_TIME.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/festago/domain/TicketAmountTest.java
+++ b/backend/src/test/java/com/festago/domain/TicketAmountTest.java
@@ -1,5 +1,6 @@
 package com.festago.domain;
 
+import static com.festago.common.exception.ErrorCode.TICKET_SOLD_OUT;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.festago.common.exception.BadRequestException;
@@ -25,6 +26,6 @@ class TicketAmountTest {
         // then
         assertThatThrownBy(ticketAmount::increaseReservedAmount)
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("매진된 티켓입니다.");
+            .hasMessage(TICKET_SOLD_OUT.getMessage());
     }
 }

--- a/backend/src/test/java/com/festago/domain/TicketEntryTimeTest.java
+++ b/backend/src/test/java/com/festago/domain/TicketEntryTimeTest.java
@@ -1,5 +1,6 @@
 package com.festago.domain;
 
+import static com.festago.common.exception.ErrorCode.INVALID_MIN_TICKET_AMOUNT;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.festago.common.exception.BadRequestException;
@@ -32,6 +33,6 @@ class TicketEntryTimeTest {
         // when & then
         assertThatThrownBy(() -> new TicketEntryTime(now, 0))
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("티켓은 적어도 한장 이상 발급해야합니다.");
+            .hasMessage(INVALID_MIN_TICKET_AMOUNT.getMessage());
     }
 }

--- a/backend/src/test/java/com/festago/domain/TicketTest.java
+++ b/backend/src/test/java/com/festago/domain/TicketTest.java
@@ -1,5 +1,11 @@
 package com.festago.domain;
 
+import static com.festago.common.exception.ErrorCode.EARLY_TICKET_ENTRY_THAN_OPEN;
+import static com.festago.common.exception.ErrorCode.EARLY_TICKET_ENTRY_TIME;
+import static com.festago.common.exception.ErrorCode.INVALID_TICKET_CREATE_TIME;
+import static com.festago.common.exception.ErrorCode.LATE_TICKET_ENTRY_TIME;
+import static com.festago.common.exception.ErrorCode.TICKET_CANNOT_RESERVE_STAGE_START;
+import static com.festago.common.exception.ErrorCode.TICKET_SOLD_OUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -46,7 +52,7 @@ class TicketTest {
             assertThatThrownBy(
                 () -> ticket.addTicketEntryTime(now.minusMinutes(10), now.minusMinutes(minute), 100))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("입장 시간은 티켓 오픈 시간 이후여야합니다.");
+                .hasMessage(EARLY_TICKET_ENTRY_THAN_OPEN.getMessage());
         }
 
         @ParameterizedTest
@@ -64,7 +70,7 @@ class TicketTest {
             // when & then
             assertThatThrownBy(() -> ticket.addTicketEntryTime(ticketOpenTime.minusMinutes(10), entryTime, 100))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("입장 시간은 공연 시간보다 빨라야합니다.");
+                .hasMessage(LATE_TICKET_ENTRY_TIME.getMessage());
         }
 
         @Test
@@ -81,7 +87,7 @@ class TicketTest {
             // when & then
             assertThatThrownBy(() -> ticket.addTicketEntryTime(ticketOpenTime.minusMinutes(10), entryTime, 100))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("입장 시간은 공연 시작 12시간 이내여야 합니다.");
+                .hasMessage(EARLY_TICKET_ENTRY_TIME.getMessage());
         }
 
         @Test
@@ -98,7 +104,7 @@ class TicketTest {
             // when & then
             assertThatThrownBy(() -> ticket.addTicketEntryTime(LocalDateTime.now(), startTime.minusHours(3), 100))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("티켓 예매 시작 후 새롭게 티켓을 발급할 수 없습니다.");
+                .hasMessage(INVALID_TICKET_CREATE_TIME.getMessage());
         }
 
         @Test
@@ -151,7 +157,7 @@ class TicketTest {
             // when & then
             assertThatThrownBy(() -> ticket.createMemberTicket(member, 101, now))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("매진된 티켓입니다.");
+                .hasMessage(TICKET_SOLD_OUT.getMessage());
         }
 
         @Test
@@ -179,7 +185,7 @@ class TicketTest {
             // when & then
             assertThatThrownBy(() -> ticket.createMemberTicket(member, 1, now))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("공연의 시작 시간 이후로 예매할 수 없습니다.");
+                .hasMessage(TICKET_CANNOT_RESERVE_STAGE_START.getMessage());
         }
 
         @ParameterizedTest

--- a/backend/src/test/java/com/festago/infrastructure/JwtEntryCodeExtractorTest.java
+++ b/backend/src/test/java/com/festago/infrastructure/JwtEntryCodeExtractorTest.java
@@ -1,5 +1,9 @@
 package com.festago.infrastructure;
 
+import static com.festago.common.exception.ErrorCode.EXPIRED_ENTRY_CODE;
+import static com.festago.common.exception.ErrorCode.INVALID_ENTRY_CODE;
+import static com.festago.common.exception.ErrorCode.INVALID_ENTRY_CODE_PAYLOAD;
+import static com.festago.common.exception.ErrorCode.INVALID_ENTRY_STATE_INDEX;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -36,7 +40,7 @@ class JwtEntryCodeExtractorTest {
         // when & then
         assertThatThrownBy(() -> jwtEntryCodeExtractor.extract(code))
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("올바르지 않은 입장코드입니다.");
+            .hasMessage(INVALID_ENTRY_CODE.getMessage());
     }
 
     @Test
@@ -46,7 +50,7 @@ class JwtEntryCodeExtractorTest {
         // when & then
         assertThatThrownBy(() -> jwtEntryCodeExtractor.extract(code))
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("올바르지 않은 입장코드입니다.");
+            .hasMessage(INVALID_ENTRY_CODE.getMessage());
     }
 
     @Test
@@ -62,7 +66,7 @@ class JwtEntryCodeExtractorTest {
         // when & then
         assertThatThrownBy(() -> jwtEntryCodeExtractor.extract(code))
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("만료된 입장 코드입니다.");
+            .hasMessage(EXPIRED_ENTRY_CODE.getMessage());
     }
 
     @Test
@@ -80,7 +84,7 @@ class JwtEntryCodeExtractorTest {
         // when & then
         assertThatThrownBy(() -> jwtEntryCodeExtractor.extract(code))
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("올바르지 않은 입장코드입니다.");
+            .hasMessage(INVALID_ENTRY_CODE.getMessage());
     }
 
     @Test
@@ -95,7 +99,7 @@ class JwtEntryCodeExtractorTest {
         // when & then
         assertThatThrownBy(() -> jwtEntryCodeExtractor.extract(code))
             .isInstanceOf(InternalServerException.class)
-            .hasMessage("유효하지 않은 입장코드 payload 입니다.");
+            .hasMessage(INVALID_ENTRY_CODE_PAYLOAD.getMessage());
     }
 
     @Test
@@ -110,7 +114,7 @@ class JwtEntryCodeExtractorTest {
         // when & then
         assertThatThrownBy(() -> jwtEntryCodeExtractor.extract(code))
             .isInstanceOf(InternalServerException.class)
-            .hasMessage("올바르지 않은 입장상태 인덱스입니다.");
+            .hasMessage(INVALID_ENTRY_STATE_INDEX.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/festago/infrastructure/JwtEntryCodeProviderTest.java
+++ b/backend/src/test/java/com/festago/infrastructure/JwtEntryCodeProviderTest.java
@@ -1,5 +1,6 @@
 package com.festago.infrastructure;
 
+import static com.festago.common.exception.ErrorCode.INVALID_ENTRY_CODE_EXPIRATION_TIME;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -37,7 +38,7 @@ class JwtEntryCodeProviderTest {
         // when & then
         assertThatThrownBy(() -> entryCodeProvider.provide(entryCodePayload, expiredAt))
             .isInstanceOf(InternalServerException.class)
-            .hasMessage("올바르지 않은 입장코드 만료 일자입니다.");
+            .hasMessage(INVALID_ENTRY_CODE_EXPIRATION_TIME.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/festago/ticketing/application/TicketingServiceTest.java
+++ b/backend/src/test/java/com/festago/ticketing/application/TicketingServiceTest.java
@@ -1,5 +1,6 @@
 package com.festago.ticketing.application;
 
+import static com.festago.common.exception.ErrorCode.NEED_STUDENT_VERIFICATION;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -77,6 +78,6 @@ class TicketingServiceTest {
         // when & then
         assertThatThrownBy(() -> ticketingService.ticketing(1L, request))
             .isInstanceOf(BadRequestException.class)
-            .hasMessage("학생 인증이 필요합니다.");
+            .hasMessage(NEED_STUDENT_VERIFICATION.getMessage());
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #476

