### PR TITLE
[BE] fix: 컴포넌트 스캔 대상이 되는 빈의 @Profile 설정 수정 (#551)

### DIFF
--- a/backend/src/main/java/com/festago/fcm/application/FCMNotificationEventListener.java
+++ b/backend/src/main/java/com/festago/fcm/application/FCMNotificationEventListener.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
-@Profile({"prod", "dev"})
+@Profile("prod | dev")
 public class FCMNotificationEventListener {
 
     private static final Logger log = LoggerFactory.getLogger(FCMNotificationEventListener.class);

--- a/backend/src/main/java/com/festago/fcm/config/FCMConfig.java
+++ b/backend/src/main/java/com/festago/fcm/config/FCMConfig.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
 
 @Configuration
-@Profile({"prod", "dev"})
+@Profile("prod | dev")
 public class FCMConfig {
 
     @Value("${fcm.key.path}")

--- a/backend/src/main/java/com/festago/student/infrastructure/GoogleMailClient.java
+++ b/backend/src/main/java/com/festago/student/infrastructure/GoogleMailClient.java
@@ -10,7 +10,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile({"prod", "dev"})
+@Profile("prod | dev")
 public class GoogleMailClient implements MailClient {
 
     private final MailSender mailSender;

--- a/backend/src/main/java/com/festago/student/infrastructure/MockMailClient.java
+++ b/backend/src/main/java/com/festago/student/infrastructure/MockMailClient.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile({"infra", "test", "local"})
+@Profile("!dev & !prod")
 public class MockMailClient implements MailClient {
 
     @Override


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #551 

## ✨ PR 세부 내용

```java
@Component
@Profile("!dev & !prod")
public class MockMailClient implements MailClient {

    private static final Logger log = LoggerFactory.getLogger(MockMailClient.class);

    @Override
    public void send(String message) {

    }

    @PostConstruct
    public void post() {
        log.info("Mock Mail Init!");
    }
}
```
```java
@Component
@Profile("dev | prod")
public class RealMailClient implements MailClient {

    private static final Logger log = LoggerFactory.getLogger(RealMailClient.class);

    @Override
    public void send(String message) {

    }

    @PostConstruct
    public void post() {
        log.info("Real Mail Init!");
    }
}
```
다음과 같이 프로파일 설정 후 테스트 결과 
`MockMailClient`는 dev 또는 prod 프로파일이 아닐 때 등록이 확인되었고,
`RealMailClient`는 dev 또는 prod 프로파일 일 때 등록이 확인되었습니다.