### PR TITLE
[BE] fix: MockMailClient 빈으로 등록되는 프로파일 변경 (#542)

### DIFF
--- a/backend/src/main/java/com/festago/fcm/application/FCMNotificationEventListener.java
+++ b/backend/src/main/java/com/festago/fcm/application/FCMNotificationEventListener.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
-@Profile({"dev", "prod"})
+@Profile({"prod", "dev"})
 public class FCMNotificationEventListener {
 
     private static final Logger log = LoggerFactory.getLogger(FCMNotificationEventListener.class);

--- a/backend/src/main/java/com/festago/student/infrastructure/MockMailClient.java
+++ b/backend/src/main/java/com/festago/student/infrastructure/MockMailClient.java
@@ -6,10 +6,11 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile({"local", "test"})
+@Profile("!{dev|prod}")
 public class MockMailClient implements MailClient {
 
     @Override
     public void send(VerificationMailPayload payload) {
+        // no-op
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #542

## ✨ PR 세부 내용

```java
@Component
@Profile("!{dev|prod}")
public class MockMailClient implements MailClient {
    ...
}
```

스프링 5.1 이상 부터 정규식을 통해 프로파일을 설정할 수 있다고 하네요.
따라서 정규식을 사용하여 `dev` 또는 `prod` 프로파일이 아니면 해당 빈을 등록하도록 하였습니다. 