### PR TITLE
[AN/USER] feat: 축제 목록 화면 UX 개선(#614)

### DIFF
--- a/android/festago/app/src/main/res/layout/fragment_festival_list.xml
+++ b/android/festago/app/src/main/res/layout/fragment_festival_list.xml
@@ -27,57 +27,67 @@
                 <com.google.android.material.appbar.CollapsingToolbarLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="?attr/colorSurface"
-                    app:layout_scrollFlags="scroll|enterAlways">
+                    app:layout_scrollFlags="scroll|snap|enterAlways">
 
-                    <androidx.constraintlayout.widget.ConstraintLayout
+                    <androidx.appcompat.widget.Toolbar
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:background="?attr/colorSurface"
+                        app:contentInsetStart="0dp"
                         app:layout_collapseMode="pin">
 
-                        <ImageView
-                            android:id="@+id/imgFestagoLogo"
-                            android:layout_width="160dp"
-                            android:layout_height="45dp"
-                            android:layout_marginStart="12dp"
-                            android:layout_marginTop="12dp"
-                            android:src="@drawable/img_festago_home_logo"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="parent" />
-
-                        <com.google.android.material.chip.ChipGroup
-                            android:id="@+id/cgFilterOption"
+                        <androidx.appcompat.widget.LinearLayoutCompat
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:paddingHorizontal="16dp"
-                            android:paddingTop="12dp"
-                            app:checkedChip="@+id/chipProgress"
-                            app:layout_constraintTop_toBottomOf="@id/imgFestagoLogo"
-                            app:selectionRequired="true"
-                            app:singleSelection="true">
+                            android:orientation="vertical">
 
-                            <com.google.android.material.chip.Chip
-                                android:id="@+id/chipProgress"
-                                style="@style/chipFesta"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/festival_list_chip_progress" />
+                            <ImageView
+                                android:id="@+id/imgFestagoLogo"
+                                android:layout_width="160dp"
+                                android:layout_height="45dp"
+                                android:layout_marginStart="12dp"
+                                android:layout_marginTop="12dp"
+                                android:src="@drawable/img_festago_home_logo"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toTopOf="parent"
+                                android:importantForAccessibility="no" />
 
-                            <com.google.android.material.chip.Chip
-                                android:id="@+id/chipPlanned"
-                                style="@style/chipFesta"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/festival_list_chip_planned" />
+                            <com.google.android.material.chip.ChipGroup
+                                android:id="@+id/cgFilterOption"
+                                android:layout_width="392dp"
+                                android:layout_height="64dp"
+                                android:paddingHorizontal="16dp"
+                                android:paddingTop="12dp"
+                                app:checkedChip="@+id/chipProgress"
+                                app:layout_constraintTop_toBottomOf="@id/imgFestagoLogo"
+                                app:selectionRequired="true"
+                                app:singleSelection="true"
+                                tools:layout_editor_absoluteX="3dp">
 
-                            <com.google.android.material.chip.Chip
-                                android:id="@+id/chipEnd"
-                                style="@style/chipFesta"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/festival_list_chip_end" />
-                        </com.google.android.material.chip.ChipGroup>
-                    </androidx.constraintlayout.widget.ConstraintLayout>
+                                <com.google.android.material.chip.Chip
+                                    android:id="@+id/chipProgress"
+                                    style="@style/chipFesta"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/festival_list_chip_progress" />
+
+                                <com.google.android.material.chip.Chip
+                                    android:id="@+id/chipPlanned"
+                                    style="@style/chipFesta"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/festival_list_chip_planned" />
+
+                                <com.google.android.material.chip.Chip
+                                    android:id="@+id/chipEnd"
+                                    style="@style/chipFesta"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/festival_list_chip_end" />
+
+                            </com.google.android.material.chip.ChipGroup>
+                        </androidx.appcompat.widget.LinearLayoutCompat>
+                    </androidx.appcompat.widget.Toolbar>
                 </com.google.android.material.appbar.CollapsingToolbarLayout>
             </com.google.android.material.appbar.AppBarLayout>
 
@@ -85,7 +95,6 @@
                 android:id="@+id/srlFestivalList"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_marginTop="12dp"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
                 <androidx.recyclerview.widget.RecyclerView
@@ -98,6 +107,7 @@
                     app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
                     app:spanCount="2"
                     tools:listitem="@layout/item_festival_list" />
+
             </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/android/festago/app/src/main/res/layout/fragment_festival_list.xml
+++ b/android/festago/app/src/main/res/layout/fragment_festival_list.xml
@@ -22,8 +22,7 @@
 
             <com.google.android.material.appbar.AppBarLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="#00000000">
+                android:layout_height="wrap_content">
 
                 <com.google.android.material.appbar.CollapsingToolbarLayout
                     android:layout_width="match_parent"
@@ -33,6 +32,7 @@
                     <androidx.appcompat.widget.Toolbar
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:background="?attr/colorSurface"
                         app:contentInsetStart="0dp"
                         app:layout_collapseMode="pin">
 
@@ -44,13 +44,11 @@
                             <ImageView
                                 android:id="@+id/imgFestagoLogo"
                                 android:layout_width="160dp"
-                                android:layout_height="45dp"
+                                android:layout_height="44dp"
                                 android:layout_marginStart="12dp"
                                 android:layout_marginTop="12dp"
-                                android:src="@drawable/img_festago_home_logo"
-                                app:layout_constraintStart_toStartOf="parent"
-                                app:layout_constraintTop_toTopOf="parent"
-                                android:importantForAccessibility="no" />
+                                android:importantForAccessibility="no"
+                                android:src="@drawable/img_festago_home_logo" />
 
                             <com.google.android.material.chip.ChipGroup
                                 android:id="@+id/cgFilterOption"
@@ -59,10 +57,8 @@
                                 android:paddingHorizontal="16dp"
                                 android:paddingTop="12dp"
                                 app:checkedChip="@+id/chipProgress"
-                                app:layout_constraintTop_toBottomOf="@id/imgFestagoLogo"
                                 app:selectionRequired="true"
-                                app:singleSelection="true"
-                                tools:layout_editor_absoluteX="3dp">
+                                app:singleSelection="true">
 
                                 <com.google.android.material.chip.Chip
                                     android:id="@+id/chipProgress"
@@ -116,7 +112,7 @@
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:orientation="horizontal"
-            app:layout_constraintGuide_begin="130dp" />
+            app:layout_constraintGuide_begin="132dp" />
 
         <ProgressBar
             android:id="@+id/pbLoading"

--- a/android/festago/app/src/main/res/layout/fragment_festival_list.xml
+++ b/android/festago/app/src/main/res/layout/fragment_festival_list.xml
@@ -81,27 +81,44 @@
                 </com.google.android.material.appbar.CollapsingToolbarLayout>
             </com.google.android.material.appbar.AppBarLayout>
 
-        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-            android:id="@+id/srlFestivalList"
+            <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+                android:id="@+id/srlFestivalList"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginTop="12dp"
+                app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rvFestivalList"
+                    visibility="@{uiState.shouldShowSuccess}"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:clipToPadding="false"
+                    android:padding="8dp"
+                    app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                    app:spanCount="2"
+                    tools:listitem="@layout/item_festival_list" />
+            </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/glFestivalListTop"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_begin="130dp" />
+
+        <ProgressBar
+            android:id="@+id/pbLoading"
+            visibility="@{uiState.shouldShowLoading}"
             android:layout_width="wrap_content"
             android:layout_height="0dp"
-            android:layout_marginTop="12dp"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cgFilterOption">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/rvFestivalList"
-                visibility="@{uiState.shouldShowSuccess}"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:clipToPadding="false"
-                android:padding="8dp"
-                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-                app:spanCount="2"
-                tools:listitem="@layout/item_festival_list" />
-        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+            app:layout_constraintTop_toBottomOf="@id/glFestivalListTop"
+            tools:visibility="gone" />
 
         <TextView
             android:id="@+id/tvErrorOrEmpty"
@@ -113,7 +130,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cgFilterOption"
+            app:layout_constraintTop_toBottomOf="@id/glFestivalListTop"
             tools:text="조회된 축제가 없습니다"
             tools:visibility="gone" />
 

--- a/android/festago/app/src/main/res/layout/fragment_festival_list.xml
+++ b/android/festago/app/src/main/res/layout/fragment_festival_list.xml
@@ -15,59 +15,71 @@
         android:layout_height="match_parent"
         tools:context=".presentation.ui.home.festivallist.FestivalListFragment">
 
-        <ImageView
-            android:id="@+id/imgFestagoLogo"
-            android:layout_width="160dp"
-            android:layout_height="45dp"
-            android:layout_marginStart="12dp"
-            android:layout_marginTop="12dp"
-            android:src="@drawable/img_festago_home_logo"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <com.google.android.material.chip.ChipGroup
-            android:id="@+id/cgFilterOption"
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingHorizontal="16dp"
-            android:paddingTop="12dp"
-            app:checkedChip="@+id/chipProgress"
-            app:layout_constraintTop_toBottomOf="@id/imgFestagoLogo"
-            app:selectionRequired="true"
-            app:singleSelection="true">
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chipProgress"
-                style="@style/chipFesta"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/festival_list_chip_progress" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chipPlanned"
-                style="@style/chipFesta"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/festival_list_chip_planned" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chipEnd"
-                style="@style/chipFesta"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/festival_list_chip_end" />
-        </com.google.android.material.chip.ChipGroup>
-
-        <ProgressBar
-            android:id="@+id/pbLoading"
-            visibility="@{uiState.shouldShowLoading}"
-            android:layout_width="wrap_content"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/srlFestivalList"
-            app:layout_constraintTop_toBottomOf="@id/cgFilterOption"
-            tools:visibility="gone" />
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.appbar.AppBarLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.google.android.material.appbar.CollapsingToolbarLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/colorSurface"
+                    app:layout_scrollFlags="scroll|enterAlways">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:layout_collapseMode="pin">
+
+                        <ImageView
+                            android:id="@+id/imgFestagoLogo"
+                            android:layout_width="160dp"
+                            android:layout_height="45dp"
+                            android:layout_marginStart="12dp"
+                            android:layout_marginTop="12dp"
+                            android:src="@drawable/img_festago_home_logo"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <com.google.android.material.chip.ChipGroup
+                            android:id="@+id/cgFilterOption"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:paddingHorizontal="16dp"
+                            android:paddingTop="12dp"
+                            app:checkedChip="@+id/chipProgress"
+                            app:layout_constraintTop_toBottomOf="@id/imgFestagoLogo"
+                            app:selectionRequired="true"
+                            app:singleSelection="true">
+
+                            <com.google.android.material.chip.Chip
+                                android:id="@+id/chipProgress"
+                                style="@style/chipFesta"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/festival_list_chip_progress" />
+
+                            <com.google.android.material.chip.Chip
+                                android:id="@+id/chipPlanned"
+                                style="@style/chipFesta"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/festival_list_chip_planned" />
+
+                            <com.google.android.material.chip.Chip
+                                android:id="@+id/chipEnd"
+                                style="@style/chipFesta"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/festival_list_chip_end" />
+                        </com.google.android.material.chip.ChipGroup>
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+                </com.google.android.material.appbar.CollapsingToolbarLayout>
+            </com.google.android.material.appbar.AppBarLayout>
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/srlFestivalList"

--- a/android/festago/app/src/main/res/layout/fragment_festival_list.xml
+++ b/android/festago/app/src/main/res/layout/fragment_festival_list.xml
@@ -22,7 +22,8 @@
 
             <com.google.android.material.appbar.AppBarLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:background="#00000000">
 
                 <com.google.android.material.appbar.CollapsingToolbarLayout
                     android:layout_width="match_parent"
@@ -32,7 +33,6 @@
                     <androidx.appcompat.widget.Toolbar
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:background="?attr/colorSurface"
                         app:contentInsetStart="0dp"
                         app:layout_collapseMode="pin">
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #614 

## ✨ PR 세부 내용

홈 화면 UX 개선 완료했습니다.
Coordinator layout 을 사용했습니다.
CollapsiongToolbarLayout 의 collapseMode 를 pin 으로 하고 RecyclerView 에 behavior 를 지정해주어
리사이클러뷰 스크롤 시 상단 바가 접히게됩니다.

또한 enterAlways 로 리사이클러뷰 스크롤이 어느 부분에 있더라도 항상 동작합니다.

## 시연 영상

https://github.com/woowacourse-teams/2023-festa-go/assets/108349655/f753c47c-6127-40b1-b76d-d15aa431b0fa

## 최종 변경

https://github.com/woowacourse-teams/2023-festa-go/assets/108349655/6654874f-d479-434e-ab98-ac2d3aec2eef


