### PR TITLE
[AN/USER] fix: SwipeRefresh 무한 로딩 버그 수정 (#514)

### DIFF
--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
@@ -59,6 +59,7 @@ class FestivalListFragment : Fragment(R.layout.fragment_festival_list) {
 
         binding.srlFestivalList.setOnRefreshListener {
             vm.loadFestivals()
+            binding.srlFestivalList.isRefreshing = false
         }
     }
 
@@ -66,7 +67,7 @@ class FestivalListFragment : Fragment(R.layout.fragment_festival_list) {
         when (uiState) {
             is FestivalListUiState.Loading,
             is FestivalListUiState.Error,
-            -> binding.srlFestivalList.isRefreshing = false
+            -> Unit
 
             is FestivalListUiState.Success -> handleSuccess(uiState)
         }
@@ -74,7 +75,6 @@ class FestivalListFragment : Fragment(R.layout.fragment_festival_list) {
 
     private fun handleSuccess(uiState: FestivalListUiState.Success) {
         adapter.submitList(uiState.festivals)
-        binding.srlFestivalList.isRefreshing = false
     }
 
     private fun handleEvent(event: FestivalListEvent) {

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/mypage/MyPageFragment.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/mypage/MyPageFragment.kt
@@ -60,7 +60,6 @@ class MyPageFragment : Fragment(R.layout.fragment_my_page) {
 
             is MyPageUiState.Success -> handleSuccess(uiState)
         }
-        binding.srlMyPage.isRefreshing = false
     }
 
     private fun handleEvent(event: MyPageEvent) {
@@ -116,6 +115,7 @@ class MyPageFragment : Fragment(R.layout.fragment_my_page) {
 
         binding.srlMyPage.setOnRefreshListener {
             vm.loadUserInfo()
+            binding.srlMyPage.isRefreshing = false
         }
 
         binding.tvSchoolAuthorization.setOnClickListener {

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/ticketlist/TicketListFragment.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/home/ticketlist/TicketListFragment.kt
@@ -62,11 +62,10 @@ class TicketListFragment : Fragment(R.layout.fragment_ticket_list) {
         when (uiState) {
             is TicketListUiState.Loading,
             is TicketListUiState.Error,
-            -> binding.srlTicketList.isRefreshing = false
+            -> Unit
 
             is TicketListUiState.Success -> {
                 adapter.submitList(uiState.tickets)
-                binding.srlTicketList.isRefreshing = false
             }
         }
     }
@@ -106,6 +105,7 @@ class TicketListFragment : Fragment(R.layout.fragment_ticket_list) {
     private fun initRefresh() {
         binding.srlTicketList.setOnRefreshListener {
             vm.loadCurrentTickets()
+            binding.srlTicketList.isRefreshing = false
         }
     }
 

--- a/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveActivity.kt
+++ b/android/festago/app/src/main/java/com/festago/festago/presentation/ui/ticketreserve/TicketReserveActivity.kt
@@ -131,13 +131,14 @@ class TicketReserveActivity : AppCompatActivity() {
                 festivalId = intent.getLongExtra(KEY_FESTIVAL_ID, -1),
                 refresh = true,
             )
+            binding.srlTicketReserve.isRefreshing = false
         }
     }
 
     private fun updateUi(uiState: TicketReserveUiState) = when (uiState) {
         is TicketReserveUiState.Loading,
         is TicketReserveUiState.Error,
-        -> binding.srlTicketReserve.isRefreshing = false
+        -> Unit
 
         is TicketReserveUiState.Success -> updateSuccess(uiState)
     }
@@ -145,7 +146,6 @@ class TicketReserveActivity : AppCompatActivity() {
     private fun updateSuccess(successState: TicketReserveUiState.Success) {
         headerAdapter.submitList(listOf(successState.festival))
         contentsAdapter.submitList(successState.stages)
-        binding.srlTicketReserve.isRefreshing = false
     }
 
     companion object {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #514 

## ✨ PR 세부 내용

- uiState 값이 변경되지 않았을 때 collect가 발생하지 않아 무한 로딩하는 버그 수정했습니다.
- 축제 목록, 마이페이지, 티켓 목록, 축제 상세 화면
