### PR TITLE
[BE] refactor: JPQL을 사용하는 Repository 메소드를 QueryDsl로 변경 (#627)

### DIFF
--- a/backend/src/main/java/com/festago/stage/repository/StageRepository.java
+++ b/backend/src/main/java/com/festago/stage/repository/StageRepository.java
@@ -1,27 +1,7 @@
 package com.festago.stage.repository;
 
 import com.festago.stage.domain.Stage;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface StageRepository extends JpaRepository<Stage, Long> {
-
-    @Query("""
-        SELECT s FROM Stage s
-        LEFT JOIN FETCH s.tickets t
-        LEFT JOIN FETCH t.ticketAmount
-        WHERE s.festival.id = :festivalId
-        """)
-    List<Stage> findAllDetailByFestivalId(@Param("festivalId") Long festivalId);
-
-    @Query("""
-        SELECT s FROM Stage s
-        LEFT JOIN s.festival f
-        LEFT JOIN f.school sc
-        WHERE s.id = :id
-        """)
-    Optional<Stage> findByIdWithFetch(@Param("id") Long id);
+public interface StageRepository extends JpaRepository<Stage, Long>, StageRepositoryCustom {
 }

--- a/backend/src/main/java/com/festago/stage/repository/StageRepositoryCustom.java
+++ b/backend/src/main/java/com/festago/stage/repository/StageRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.festago.stage.repository;
+
+import com.festago.stage.domain.Stage;
+import java.util.List;
+import java.util.Optional;
+
+public interface StageRepositoryCustom {
+
+    List<Stage> findAllDetailByFestivalId(Long festivalId);
+
+    Optional<Stage> findByIdWithFetch(Long id);
+}

--- a/backend/src/main/java/com/festago/stage/repository/StageRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/festago/stage/repository/StageRepositoryCustomImpl.java
@@ -1,0 +1,35 @@
+package com.festago.stage.repository;
+
+import static com.festago.festival.domain.QFestival.festival;
+import static com.festago.stage.domain.QStage.stage;
+import static com.festago.ticket.domain.QTicket.ticket;
+
+import com.festago.stage.domain.Stage;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class StageRepositoryCustomImpl implements StageRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Stage> findAllDetailByFestivalId(Long festivalId) {
+        return queryFactory.selectFrom(stage)
+                .leftJoin(stage.tickets, ticket).fetchJoin()
+                .leftJoin(ticket.ticketAmount).fetchJoin()
+                .where(stage.festival.id.eq(festivalId))
+                .fetch();
+    }
+
+    @Override
+    public Optional<Stage> findByIdWithFetch(Long id) {
+        return Optional.ofNullable(queryFactory.selectFrom(stage)
+                .leftJoin(stage.festival, festival).fetchJoin()
+                .leftJoin(festival.school).fetchJoin()
+                .where(stage.id.eq(id))
+                .fetchOne());
+    }
+}

--- a/backend/src/main/java/com/festago/stage/repository/StageRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/festago/stage/repository/StageRepositoryCustomImpl.java
@@ -1,8 +1,10 @@
 package com.festago.stage.repository;
 
 import static com.festago.festival.domain.QFestival.festival;
+import static com.festago.school.domain.QSchool.school;
 import static com.festago.stage.domain.QStage.stage;
 import static com.festago.ticket.domain.QTicket.ticket;
+import static com.festago.ticket.domain.QTicketAmount.ticketAmount;
 
 import com.festago.stage.domain.Stage;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -19,7 +21,7 @@ public class StageRepositoryCustomImpl implements StageRepositoryCustom {
     public List<Stage> findAllDetailByFestivalId(Long festivalId) {
         return queryFactory.selectFrom(stage)
                 .leftJoin(stage.tickets, ticket).fetchJoin()
-                .leftJoin(ticket.ticketAmount).fetchJoin()
+                .leftJoin(ticket.ticketAmount, ticketAmount).fetchJoin()
                 .where(stage.festival.id.eq(festivalId))
                 .fetch();
     }
@@ -28,7 +30,7 @@ public class StageRepositoryCustomImpl implements StageRepositoryCustom {
     public Optional<Stage> findByIdWithFetch(Long id) {
         return Optional.ofNullable(queryFactory.selectFrom(stage)
                 .leftJoin(stage.festival, festival).fetchJoin()
-                .leftJoin(festival.school).fetchJoin()
+                .leftJoin(festival.school, school).fetchJoin()
                 .where(stage.id.eq(id))
                 .fetchOne());
     }

--- a/backend/src/main/java/com/festago/student/repository/StudentRepository.java
+++ b/backend/src/main/java/com/festago/student/repository/StudentRepository.java
@@ -2,24 +2,13 @@ package com.festago.student.repository;
 
 import com.festago.member.domain.Member;
 import com.festago.student.domain.Student;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface StudentRepository extends JpaRepository<Student, Long> {
+public interface StudentRepository extends JpaRepository<Student, Long>, StudentRepositoryCustom {
 
     boolean existsByMemberAndSchoolId(Member member, Long schoolId);
 
     boolean existsByUsernameAndSchoolId(String username, Long id);
 
     boolean existsByMemberId(Long id);
-
-    @Query("""
-        SELECT st
-        FROM Student st
-        INNER JOIN FETCH st.school sc
-        WHERE st.member.id = :memberId
-        """)
-    Optional<Student> findByMemberIdWithFetch(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/com/festago/student/repository/StudentRepositoryCustom.java
+++ b/backend/src/main/java/com/festago/student/repository/StudentRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.festago.student.repository;
+
+import com.festago.student.domain.Student;
+import java.util.Optional;
+
+public interface StudentRepositoryCustom {
+
+    Optional<Student> findByMemberIdWithFetch(Long memberId);
+}

--- a/backend/src/main/java/com/festago/student/repository/StudentRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/festago/student/repository/StudentRepositoryCustomImpl.java
@@ -1,0 +1,22 @@
+package com.festago.student.repository;
+
+import static com.festago.student.domain.QStudent.student;
+
+import com.festago.student.domain.Student;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class StudentRepositoryCustomImpl implements StudentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Student> findByMemberIdWithFetch(Long memberId) {
+        return Optional.ofNullable(queryFactory.selectFrom(student)
+                .innerJoin(student.school).fetchJoin()
+                .where(student.member.id.eq(memberId))
+                .fetchOne());
+    }
+}

--- a/backend/src/main/java/com/festago/student/repository/StudentRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/festago/student/repository/StudentRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.festago.student.repository;
 
+import static com.festago.school.domain.QSchool.school;
 import static com.festago.student.domain.QStudent.student;
 
 import com.festago.student.domain.Student;
@@ -15,7 +16,7 @@ public class StudentRepositoryCustomImpl implements StudentRepositoryCustom {
     @Override
     public Optional<Student> findByMemberIdWithFetch(Long memberId) {
         return Optional.ofNullable(queryFactory.selectFrom(student)
-                .innerJoin(student.school).fetchJoin()
+                .innerJoin(student.school, school).fetchJoin()
                 .where(student.member.id.eq(memberId))
                 .fetchOne());
     }

--- a/backend/src/main/java/com/festago/ticket/repository/TicketAmountRepository.java
+++ b/backend/src/main/java/com/festago/ticket/repository/TicketAmountRepository.java
@@ -1,16 +1,7 @@
 package com.festago.ticket.repository;
 
 import com.festago.ticket.domain.TicketAmount;
-import jakarta.persistence.LockModeType;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface TicketAmountRepository extends JpaRepository<TicketAmount, Long> {
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select ta from TicketAmount ta where ta.id = :ticketId")
-    Optional<TicketAmount> findByTicketIdForUpdate(@Param("ticketId") Long ticketId);
+public interface TicketAmountRepository extends JpaRepository<TicketAmount, Long>, TicketAmountRepositoryCustom {
 }

--- a/backend/src/main/java/com/festago/ticket/repository/TicketAmountRepositoryCustom.java
+++ b/backend/src/main/java/com/festago/ticket/repository/TicketAmountRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.festago.ticket.repository;
+
+import com.festago.ticket.domain.TicketAmount;
+import java.util.Optional;
+
+public interface TicketAmountRepositoryCustom {
+
+    Optional<TicketAmount> findByTicketIdForUpdate(Long ticketId);
+}

--- a/backend/src/main/java/com/festago/ticket/repository/TicketAmountRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/festago/ticket/repository/TicketAmountRepositoryCustomImpl.java
@@ -1,0 +1,23 @@
+package com.festago.ticket.repository;
+
+import static com.festago.ticket.domain.QTicketAmount.ticketAmount;
+
+import com.festago.ticket.domain.TicketAmount;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TicketAmountRepositoryCustomImpl implements TicketAmountRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<TicketAmount> findByTicketIdForUpdate(Long ticketId) {
+        return Optional.ofNullable(queryFactory.selectFrom(ticketAmount)
+                .where(ticketAmount.id.eq(ticketId))
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .fetchOne());
+    }
+}

--- a/backend/src/main/java/com/festago/ticket/repository/TicketRepository.java
+++ b/backend/src/main/java/com/festago/ticket/repository/TicketRepository.java
@@ -3,28 +3,10 @@ package com.festago.ticket.repository;
 import com.festago.stage.domain.Stage;
 import com.festago.ticket.domain.Ticket;
 import com.festago.ticket.domain.TicketType;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface TicketRepository extends JpaRepository<Ticket, Long> {
-
-    @Query("""
-            SELECT t from Ticket t
-            INNER JOIN FETCH t.ticketAmount
-            WHERE t.stage.id = :stageId
-        """)
-    List<Ticket> findAllByStageIdWithFetch(@Param("stageId") Long stageId);
+public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketRepositoryCustom {
 
     Optional<Ticket> findByTicketTypeAndStage(TicketType ticketType, Stage stage);
-
-    @Query("""
-        SELECT t FROM Ticket t
-        JOIN FETCH t.stage s
-        JOIN FETCH t.ticketEntryTimes et
-        WHERE t.id = :ticketId
-        """)
-    Optional<Ticket> findByIdWithFetch(@Param("ticketId") Long ticketId);
 }

--- a/backend/src/main/java/com/festago/ticket/repository/TicketRepositoryCustom.java
+++ b/backend/src/main/java/com/festago/ticket/repository/TicketRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.festago.ticket.repository;
+
+import com.festago.ticket.domain.Ticket;
+import java.util.List;
+import java.util.Optional;
+
+public interface TicketRepositoryCustom {
+
+    List<Ticket> findAllByStageIdWithFetch(Long stageId);
+
+    Optional<Ticket> findByIdWithFetch(Long ticketId);
+}

--- a/backend/src/main/java/com/festago/ticket/repository/TicketRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/festago/ticket/repository/TicketRepositoryCustomImpl.java
@@ -1,0 +1,32 @@
+package com.festago.ticket.repository;
+
+import static com.festago.ticket.domain.QTicket.ticket;
+
+import com.festago.ticket.domain.Ticket;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TicketRepositoryCustomImpl implements TicketRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Ticket> findAllByStageIdWithFetch(Long stageId) {
+        return queryFactory.selectFrom(ticket)
+                .innerJoin(ticket.ticketAmount).fetchJoin()
+                .where(ticket.stage.id.eq(stageId))
+                .fetch();
+    }
+
+    @Override
+    public Optional<Ticket> findByIdWithFetch(Long ticketId) {
+        return Optional.ofNullable(queryFactory.selectFrom(ticket)
+                .join(ticket.stage).fetchJoin()
+                .join(ticket.ticketEntryTimes).fetchJoin()
+                .where(ticket.id.eq(ticketId))
+                .fetchOne());
+    }
+}

--- a/backend/src/main/java/com/festago/ticket/repository/TicketRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/festago/ticket/repository/TicketRepositoryCustomImpl.java
@@ -1,6 +1,8 @@
 package com.festago.ticket.repository;
 
+import static com.festago.stage.domain.QStage.stage;
 import static com.festago.ticket.domain.QTicket.ticket;
+import static com.festago.ticket.domain.QTicketEntryTime.ticketEntryTime;
 
 import com.festago.ticket.domain.Ticket;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -24,8 +26,8 @@ public class TicketRepositoryCustomImpl implements TicketRepositoryCustom {
     @Override
     public Optional<Ticket> findByIdWithFetch(Long ticketId) {
         return Optional.ofNullable(queryFactory.selectFrom(ticket)
-                .join(ticket.stage).fetchJoin()
-                .join(ticket.ticketEntryTimes).fetchJoin()
+                .innerJoin(ticket.stage, stage).fetchJoin()
+                .innerJoin(ticket.ticketEntryTimes, ticketEntryTime).fetchJoin()
                 .where(ticket.id.eq(ticketId))
                 .fetchOne());
     }


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #627 

## ✨ PR 세부 내용

일단 모든 JPQL을 옮겼는데 사실 클래스가 2개가 늘어나니 이게 맞나? 싶기도 하고 미리 처내는게 좋겠다는 생각도 들더라고요.
컨벤션 같은 부분도 자의적인 부분이 있으니 여러분이 보시기에 합리적이지 않다 싶은 부분, 생각해보면 좋겠다 싶은 부분은 편하게 의견 남겨주세요.
코드단에도 코멘트를 남기겠습니다.