### PR TITLE
[BE] feat: CI workflow에 캐싱 및 버전 업데이트 적용 (#633)

### DIFF
--- a/.github/workflows/ci-back.yml
+++ b/.github/workflows/ci-back.yml
@@ -40,8 +40,8 @@ jobs:
       - name: assign grant gradlew
         run: chmod +x gradlew
 
-      - name: build with gradle
-        run: ./gradlew build
+      - name: Test with gradle
+        run: ./gradlew --info test
 
       - name: 테스트 결과 PR에 커멘트 등록
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/ci-back.yml
+++ b/.github/workflows/ci-back.yml
@@ -1,4 +1,4 @@
-name: CI-Back
+name: CI Back
 
 on:
   pull_request:
@@ -15,13 +15,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: repository checkout
+      - name: Repository checkout
         uses: actions/checkout@v3
         with:
           submodules: recursive
           token: ${{ secrets.SUBMODULE_TOKEN }}
 
-      - name: install java 17
+      - name: Setup java 17
         uses: actions/setup-java@v3
         with:
           java-version: 17
@@ -37,20 +37,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: assign grant gradlew
+      - name: Assign grant gradlew
         run: chmod +x gradlew
 
       - name: Test with gradle
         run: ./gradlew --info test
 
-      - name: 테스트 결과 PR에 커멘트 등록
-        uses: EnricoMi/publish-unit-test-result-action@v1
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: '**/build/test-results/test/TEST-*.xml'
 
-      - name: 테스트 실패 Check 코멘트 등록
-        uses: mikepenz/action-junit-report@v3
+      - name: Publish test report
+        uses: mikepenz/action-junit-report@v4
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/ci-back.yml
+++ b/.github/workflows/ci-back.yml
@@ -54,4 +54,3 @@ jobs:
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          token: ${{ github.token }}

--- a/.github/workflows/ci-back.yml
+++ b/.github/workflows/ci-back.yml
@@ -27,6 +27,16 @@ jobs:
           java-version: 17
           distribution: 'zulu'
 
+      - name: Cache gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: assign grant gradlew
         run: chmod +x gradlew
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #633

## ✨ PR 세부 내용

`Cache Gradle packages` job을 통해 캐싱을 수행하여 실행 시간을 단축시켰습니다.
`gradlew build` 대신 `gradlew test`를 사용하여, 오버헤드를 줄였습니다.
자세한 변경 이력은 커밋 참조하시면 될 것 같습니다.