### PR TITLE
[BE] fix: 학생 인증 코드가 유효하지 않을 시 500이 아닌 400 에러를 반환 (#447)

### DIFF
--- a/backend/src/main/java/com/festago/student/domain/VerificationCode.java
+++ b/backend/src/main/java/com/festago/student/domain/VerificationCode.java
@@ -1,12 +1,12 @@
 package com.festago.student.domain;
 
-import com.festago.common.exception.UnexpectedException;
+import com.festago.common.exception.ValidException;
+import com.festago.common.util.Validator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.springframework.util.StringUtils;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,20 +29,18 @@ public class VerificationCode {
     }
 
     private void validateBlank(String value) {
-        if (!StringUtils.hasText(value)) {
-            throw new UnexpectedException("VerificationCode는 null 또는 공백이 될 수 없습니다.");
-        }
+        Validator.hasBlank(value, "VerificationCode");
     }
 
     private void validateLength(String value) {
         if (value.length() != LENGTH) {
-            throw new UnexpectedException("VerificationCode의 길이는 %d 이어야 합니다.".formatted(LENGTH));
+            throw new ValidException("VerificationCode의 길이는 %d 이어야 합니다.".formatted(LENGTH));
         }
     }
 
     private void validatePositive(String value) {
         if (!POSITIVE_REGEX.matcher(value).matches()) {
-            throw new UnexpectedException("VerificationCode는 0~9의 양수 형식이어야 합니다.");
+            throw new ValidException("VerificationCode는 0~9의 양수 형식이어야 합니다.");
         }
     }
 

--- a/backend/src/test/java/com/festago/student/domain/VerificationCodeTest.java
+++ b/backend/src/test/java/com/festago/student/domain/VerificationCodeTest.java
@@ -3,7 +3,7 @@ package com.festago.student.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.festago.common.exception.UnexpectedException;
+import com.festago.common.exception.ValidException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -18,8 +18,8 @@ class VerificationCodeTest {
     void null_이면_예외() {
         // when & then
         assertThatThrownBy(() -> new VerificationCode(null))
-            .isInstanceOf(UnexpectedException.class)
-            .hasMessage("VerificationCode는 null 또는 공백이 될 수 없습니다.");
+            .isInstanceOf(ValidException.class)
+            .hasMessage("VerificationCode은/는 null 또는 공백이 될 수 없습니다.");
     }
 
     @ParameterizedTest
@@ -27,7 +27,7 @@ class VerificationCodeTest {
     void 길이가_6자리가_아니면_예외(String code) {
         // when & then
         assertThatThrownBy(() -> new VerificationCode(code))
-            .isInstanceOf(UnexpectedException.class)
+            .isInstanceOf(ValidException.class)
             .hasMessage("VerificationCode의 길이는 6 이어야 합니다.");
     }
 
@@ -35,7 +35,7 @@ class VerificationCodeTest {
     void 숫자가_아니면_예외() {
         // when & then
         assertThatThrownBy(() -> new VerificationCode("일이삼사오육"))
-            .isInstanceOf(UnexpectedException.class)
+            .isInstanceOf(ValidException.class)
             .hasMessage("VerificationCode는 0~9의 양수 형식이어야 합니다.");
     }
 
@@ -43,7 +43,7 @@ class VerificationCodeTest {
     void 음수이면_예외() {
         // when & then
         assertThatThrownBy(() -> new VerificationCode("-12345"))
-            .isInstanceOf(UnexpectedException.class)
+            .isInstanceOf(ValidException.class)
             .hasMessage("VerificationCode는 0~9의 양수 형식이어야 합니다.");
     }
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #447 

## ✨ PR 세부 내용

#482 에서 처리해야 했을 기능입니다.
