### PR TITLE
[BE] feat: CD 작업 수행 시, 기존 CD 작업의 실행을 취소하여 동시에 CD가 되는 것을 방지 (#641)

### DIFF
--- a/.github/workflows/cd-back-dev.yml
+++ b/.github/workflows/cd-back-dev.yml
@@ -5,8 +5,11 @@ on:
     branches:
       - dev
     paths: 'backend/**'
-
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 defaults:
   run:


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #641 

## ✨ PR 세부 내용

이슈 내용 그대로 입니다.
동시에 PR을 머지하는 상황에서 CD 작업이 여러 번 실행되지 않게 `concurrency` 설정을 추가했습니다.
