### PR TITLE
[BE] feat: 어드민 비밀번호 암호화하여 저장 (#631)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+    // Spring Security
+    implementation 'org.springframework.security:spring-security-crypto'
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/backend/src/main/java/com/festago/admin/repository/AdminRepository.java
+++ b/backend/src/main/java/com/festago/admin/repository/AdminRepository.java
@@ -2,9 +2,13 @@ package com.festago.admin.repository;
 
 import com.festago.admin.domain.Admin;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
 
-public interface AdminRepository extends JpaRepository<Admin, Long> {
+public interface AdminRepository extends Repository<Admin, Long> {
+
+    Admin save(Admin admin);
+
+    Optional<Admin> findById(Long adminId);
 
     Optional<Admin> findByUsername(String username);
 

--- a/backend/src/main/java/com/festago/auth/config/AuthConfig.java
+++ b/backend/src/main/java/com/festago/auth/config/AuthConfig.java
@@ -10,6 +10,8 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class AuthConfig {
@@ -37,5 +39,10 @@ public class AuthConfig {
     @Bean
     public AuthExtractor authExtractor() {
         return new JwtAuthExtractor(secretKey);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/backend/src/main/java/com/festago/auth/config/AuthConfig.java
+++ b/backend/src/main/java/com/festago/auth/config/AuthConfig.java
@@ -10,7 +10,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
@@ -43,6 +43,6 @@ public class AuthConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/backend/src/test/java/com/festago/admin/repository/MemoryAdminRepository.java
+++ b/backend/src/test/java/com/festago/admin/repository/MemoryAdminRepository.java
@@ -1,31 +1,21 @@
 package com.festago.admin.repository;
 
 import com.festago.admin.domain.Admin;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class MemoryAdminRepository implements AdminRepository {
 
-    private final Map<Long, Admin> memory = new HashMap<>();
-    private final AtomicLong autoIncrement = new AtomicLong(1);
+    private final ConcurrentHashMap<Long, Admin> memory = new ConcurrentHashMap<>();
+    private final AtomicLong autoIncrement = new AtomicLong();
 
     @Override
     public Admin save(Admin admin) {
-        if (admin.getId() != null) {
-            memory.put(admin.getId(), admin);
-            return admin;
-        }
-        while (true) {
-            long id = autoIncrement.get();
-            if (!memory.containsKey(id)) {
-                memory.put(id, admin);
-                return admin;
-            }
-            autoIncrement.incrementAndGet();
-        }
+        long id = autoIncrement.incrementAndGet();
+        memory.put(id, new Admin(id, admin.getUsername(), admin.getPassword()));
+        return memory.get(id);
     }
 
     @Override

--- a/backend/src/test/java/com/festago/admin/repository/MemoryAdminRepository.java
+++ b/backend/src/test/java/com/festago/admin/repository/MemoryAdminRepository.java
@@ -1,0 +1,48 @@
+package com.festago.admin.repository;
+
+import com.festago.admin.domain.Admin;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MemoryAdminRepository implements AdminRepository {
+
+    private final Map<Long, Admin> memory = new HashMap<>();
+    private final AtomicLong autoIncrement = new AtomicLong(1);
+
+    @Override
+    public Admin save(Admin admin) {
+        if (admin.getId() != null) {
+            memory.put(admin.getId(), admin);
+            return admin;
+        }
+        while (true) {
+            long id = autoIncrement.get();
+            if (!memory.containsKey(id)) {
+                memory.put(id, admin);
+                return admin;
+            }
+            autoIncrement.incrementAndGet();
+        }
+    }
+
+    @Override
+    public Optional<Admin> findById(Long adminId) {
+        return Optional.ofNullable(memory.get(adminId));
+    }
+
+    @Override
+    public Optional<Admin> findByUsername(String username) {
+        return memory.values().stream()
+            .filter(admin -> Objects.equals(admin.getUsername(), username))
+            .findAny();
+    }
+
+    @Override
+    public boolean existsByUsername(String username) {
+        return memory.values().stream()
+            .anyMatch(admin -> Objects.equals(admin.getUsername(), username));
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #631

## ✨ PR 세부 내용

슬랙에서 얘기했던 [Spring Security Crypto](https://mvnrepository.com/artifact/org.springframework.security/spring-security-crypto) 라이브러리를 적용하였습니다.

`AuthService`가 가지는 암호화에 대한 의존성은 `PasswordEncoder` 인터페이스를 사용하였습니다.
따라서 테스트, 암호화 알고리즘의 변경에 대해서 유연하게 대응할 수 있도록 하였습니다.

`AuthConfig`에서 `PasswordEncoder` 구현체를 빈으로 등록하는데, 여기서 사용한 구현체는 `DelegatingPasswordEncoder` 클래스 입니다.

해당 구현체를 사용하여 비밀번호를 암호화하면 `{bcrypt}$2a$10$dXJ3...`과 같이 "{알고리즘}" 접두사가 붙습니다.
따라서 새로운 암호화 알고리즘을 적용했을 때, 기존 DB에 저장된 비밀번호를 호환시킬 때 문제가 발생될 여지를 없앨 수 있습니다.
자세한 내용은 [링크](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/crypto/password/DelegatingPasswordEncoder.html) 참조하시면 될 것 같습니다.

테스트 코드에서 구체적인 암호화 알고리즘은 필요하지 않으므로, 평문으로 저장되게 하는 "{noop}"를 사용하였습니다.

추가적으로 `PasswordEncoder`를 빈으로 등록할 때 `DelegatingPasswordEncoder.setDefaultPasswordEncoderForMatches()` 메서드를 사용하여, 알고리즘 접두사가 붙지 않은 비밀번호에 대해 기본적으로 사용할 알고리즘을 적용할 수 있는데, DB에 암호화된 비밀번호가 저장되어 있지 않으므로 해당 사항은 적용하지 않았습니다.