### PR TITLE
[AN/USER] feat: 축제 목록, 축제 상세 API 변경사항 반영

### DIFF
--- a/android/festago/app/src/main/java/com/festago/festago/data/dto/FestivalResponse.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/data/dto/FestivalResponse.kt
@@ -7,6 +7,7 @@ import java.time.LocalDate
 @Serializable
 data class FestivalResponse(
     val id: Int,
+    val schoolId: Int,
     val name: String,
     val startDate: String,
     val endDate: String,

--- a/android/festago/app/src/main/java/com/festago/festago/data/dto/ReservationFestivalResponse.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/data/dto/ReservationFestivalResponse.kt
@@ -7,6 +7,7 @@ import java.time.LocalDate
 @Serializable
 data class ReservationFestivalResponse(
     val id: Int,
+    val schoolId: Int,
     val name: String,
     val startDate: String,
     val endDate: String,

--- a/android/festago/app/src/test/java/com/festago/festago/data/repository/ReservationTicketRetrofitServiceTest.kt
+++ b/android/festago/app/src/test/java/com/festago/festago/data/repository/ReservationTicketRetrofitServiceTest.kt
@@ -187,6 +187,7 @@ class ReservationTicketRetrofitServiceTest {
         private fun getFakeFestival(): ReservationFestivalResponse {
             return ReservationFestivalResponse(
                 id = 1,
+                schoolId = 1,
                 name = "테코대학교",
                 startDate = "2023-07-03",
                 endDate = "2023-07-09",
@@ -240,6 +241,7 @@ class ReservationTicketRetrofitServiceTest {
             return """
 {
 	"id": 1,
+    "schoolId": 1,
 	"name": "테코대학교",
 	"startDate": "2023-07-03",
 	"endDate": "2023-07-09",	


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #507 

## ✨ PR 세부 내용

- dto에 schoolId 추가했습니다. 
- 이제 축제 목록, 축제 상세 정상 조회됩니다.
- 아직 어디에 필요한지 결정되지 않아 도메인 모델에는 반영하지 않았습니다. (아마 재학생 여부 확인에 사용할듯?)
