### PR TITLE
[BE] feat: 회원의 학생 인증 정보 조회 API 구현 (#496)

### DIFF
--- a/backend/src/main/java/com/festago/presentation/StudentController.java
+++ b/backend/src/main/java/com/festago/presentation/StudentController.java
@@ -2,6 +2,7 @@ package com.festago.presentation;
 
 import com.festago.auth.annotation.Member;
 import com.festago.student.application.StudentService;
+import com.festago.student.dto.StudentResponse;
 import com.festago.student.dto.StudentSendMailRequest;
 import com.festago.student.dto.StudentVerificateRequest;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,5 +40,13 @@ public class StudentController {
         studentService.verify(memberId, request);
         return ResponseEntity.ok()
             .build();
+    }
+
+    @GetMapping
+    @Operation(description = "학생 인증 정보를 조회한다.", summary = "학생 인증 정보 조회")
+    public ResponseEntity<StudentResponse> findVerification(@Member Long memberId) {
+        StudentResponse response = studentService.findVerification(memberId);
+        return ResponseEntity.ok()
+            .body(response);
     }
 }

--- a/backend/src/main/java/com/festago/presentation/StudentController.java
+++ b/backend/src/main/java/com/festago/presentation/StudentController.java
@@ -33,9 +33,9 @@ public class StudentController {
 
     @PostMapping("/verification")
     @Operation(description = "학교 인증을 수행한다.", summary = "학생 인증 수행")
-    public ResponseEntity<Void> verificate(@Member Long memberId,
-                                           @RequestBody @Valid StudentVerificateRequest request) {
-        studentService.verificate(memberId, request);
+    public ResponseEntity<Void> verify(@Member Long memberId,
+                                       @RequestBody @Valid StudentVerificateRequest request) {
+        studentService.verify(memberId, request);
         return ResponseEntity.ok()
             .build();
     }

--- a/backend/src/main/java/com/festago/student/application/StudentService.java
+++ b/backend/src/main/java/com/festago/student/application/StudentService.java
@@ -19,7 +19,6 @@ import com.festago.student.repository.StudentCodeRepository;
 import com.festago.student.repository.StudentRepository;
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -102,8 +101,7 @@ public class StudentService {
     }
 
     public StudentResponse findVerification(Long memberId) {
-        Optional<Student> student = studentRepository.findByMemberIdWithFetch(memberId);
-        return student
+        return studentRepository.findByMemberIdWithFetch(memberId)
             .map(value -> StudentResponse.verified(value.getSchool()))
             .orElseGet(StudentResponse::notVerified);
     }

--- a/backend/src/main/java/com/festago/student/application/StudentService.java
+++ b/backend/src/main/java/com/festago/student/application/StudentService.java
@@ -89,7 +89,7 @@ public class StudentService {
             );
     }
 
-    public void verificate(Long memberId, StudentVerificateRequest request) {
+    public void verify(Long memberId, StudentVerificateRequest request) {
         validateStudent(memberId);
         Member member = findMember(memberId);
         StudentCode studentCode = studentCodeRepository.findByCodeAndMember(new VerificationCode(request.code()),

--- a/backend/src/main/java/com/festago/student/application/StudentService.java
+++ b/backend/src/main/java/com/festago/student/application/StudentService.java
@@ -12,12 +12,14 @@ import com.festago.student.domain.Student;
 import com.festago.student.domain.StudentCode;
 import com.festago.student.domain.VerificationCode;
 import com.festago.student.domain.VerificationMailPayload;
+import com.festago.student.dto.StudentResponse;
 import com.festago.student.dto.StudentSendMailRequest;
 import com.festago.student.dto.StudentVerificateRequest;
 import com.festago.student.repository.StudentCodeRepository;
 import com.festago.student.repository.StudentRepository;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -97,5 +99,12 @@ public class StudentService {
             .orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_STUDENT_VERIFICATION_CODE));
         studentRepository.save(new Student(member, studentCode.getSchool(), studentCode.getUsername()));
         studentCodeRepository.deleteByMember(member);
+    }
+
+    public StudentResponse findVerification(Long memberId) {
+        Optional<Student> student = studentRepository.findByMemberIdWithFetch(memberId);
+        return student
+            .map(value -> StudentResponse.verified(value.getSchool()))
+            .orElseGet(StudentResponse::notVerified);
     }
 }

--- a/backend/src/main/java/com/festago/student/dto/StudentResponse.java
+++ b/backend/src/main/java/com/festago/student/dto/StudentResponse.java
@@ -1,0 +1,23 @@
+package com.festago.student.dto;
+
+import com.festago.school.domain.School;
+
+public record StudentResponse(
+    boolean isVerified,
+    StudentSchoolResponse school
+) {
+
+    public static StudentResponse verified(School school) {
+        return new StudentResponse(
+            true,
+            StudentSchoolResponse.from(school)
+        );
+    }
+
+    public static StudentResponse notVerified() {
+        return new StudentResponse(
+            false,
+            null
+        );
+    }
+}

--- a/backend/src/main/java/com/festago/student/dto/StudentResponse.java
+++ b/backend/src/main/java/com/festago/student/dto/StudentResponse.java
@@ -7,6 +7,8 @@ public record StudentResponse(
     StudentSchoolResponse school
 ) {
 
+    private static final StudentResponse NOT_VERIFIED = new StudentResponse(false, null);
+
     public static StudentResponse verified(School school) {
         return new StudentResponse(
             true,
@@ -15,9 +17,6 @@ public record StudentResponse(
     }
 
     public static StudentResponse notVerified() {
-        return new StudentResponse(
-            false,
-            null
-        );
+        return NOT_VERIFIED;
     }
 }

--- a/backend/src/main/java/com/festago/student/dto/StudentSchoolResponse.java
+++ b/backend/src/main/java/com/festago/student/dto/StudentSchoolResponse.java
@@ -1,0 +1,18 @@
+package com.festago.student.dto;
+
+import com.festago.school.domain.School;
+
+public record StudentSchoolResponse(
+    Long id,
+    String schoolName,
+    String domain
+) {
+
+    public static StudentSchoolResponse from(School school) {
+        return new StudentSchoolResponse(
+            school.getId(),
+            school.getName(),
+            school.getDomain()
+        );
+    }
+}

--- a/backend/src/main/java/com/festago/student/repository/StudentRepository.java
+++ b/backend/src/main/java/com/festago/student/repository/StudentRepository.java
@@ -17,8 +17,8 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
 
     @Query("""
         SELECT st
-        FROM Student  st
-        LEFT JOIN FETCH st.school sc
+        FROM Student st
+        INNER JOIN FETCH st.school sc
         WHERE st.member.id = :memberId
         """)
     Optional<Student> findByMemberIdWithFetch(@Param("memberId") Long memberId);

--- a/backend/src/main/java/com/festago/student/repository/StudentRepository.java
+++ b/backend/src/main/java/com/festago/student/repository/StudentRepository.java
@@ -2,7 +2,10 @@ package com.festago.student.repository;
 
 import com.festago.member.domain.Member;
 import com.festago.student.domain.Student;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StudentRepository extends JpaRepository<Student, Long> {
 
@@ -11,4 +14,12 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
     boolean existsByUsernameAndSchoolId(String username, Long id);
 
     boolean existsByMemberId(Long id);
+
+    @Query("""
+        SELECT st
+        FROM Student  st
+        LEFT JOIN FETCH st.school sc
+        WHERE st.member.id = :memberId
+        """)
+    Optional<Student> findByMemberIdWithFetch(@Param("memberId") Long memberId);
 }

--- a/backend/src/test/java/com/festago/presentation/StudentControllerTest.java
+++ b/backend/src/test/java/com/festago/presentation/StudentControllerTest.java
@@ -1,14 +1,22 @@
 package com.festago.presentation;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.festago.student.application.StudentService;
+import com.festago.student.dto.StudentResponse;
+import com.festago.student.dto.StudentSchoolResponse;
 import com.festago.student.dto.StudentSendMailRequest;
 import com.festago.student.dto.StudentVerificateRequest;
 import com.festago.support.CustomWebMvcTest;
 import com.festago.support.WithMockAuth;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
@@ -91,6 +99,44 @@ class StudentControllerTest {
                     .header(HttpHeaders.AUTHORIZATION, "Bearer token")
                     .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    class 학생_인증_정보_조회 {
+
+        @Test
+        void 인증이_되지_않으면_401() throws Exception {
+            // given
+            StudentVerificateRequest request = new StudentVerificateRequest("123456");
+
+            // when & then
+            mockMvc.perform(get("/students")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @WithMockAuth
+        void 학생_인증_조회() throws Exception {
+            // given
+            StudentResponse expected = new StudentResponse(true, new StudentSchoolResponse(1L, "테코대학교", "teco.ac.kr"));
+            given(studentService.findVerification(anyLong()))
+                .willReturn(expected);
+
+            // when & then
+            String content = mockMvc.perform(get("/students")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer token")
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
+            StudentResponse actual = objectMapper.readValue(content, StudentResponse.class);
+            assertThat(actual).isEqualTo(expected);
         }
     }
 }

--- a/backend/src/test/java/com/festago/student/application/StudentServiceTest.java
+++ b/backend/src/test/java/com/festago/student/application/StudentServiceTest.java
@@ -186,7 +186,7 @@ class StudentServiceTest {
                 .willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> studentService.verificate(memberId, request))
+            assertThatThrownBy(() -> studentService.verify(memberId, request))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ALREADY_STUDENT_VERIFIED.getMessage());
         }
@@ -202,7 +202,7 @@ class StudentServiceTest {
                 .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> studentService.verificate(memberId, request))
+            assertThatThrownBy(() -> studentService.verify(memberId, request))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(INVALID_STUDENT_VERIFICATION_CODE.getMessage());
         }
@@ -225,7 +225,7 @@ class StudentServiceTest {
 
             // when & then
             assertThatNoException()
-                .isThrownBy(() -> studentService.verificate(memberId, request));
+                .isThrownBy(() -> studentService.verify(memberId, request));
         }
     }
 }

--- a/backend/src/test/java/com/festago/student/repository/StudentRepositoryTest.java
+++ b/backend/src/test/java/com/festago/student/repository/StudentRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.festago.student.repository;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.festago.member.domain.Member;
+import com.festago.member.repository.MemberRepository;
+import com.festago.school.domain.School;
+import com.festago.school.repository.SchoolRepository;
+import com.festago.student.domain.Student;
+import com.festago.support.MemberFixture;
+import com.festago.support.SchoolFixture;
+import com.festago.support.StudentFixture;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@DataJpaTest
+class StudentRepositoryTest {
+
+    @Autowired
+    StudentRepository studentRepository;
+
+    @Autowired
+    SchoolRepository schoolRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    void 멤버id로_조회() {
+        // given
+        Member member = memberRepository.save(MemberFixture.member().build());
+        School school = schoolRepository.save(SchoolFixture.school().build());
+        Student student = studentRepository.save(StudentFixture.student().school(school).member(member).build());
+
+        // when
+        Optional<Student> actual = studentRepository.findByMemberIdWithFetch(member.getId());
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(actual).isNotEmpty();
+            softly.assertThat(actual.get().getId()).isEqualTo(student.getId());
+        });
+    }
+}

--- a/backend/src/test/java/com/festago/support/StudentFixture.java
+++ b/backend/src/test/java/com/festago/support/StudentFixture.java
@@ -1,0 +1,44 @@
+package com.festago.support;
+
+import com.festago.member.domain.Member;
+import com.festago.school.domain.School;
+import com.festago.student.domain.Student;
+
+public class StudentFixture {
+
+    private Long id;
+    private Member member = MemberFixture.member().build();
+    private School school = SchoolFixture.school().build();
+    private String username = "xxeol2";
+
+    private StudentFixture() {
+    }
+
+    public static StudentFixture student() {
+        return new StudentFixture();
+    }
+
+    public StudentFixture id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public StudentFixture member(Member member) {
+        this.member = member;
+        return this;
+    }
+
+    public StudentFixture school(School school) {
+        this.school = school;
+        return this;
+    }
+
+    public StudentFixture username(String username) {
+        this.username = username;
+        return this;
+    }
+
+    public Student build() {
+        return new Student(id, member, school, username);
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #496 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
마이페이지 및 티케팅시 필요한 회원의 학생 인증 정보 조회 API를 구현하였습니다!
