### PR TITLE
[BE] FCMNotificationEventListener의 FCMChannel을 수정 (#565)

### DIFF
--- a/backend/src/main/java/com/festago/entry/dto/event/EntryProcessEvent.java
+++ b/backend/src/main/java/com/festago/entry/dto/event/EntryProcessEvent.java
@@ -1,6 +1,7 @@
 package com.festago.entry.dto.event;
 
 public record EntryProcessEvent(
-    Long memberId) {
+    Long memberId
+) {
 
 }

--- a/backend/src/main/java/com/festago/fcm/application/FCMNotificationEventListener.java
+++ b/backend/src/main/java/com/festago/fcm/application/FCMNotificationEventListener.java
@@ -36,7 +36,7 @@ public class FCMNotificationEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
     public void sendFcmNotification(EntryProcessEvent event) {
-        List<Message> messages = createMessages(getMemberFCMToken(event.memberId()), FCMChannel.NOT_DEFINED.name());
+        List<Message> messages = createMessages(getMemberFCMToken(event.memberId()), FCMChannel.ENTRY_PROCESS.name());
         try {
             BatchResponse batchResponse = firebaseMessaging.sendAll(messages);
             checkAllSuccess(batchResponse, event.memberId());

--- a/backend/src/main/java/com/festago/fcm/domain/FCMChannel.java
+++ b/backend/src/main/java/com/festago/fcm/domain/FCMChannel.java
@@ -1,5 +1,6 @@
 package com.festago.fcm.domain;
 
 public enum FCMChannel {
-    NOT_DEFINED;
+    ENTRY_PROCESS,
+    ENTRY_ALERT
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #565

## ✨ PR 세부 내용

우선 작동을 위해 `ENTRY_PROCESS`를 하드코딩 하였습니다.
추후 #483 이슈가 처리되면 개선이 필요할 것 같습니다.
