### PR TITLE
refactor: Repository 개선 및 서비스 단위 테스트 Fake 사용 (#648)

### DIFF
--- a/backend/src/main/java/com/festago/auth/application/AuthService.java
+++ b/backend/src/main/java/com/festago/auth/application/AuthService.java
@@ -33,6 +33,7 @@ public class AuthService {
         return memberRepository.save(userInfo.toMember());
     }
 
+    // TODO FCM 삭제를 위해 DeleteMemberEvent 발행 고려
     public void deleteMember(Long memberId) {
         Member member = memberRepository.getOrThrow(memberId);
         logDeleteMember(member);

--- a/backend/src/main/java/com/festago/auth/application/AuthService.java
+++ b/backend/src/main/java/com/festago/auth/application/AuthService.java
@@ -2,8 +2,6 @@ package com.festago.auth.application;
 
 import com.festago.auth.domain.UserInfo;
 import com.festago.auth.dto.LoginMemberDto;
-import com.festago.common.exception.ErrorCode;
-import com.festago.common.exception.NotFoundException;
 import com.festago.member.domain.Member;
 import com.festago.member.repository.MemberRepository;
 import java.util.Optional;
@@ -36,8 +34,7 @@ public class AuthService {
     }
 
     public void deleteMember(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = memberRepository.getOrThrow(memberId);
         logDeleteMember(member);
         memberRepository.delete(member);
     }

--- a/backend/src/main/java/com/festago/entry/domain/EntryCodePayload.java
+++ b/backend/src/main/java/com/festago/entry/domain/EntryCodePayload.java
@@ -4,6 +4,7 @@ import com.festago.common.exception.UnexpectedException;
 import com.festago.ticketing.domain.EntryState;
 import com.festago.ticketing.domain.MemberTicket;
 
+// TODO Record 클래스로 바꿔도 좋을듯
 public class EntryCodePayload {
 
     private final Long memberTicketId;

--- a/backend/src/main/java/com/festago/fcm/application/MemberFCMService.java
+++ b/backend/src/main/java/com/festago/fcm/application/MemberFCMService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class MemberFCMService {
 
+    // TODO @Slf4j 어노테이션 사용하면 어떨까요
     private static final Logger log = LoggerFactory.getLogger(MemberFCMService.class);
 
     private final MemberFCMRepository memberFCMRepository;
@@ -36,6 +37,10 @@ public class MemberFCMService {
         return MemberFCMsResponse.from(memberFCM);
     }
 
+    // TODO 사용하지 않는 메서드 같음
+    // 비즈니스 파라미터의 isNewMember가 애매한 것 같음.
+    // 다른 회원이 같은 FCM 토큰을 저장하면??
+    // existsByFcmToken으로 Validation 고려해도 좋을듯 ex) 이미 사용중인 토큰입니다.
     @Async
     public void saveMemberFCM(boolean isNewMember, String accessToken, String fcmToken) {
         if (isNewMember) {
@@ -63,6 +68,7 @@ public class MemberFCMService {
         return authPayload.getMemberId();
     }
 
+    // TODO 사용하지 않는 메서드 같음
     @Async
     public void deleteMemberFCM(Long memberId) {
         memberFCMRepository.deleteAllByMemberId(memberId);

--- a/backend/src/main/java/com/festago/fcm/repository/MemberFCMRepository.java
+++ b/backend/src/main/java/com/festago/fcm/repository/MemberFCMRepository.java
@@ -3,9 +3,11 @@ package com.festago.fcm.repository;
 import com.festago.fcm.domain.MemberFCM;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
 
-public interface MemberFCMRepository extends JpaRepository<MemberFCM, Long> {
+public interface MemberFCMRepository extends Repository<MemberFCM, Long> {
+
+    MemberFCM save(MemberFCM memberFCM);
 
     List<MemberFCM> findByMemberId(Long memberId);
 

--- a/backend/src/main/java/com/festago/festival/application/FestivalService.java
+++ b/backend/src/main/java/com/festago/festival/application/FestivalService.java
@@ -2,7 +2,6 @@ package com.festago.festival.application;
 
 import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.ErrorCode;
-import com.festago.common.exception.NotFoundException;
 import com.festago.festival.domain.Festival;
 import com.festago.festival.dto.DetailFestivalResponse;
 import com.festago.festival.dto.FestivalCreateRequest;
@@ -32,8 +31,7 @@ public class FestivalService {
     private final Clock clock;
 
     public FestivalResponse create(FestivalCreateRequest request) {
-        School school = schoolRepository.findById(request.schoolId())
-            .orElseThrow(() -> new NotFoundException(ErrorCode.SCHOOL_NOT_FOUND));
+        School school = schoolRepository.getOrThrow(request.schoolId());
         Festival festival = request.toEntity(school);
         validate(festival);
         return FestivalResponse.from(festivalRepository.save(festival));
@@ -56,13 +54,8 @@ public class FestivalService {
         return festivalStageService.findDetail(festivalId);
     }
 
-    private Festival findFestival(Long festivalId) {
-        return festivalRepository.findById(festivalId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.FESTIVAL_NOT_FOUND));
-    }
-
     public void update(Long festivalId, FestivalUpdateRequest request) {
-        Festival festival = findFestival(festivalId);
+        Festival festival = festivalRepository.getOrThrow(festivalId);
         festival.changeName(request.name());
         festival.changeThumbnail(request.thumbnail());
         festival.changeDate(request.startDate(), request.endDate());

--- a/backend/src/main/java/com/festago/festival/application/FestivalService.java
+++ b/backend/src/main/java/com/festago/festival/application/FestivalService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class FestivalService {
 
     private final FestivalRepository festivalRepository;
+    // TODO FestivalStageService를 FestivalController가 의존하게 하는게 좋을듯?
     private final FestivalStageService festivalStageService;
     private final SchoolRepository schoolRepository;
     private final Clock clock;

--- a/backend/src/main/java/com/festago/festival/repository/FestivalRepository.java
+++ b/backend/src/main/java/com/festago/festival/repository/FestivalRepository.java
@@ -3,12 +3,21 @@ package com.festago.festival.repository;
 import com.festago.common.exception.ErrorCode;
 import com.festago.common.exception.NotFoundException;
 import com.festago.festival.domain.Festival;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
 
-public interface FestivalRepository extends JpaRepository<Festival, Long>, FestivalRepositoryCustom {
+public interface FestivalRepository extends Repository<Festival, Long>, FestivalRepositoryCustom {
 
     default Festival getOrThrow(Long festivalId) {
         return findById(festivalId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.FESTIVAL_NOT_FOUND));
     }
+
+    Festival save(Festival festival);
+
+    Optional<Festival> findById(Long id);
+
+    void deleteById(Long festivalId);
+
+    void flush();
 }

--- a/backend/src/main/java/com/festago/festival/repository/FestivalRepository.java
+++ b/backend/src/main/java/com/festago/festival/repository/FestivalRepository.java
@@ -1,8 +1,14 @@
 package com.festago.festival.repository;
 
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
 import com.festago.festival.domain.Festival;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FestivalRepository extends JpaRepository<Festival, Long>, FestivalRepositoryCustom {
 
+    default Festival getOrThrow(Long festivalId) {
+        return findById(festivalId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.FESTIVAL_NOT_FOUND));
+    }
 }

--- a/backend/src/main/java/com/festago/member/application/MemberService.java
+++ b/backend/src/main/java/com/festago/member/application/MemberService.java
@@ -1,7 +1,5 @@
 package com.festago.member.application;
 
-import com.festago.common.exception.ErrorCode;
-import com.festago.common.exception.NotFoundException;
 import com.festago.member.domain.Member;
 import com.festago.member.dto.MemberProfileResponse;
 import com.festago.member.repository.MemberRepository;
@@ -18,8 +16,7 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public MemberProfileResponse findMemberProfile(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = memberRepository.getOrThrow(memberId);
         return MemberProfileResponse.from(member);
     }
 }

--- a/backend/src/main/java/com/festago/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/festago/member/repository/MemberRepository.java
@@ -5,14 +5,22 @@ import com.festago.common.exception.ErrorCode;
 import com.festago.common.exception.NotFoundException;
 import com.festago.member.domain.Member;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends Repository<Member, Long> {
 
     default Member getOrThrow(Long memberId) {
         return findById(memberId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
+    Member save(Member member);
+
+    Optional<Member> findById(Long id);
+
     Optional<Member> findBySocialIdAndSocialType(String socialId, SocialType socialType);
+
+    void delete(Member member);
+
+    long count();
 }

--- a/backend/src/main/java/com/festago/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/festago/member/repository/MemberRepository.java
@@ -1,11 +1,18 @@
 package com.festago.member.repository;
 
 import com.festago.auth.domain.SocialType;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
 import com.festago.member.domain.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    default Member getOrThrow(Long memberId) {
+        return findById(memberId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+    }
 
     Optional<Member> findBySocialIdAndSocialType(String socialId, SocialType socialType);
 }

--- a/backend/src/main/java/com/festago/school/application/SchoolService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolService.java
@@ -2,7 +2,6 @@ package com.festago.school.application;
 
 import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.ErrorCode;
-import com.festago.common.exception.NotFoundException;
 import com.festago.school.domain.School;
 import com.festago.school.dto.SchoolCreateRequest;
 import com.festago.school.dto.SchoolResponse;
@@ -28,12 +27,7 @@ public class SchoolService {
 
     @Transactional(readOnly = true)
     public SchoolResponse findById(Long id) {
-        return SchoolResponse.from(findSchool(id));
-    }
-
-    private School findSchool(Long id) {
-        return schoolRepository.findById(id)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.SCHOOL_NOT_FOUND));
+        return SchoolResponse.from(schoolRepository.getOrThrow(id));
     }
 
     public SchoolResponse create(SchoolCreateRequest request) {
@@ -51,7 +45,7 @@ public class SchoolService {
     }
 
     public void update(Long schoolId, SchoolUpdateRequest request) {
-        School school = findSchool(schoolId);
+        School school = schoolRepository.getOrThrow(schoolId);
         school.changeName(request.name());
         school.changeDomain(request.domain());
     }

--- a/backend/src/main/java/com/festago/school/repository/SchoolRepository.java
+++ b/backend/src/main/java/com/festago/school/repository/SchoolRepository.java
@@ -1,9 +1,16 @@
 package com.festago.school.repository;
 
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
 import com.festago.school.domain.School;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SchoolRepository extends JpaRepository<School, Long> {
+
+    default School getOrThrow(Long schoolId) {
+        return findById(schoolId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.SCHOOL_NOT_FOUND));
+    }
 
     boolean existsByDomainOrName(String domain, String name);
 }

--- a/backend/src/main/java/com/festago/school/repository/SchoolRepository.java
+++ b/backend/src/main/java/com/festago/school/repository/SchoolRepository.java
@@ -3,14 +3,26 @@ package com.festago.school.repository;
 import com.festago.common.exception.ErrorCode;
 import com.festago.common.exception.NotFoundException;
 import com.festago.school.domain.School;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
 
-public interface SchoolRepository extends JpaRepository<School, Long> {
+public interface SchoolRepository extends Repository<School, Long> {
 
     default School getOrThrow(Long schoolId) {
         return findById(schoolId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.SCHOOL_NOT_FOUND));
     }
 
+    School save(School school);
+
+    Optional<School> findById(Long id);
+
     boolean existsByDomainOrName(String domain, String name);
+
+    List<School> findAll();
+
+    void deleteById(Long schoolId);
+
+    void flush();
 }

--- a/backend/src/main/java/com/festago/stage/application/FestivalStageServiceImpl.java
+++ b/backend/src/main/java/com/festago/stage/application/FestivalStageServiceImpl.java
@@ -4,8 +4,6 @@ import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
 
-import com.festago.common.exception.ErrorCode;
-import com.festago.common.exception.NotFoundException;
 import com.festago.festival.application.FestivalStageService;
 import com.festago.festival.domain.Festival;
 import com.festago.festival.dto.DetailFestivalResponse;
@@ -31,7 +29,7 @@ public class FestivalStageServiceImpl implements FestivalStageService {
     @Transactional(readOnly = true)
     @Override
     public DetailFestivalResponse findDetail(Long festivalId) {
-        Festival festival = findFestival(festivalId);
+        Festival festival = festivalRepository.getOrThrow(festivalId);
         return stageRepository.findAllDetailByFestivalId(festivalId).stream()
             .sorted(comparing(Stage::getStartTime))
             .map(this::createResponse)
@@ -47,11 +45,6 @@ public class FestivalStageServiceImpl implements FestivalStageService {
                     stageResponses
                 )
             ));
-    }
-
-    private Festival findFestival(Long festivalId) {
-        return festivalRepository.findById(festivalId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.FESTIVAL_NOT_FOUND));
     }
 
     private DetailStageResponse createResponse(Stage stage) {

--- a/backend/src/main/java/com/festago/stage/application/StageService.java
+++ b/backend/src/main/java/com/festago/stage/application/StageService.java
@@ -2,7 +2,6 @@ package com.festago.stage.application;
 
 import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.ErrorCode;
-import com.festago.common.exception.NotFoundException;
 import com.festago.festival.domain.Festival;
 import com.festago.festival.repository.FestivalRepository;
 import com.festago.stage.domain.Stage;
@@ -24,7 +23,7 @@ public class StageService {
     private final FestivalRepository festivalRepository;
 
     public StageResponse create(StageCreateRequest request) {
-        Festival festival = findFestival(request.festivalId());
+        Festival festival = festivalRepository.getOrThrow(request.festivalId());
         Stage newStage = stageRepository.save(new Stage(
             request.startTime(),
             request.lineUp(),
@@ -34,23 +33,13 @@ public class StageService {
         return StageResponse.from(newStage);
     }
 
-    private Festival findFestival(Long festivalId) {
-        return festivalRepository.findById(festivalId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.FESTIVAL_NOT_FOUND));
-    }
-
     public StageResponse findDetail(Long stageId) {
-        Stage stage = findStage(stageId);
+        Stage stage = stageRepository.getOrThrow(stageId);
         return StageResponse.from(stage);
     }
 
-    private Stage findStage(Long stageId) {
-        return stageRepository.findById(stageId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.STAGE_NOT_FOUND));
-    }
-
     public void update(Long stageId, StageUpdateRequest request) {
-        Stage stage = findStage(stageId);
+        Stage stage = stageRepository.getOrThrow(stageId);
         stage.changeTime(request.startTime(), request.ticketOpenTime());
         stage.changeLineUp(request.lineUp());
     }

--- a/backend/src/main/java/com/festago/stage/repository/StageRepository.java
+++ b/backend/src/main/java/com/festago/stage/repository/StageRepository.java
@@ -1,7 +1,14 @@
 package com.festago.stage.repository;
 
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
 import com.festago.stage.domain.Stage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StageRepository extends JpaRepository<Stage, Long>, StageRepositoryCustom {
+
+    default Stage getOrThrow(Long stageId) {
+        return findById(stageId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.FESTIVAL_NOT_FOUND));
+    }
 }

--- a/backend/src/main/java/com/festago/stage/repository/StageRepository.java
+++ b/backend/src/main/java/com/festago/stage/repository/StageRepository.java
@@ -3,12 +3,21 @@ package com.festago.stage.repository;
 import com.festago.common.exception.ErrorCode;
 import com.festago.common.exception.NotFoundException;
 import com.festago.stage.domain.Stage;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
 
-public interface StageRepository extends JpaRepository<Stage, Long>, StageRepositoryCustom {
+public interface StageRepository extends Repository<Stage, Long>, StageRepositoryCustom {
 
     default Stage getOrThrow(Long stageId) {
         return findById(stageId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.FESTIVAL_NOT_FOUND));
     }
+
+    Stage save(Stage stage);
+
+    Optional<Stage> findById(Long id);
+
+    void deleteById(Long stageId);
+
+    void flush();
 }

--- a/backend/src/main/java/com/festago/student/application/StudentService.java
+++ b/backend/src/main/java/com/festago/student/application/StudentService.java
@@ -2,7 +2,6 @@ package com.festago.student.application;
 
 import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.ErrorCode;
-import com.festago.common.exception.NotFoundException;
 import com.festago.member.domain.Member;
 import com.festago.member.repository.MemberRepository;
 import com.festago.school.domain.School;
@@ -42,19 +41,9 @@ public class StudentService {
     }
 
     private StudentCode createStudentCode(Long memberId, StudentSendMailRequest request) {
-        Member member = findMember(memberId);
-        School school = findSchool(request.schoolId());
+        Member member = memberRepository.getOrThrow(memberId);
+        School school = schoolRepository.getOrThrow(request.schoolId());
         return new StudentCode(codeProvider.provide(), school, member, request.username(), LocalDateTime.now(clock));
-    }
-
-    private Member findMember(Long memberId) {
-        return memberRepository.findById(memberId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
-    }
-
-    private School findSchool(Long schoolId) {
-        return schoolRepository.findById(schoolId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.SCHOOL_NOT_FOUND));
     }
 
     private void validate(StudentCode studentCode) {
@@ -97,7 +86,7 @@ public class StudentService {
 
     public void verify(Long memberId, StudentVerificateRequest request) {
         validateStudent(memberId);
-        Member member = findMember(memberId);
+        Member member = memberRepository.getOrThrow(memberId);
         VerificationCode verificationCode = new VerificationCode(request.code());
         StudentCode studentCode = studentCodeRepository.findByCodeAndMember(verificationCode, member)
             .orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_STUDENT_VERIFICATION_CODE));

--- a/backend/src/main/java/com/festago/student/repository/StudentCodeRepository.java
+++ b/backend/src/main/java/com/festago/student/repository/StudentCodeRepository.java
@@ -4,9 +4,11 @@ import com.festago.member.domain.Member;
 import com.festago.student.domain.StudentCode;
 import com.festago.student.domain.VerificationCode;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
 
-public interface StudentCodeRepository extends JpaRepository<StudentCode, Long> {
+public interface StudentCodeRepository extends Repository<StudentCode, Long> {
+
+    StudentCode save(StudentCode studentCode);
 
     void deleteByMember(Member member);
 

--- a/backend/src/main/java/com/festago/student/repository/StudentRepository.java
+++ b/backend/src/main/java/com/festago/student/repository/StudentRepository.java
@@ -2,13 +2,18 @@ package com.festago.student.repository;
 
 import com.festago.member.domain.Member;
 import com.festago.student.domain.Student;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
 
-public interface StudentRepository extends JpaRepository<Student, Long>, StudentRepositoryCustom {
+public interface StudentRepository extends Repository<Student, Long>, StudentRepositoryCustom {
 
     boolean existsByMemberAndSchoolId(Member member, Long schoolId);
 
-    boolean existsByUsernameAndSchoolId(String username, Long id);
+    boolean existsByUsernameAndSchoolId(String username, Long schoolId);
 
-    boolean existsByMemberId(Long id);
+    boolean existsByMemberId(Long memberId);
+
+    Student save(Student student);
+
+    Optional<Student> findById(Long id);
 }

--- a/backend/src/main/java/com/festago/ticket/repository/TicketAmountRepository.java
+++ b/backend/src/main/java/com/festago/ticket/repository/TicketAmountRepository.java
@@ -1,7 +1,10 @@
 package com.festago.ticket.repository;
 
 import com.festago.ticket.domain.TicketAmount;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
 
-public interface TicketAmountRepository extends JpaRepository<TicketAmount, Long>, TicketAmountRepositoryCustom {
+public interface TicketAmountRepository extends Repository<TicketAmount, Long>, TicketAmountRepositoryCustom {
+
+    Optional<TicketAmount> findById(Long id);
 }

--- a/backend/src/main/java/com/festago/ticket/repository/TicketRepository.java
+++ b/backend/src/main/java/com/festago/ticket/repository/TicketRepository.java
@@ -4,9 +4,13 @@ import com.festago.stage.domain.Stage;
 import com.festago.ticket.domain.Ticket;
 import com.festago.ticket.domain.TicketType;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
 
-public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketRepositoryCustom {
+public interface TicketRepository extends Repository<Ticket, Long>, TicketRepositoryCustom {
 
     Optional<Ticket> findByTicketTypeAndStage(TicketType ticketType, Stage stage);
+
+    Ticket save(Ticket ticket);
+
+    long count();
 }

--- a/backend/src/main/java/com/festago/ticketing/application/MemberTicketService.java
+++ b/backend/src/main/java/com/festago/ticketing/application/MemberTicketService.java
@@ -4,7 +4,6 @@ import static java.util.Comparator.comparing;
 
 import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.ErrorCode;
-import com.festago.common.exception.NotFoundException;
 import com.festago.ticketing.domain.MemberTicket;
 import com.festago.ticketing.dto.MemberTicketResponse;
 import com.festago.ticketing.dto.MemberTicketsResponse;
@@ -28,8 +27,7 @@ public class MemberTicketService {
 
     @Transactional(readOnly = true)
     public MemberTicketResponse findById(Long memberId, Long memberTicketId) {
-        MemberTicket memberTicket = memberTicketRepository.findById(memberTicketId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_TICKET_NOT_FOUND));
+        MemberTicket memberTicket = memberTicketRepository.getOrThrow(memberTicketId);
         validateOwner(memberTicket, memberId);
         return MemberTicketResponse.from(memberTicket);
     }

--- a/backend/src/main/java/com/festago/ticketing/application/TicketingService.java
+++ b/backend/src/main/java/com/festago/ticketing/application/TicketingService.java
@@ -36,7 +36,7 @@ public class TicketingService {
 
     public TicketingResponse ticketing(Long memberId, TicketingRequest request) {
         Ticket ticket = findTicketById(request.ticketId());
-        Member member = findMemberById(memberId);
+        Member member = memberRepository.getOrThrow(memberId);
         validateAlreadyReserved(member, ticket);
         validateStudent(member, ticket);
         ReservationSequence sequence = getReserveSequence(request.ticketId());
@@ -49,11 +49,6 @@ public class TicketingService {
     private Ticket findTicketById(Long ticketId) {
         return ticketRepository.findByIdWithFetch(ticketId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.TICKET_NOT_FOUND));
-    }
-
-    private Member findMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
     private void validateAlreadyReserved(Member member, Ticket ticket) {

--- a/backend/src/main/java/com/festago/ticketing/repository/MemberTicketRepository.java
+++ b/backend/src/main/java/com/festago/ticketing/repository/MemberTicketRepository.java
@@ -1,5 +1,7 @@
 package com.festago.ticketing.repository;
 
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
 import com.festago.member.domain.Member;
 import com.festago.stage.domain.Stage;
 import com.festago.ticketing.domain.MemberTicket;
@@ -8,6 +10,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberTicketRepository extends JpaRepository<MemberTicket, Long> {
+
+    default MemberTicket getOrThrow(Long memberTicketId) {
+        return findById(memberTicketId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_TICKET_NOT_FOUND));
+    }
 
     List<MemberTicket> findAllByOwnerId(Long memberId, Pageable pageable);
 

--- a/backend/src/main/java/com/festago/ticketing/repository/MemberTicketRepository.java
+++ b/backend/src/main/java/com/festago/ticketing/repository/MemberTicketRepository.java
@@ -6,17 +6,24 @@ import com.festago.member.domain.Member;
 import com.festago.stage.domain.Stage;
 import com.festago.ticketing.domain.MemberTicket;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
 
-public interface MemberTicketRepository extends JpaRepository<MemberTicket, Long> {
+public interface MemberTicketRepository extends Repository<MemberTicket, Long> {
 
     default MemberTicket getOrThrow(Long memberTicketId) {
         return findById(memberTicketId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_TICKET_NOT_FOUND));
     }
 
+    MemberTicket save(MemberTicket memberTicket);
+
+    Optional<MemberTicket> findById(Long id);
+
     List<MemberTicket> findAllByOwnerId(Long memberId, Pageable pageable);
 
     boolean existsByOwnerAndStage(Member owner, Stage stage);
+
+    long count();
 }

--- a/backend/src/test/java/com/festago/auth/application/AdminAuthServiceTest.java
+++ b/backend/src/test/java/com/festago/auth/application/AdminAuthServiceTest.java
@@ -8,9 +8,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
+import static org.mockito.Mockito.reset;
 
 import com.festago.admin.domain.Admin;
-import com.festago.admin.repository.AdminRepository;
 import com.festago.admin.repository.MemoryAdminRepository;
 import com.festago.auth.dto.AdminLoginRequest;
 import com.festago.auth.dto.AdminSignupRequest;
@@ -29,17 +29,20 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 @SuppressWarnings("NonAsciiCharacters")
 class AdminAuthServiceTest {
 
-    AdminRepository adminRepository;
+    AuthProvider authProvider = mock();
 
-    AuthProvider authProvider = mock(AuthProvider.class);
+    MemoryAdminRepository adminRepository = new MemoryAdminRepository();
 
-    AdminAuthService adminAuthService;
+    AdminAuthService adminAuthService = new AdminAuthService(
+        authProvider,
+        adminRepository,
+        PasswordEncoderFactories.createDelegatingPasswordEncoder()
+    );
 
     @BeforeEach
     void setUp() {
-        adminRepository = new MemoryAdminRepository();
-        adminAuthService = new AdminAuthService(authProvider, adminRepository,
-            PasswordEncoderFactories.createDelegatingPasswordEncoder());
+        adminRepository.clear();
+        reset(authProvider);
     }
 
     @Nested

--- a/backend/src/test/java/com/festago/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/festago/auth/application/AuthServiceTest.java
@@ -4,51 +4,39 @@ import static com.festago.common.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
 
-import com.festago.auth.domain.SocialType;
 import com.festago.auth.domain.UserInfo;
 import com.festago.auth.dto.LoginMemberDto;
 import com.festago.common.exception.NotFoundException;
 import com.festago.member.domain.Member;
-import com.festago.member.repository.MemberRepository;
+import com.festago.member.repository.MemoryMemberRepository;
 import com.festago.support.MemberFixture;
-import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-@ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
-    @Mock
-    MemberRepository memberRepository;
+    MemoryMemberRepository memberRepository = new MemoryMemberRepository();
 
-    @InjectMocks
-    AuthService authService;
+    AuthService authService = new AuthService(memberRepository);
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.clear();
+    }
 
     @Nested
     class 로그인 {
 
         @Test
-        void 신규_회원으로_로그인() {
+        void 신규_회원으로_로그인하면_isNew가_참이다() {
             // given
-            Member member = MemberFixture.member()
-                .id(1L)
-                .build();
-            given(memberRepository.findBySocialIdAndSocialType(anyString(), any(SocialType.class)))
-                .willReturn(Optional.empty());
-            given(memberRepository.save(any(Member.class)))
-                .willReturn(member);
+            Member member = MemberFixture.member().build();
             UserInfo userInfo = new UserInfo(member.getSocialId(), member.getSocialType(), member.getNickname(),
                 member.getProfileImage());
 
@@ -61,13 +49,10 @@ class AuthServiceTest {
         }
 
         @Test
-        void 기존_회원으로_로그인() {
+        void 기존_회원으로_로그인하면_isNew가_거짓이다() {
             // given
-            Member member = MemberFixture.member()
-                .id(1L)
-                .build();
-            given(memberRepository.findBySocialIdAndSocialType(anyString(), any(SocialType.class)))
-                .willReturn(Optional.of(member));
+            Member member = MemberFixture.member().build();
+            memberRepository.save(member);
             UserInfo userInfo = new UserInfo(member.getSocialId(), member.getSocialType(), member.getNickname(),
                 member.getProfileImage());
 
@@ -87,8 +72,6 @@ class AuthServiceTest {
         void 멤버가_없으면_예외() {
             // given
             Long memberId = 1L;
-            given(memberRepository.findById(memberId))
-                .willReturn(Optional.empty());
 
             // then
             assertThatThrownBy(() -> authService.deleteMember(memberId))
@@ -99,14 +82,12 @@ class AuthServiceTest {
         @Test
         void 성공() {
             // given
-            Long memberId = 1L;
-            Member member = MemberFixture.member().id(memberId).build();
-            given(memberRepository.findById(memberId))
-                .willReturn(Optional.of(member));
+            Member member = MemberFixture.member().build();
+            memberRepository.save(member);
 
             // when & then
             assertThatNoException()
-                .isThrownBy(() -> authService.deleteMember(memberId));
+                .isThrownBy(() -> authService.deleteMember(member.getId()));
         }
     }
 }

--- a/backend/src/test/java/com/festago/entry/infrastructure/JsonEntryCodeExtractor.java
+++ b/backend/src/test/java/com/festago/entry/infrastructure/JsonEntryCodeExtractor.java
@@ -1,0 +1,21 @@
+package com.festago.entry.infrastructure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.entry.application.EntryCodeExtractor;
+import com.festago.entry.domain.EntryCodePayload;
+import lombok.SneakyThrows;
+
+/**
+ * Fake이므로 프로덕션에서 사용 금지!
+ */
+public class JsonEntryCodeExtractor implements EntryCodeExtractor {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @SneakyThrows
+    @Override
+    public EntryCodePayload extract(String code) {
+        JsonEntryCodePayload payload = objectMapper.readValue(code, JsonEntryCodePayload.class);
+        return new EntryCodePayload(payload.memberTicketId(), payload.entryState());
+    }
+}

--- a/backend/src/test/java/com/festago/entry/infrastructure/JsonEntryCodePayload.java
+++ b/backend/src/test/java/com/festago/entry/infrastructure/JsonEntryCodePayload.java
@@ -1,0 +1,19 @@
+package com.festago.entry.infrastructure;
+
+import com.festago.ticketing.domain.EntryState;
+import java.util.Date;
+
+/**
+ * Fake이므로 프로덕션에서 사용 금지!
+ *
+ * @param entryState
+ * @param memberTicketId
+ * @param expiredAt
+ */
+public record JsonEntryCodePayload(
+    EntryState entryState,
+    Long memberTicketId,
+    Date expiredAt
+) {
+
+}

--- a/backend/src/test/java/com/festago/entry/infrastructure/JsonEntryCodeProvider.java
+++ b/backend/src/test/java/com/festago/entry/infrastructure/JsonEntryCodeProvider.java
@@ -1,0 +1,33 @@
+package com.festago.entry.infrastructure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.common.exception.UnexpectedException;
+import com.festago.entry.application.EntryCodeProvider;
+import com.festago.entry.domain.EntryCodePayload;
+import com.festago.ticketing.domain.EntryState;
+import java.util.Date;
+import lombok.SneakyThrows;
+
+/**
+ * Fake이므로 프로덕션에서 사용 금지!
+ */
+public class JsonEntryCodeProvider implements EntryCodeProvider {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @SneakyThrows
+    @Override
+    public String provide(EntryCodePayload entryCodePayload, Date expiredAt) {
+        validate(expiredAt);
+        EntryState entryState = entryCodePayload.getEntryState();
+        Long memberTicketId = entryCodePayload.getMemberTicketId();
+        JsonEntryCodePayload payload = new JsonEntryCodePayload(entryState, memberTicketId, expiredAt);
+        return objectMapper.writeValueAsString(payload);
+    }
+
+    private void validate(Date expiredAt) {
+        if (expiredAt.before(new Date())) {
+            throw new UnexpectedException("입장코드 만료일자는 과거일 수 없습니다.");
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/fcm/application/MemberFCMServiceTest.java
+++ b/backend/src/test/java/com/festago/fcm/application/MemberFCMServiceTest.java
@@ -2,128 +2,146 @@ package com.festago.fcm.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 
 import com.festago.auth.application.AuthExtractor;
 import com.festago.auth.domain.AuthPayload;
 import com.festago.auth.domain.Role;
 import com.festago.fcm.domain.MemberFCM;
 import com.festago.fcm.dto.MemberFCMResponse;
-import com.festago.fcm.repository.MemberFCMRepository;
+import com.festago.fcm.repository.MemoryMemberFCMRepository;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
 class MemberFCMServiceTest {
 
-    @Mock
-    MemberFCMRepository memberFCMRepository;
+    MemoryMemberFCMRepository memberFCMRepository = new MemoryMemberFCMRepository();
 
-    @Mock
-    AuthExtractor authExtractor;
+    AuthExtractor authExtractor = mock();
 
-    @InjectMocks
-    MemberFCMService memberFCMService;
+    MemberFCMService memberFCMService = new MemberFCMService(
+        memberFCMRepository,
+        authExtractor
+    );
 
-    @Test
-    void 유저의_FCM_정보를_가져온다() {
-        // given
-        List<MemberFCM> memberFCMS = List.of(
-            new MemberFCM(1L, 1L, "token"),
-            new MemberFCM(2L, 1L, "token2")
-        );
-        given(memberFCMRepository.findByMemberId(anyLong()))
-            .willReturn(memberFCMS);
-
-        List<MemberFCMResponse> expect = memberFCMS.stream()
-            .map(MemberFCMResponse::from)
-            .collect(Collectors.toList());
-
-        // when
-        List<MemberFCMResponse> actual = memberFCMService.findMemberFCM(1L).memberFCMs();
-
-        // then
-        assertThat(actual).isEqualTo(expect);
+    @BeforeEach
+    void setUp() {
+        memberFCMRepository.clear();
+        reset(authExtractor);
     }
 
-    @Test
-    void 기존_유저의_새로운_FCM_토큰이라면_저장() {
-        // given
-        String accessToken = "accessToken";
-        String fcmToken = "fcmToken";
-        boolean isNewMember = false;
-        Long memberId = 1L;
-        given(authExtractor.extract(any()))
-            .willReturn(new AuthPayload(memberId, Role.MEMBER));
-        given(memberFCMRepository.findByMemberIdAndFcmToken(memberId, fcmToken))
-            .willReturn(Optional.empty());
+    @Nested
+    class 사용자의_모든_FCM_토큰_조회 {
 
-        // when
-        memberFCMService.saveMemberFCM(isNewMember, accessToken, fcmToken);
+        @Test
+        void 성공() {
+            // given
+            MemberFCM firstMemberFCM = new MemberFCM(1L, "token1");
+            memberFCMRepository.save(firstMemberFCM);
 
-        // then
-        verify(memberFCMRepository, times(1))
-            .save(any(MemberFCM.class));
+            MemberFCM secondMemberFCM = new MemberFCM(1L, "token2");
+            memberFCMRepository.save(secondMemberFCM);
+
+            // when
+            List<MemberFCMResponse> actual = memberFCMService.findMemberFCM(1L).memberFCMs();
+
+            // then
+            assertThat(actual)
+                .map(MemberFCMResponse::fcmToken)
+                .contains(
+                    firstMemberFCM.getFcmToken(),
+                    secondMemberFCM.getFcmToken()
+                ).hasSize(2);
+        }
     }
 
-    @Test
-    void 기존_유저의_이미_존재하는_유저의_FCM_토큰이라면_저장하지_않는다() {
-        // given
-        String accessToken = "accessToken";
-        String originToken = "fcmToken";
-        boolean isNewMember = false;
-        Long memberId = 1L;
-        given(authExtractor.extract(any()))
-            .willReturn(new AuthPayload(memberId, Role.MEMBER));
-        given(memberFCMRepository.findByMemberIdAndFcmToken(memberId, originToken))
-            .willReturn(Optional.of(new MemberFCM(memberId, originToken)));
+    @Nested
+    class 사용자의_FCM_토큰_저장 {
 
-        // when
-        memberFCMService.saveMemberFCM(isNewMember, accessToken, originToken);
+        @Test
+        void 기존_유저의_새로운_FCM_토큰이라면_저장한다() {
+            // given
+            String accessToken = "accessToken";
+            String fcmToken = "fcmToken";
+            boolean isNewMember = false;
+            Long memberId = 1L;
 
-        // then
-        verify(memberFCMRepository, never())
-            .save(any(MemberFCM.class));
+            given(authExtractor.extract(any()))
+                .willReturn(new AuthPayload(memberId, Role.MEMBER));
+
+            // when
+            memberFCMService.saveMemberFCM(isNewMember, accessToken, fcmToken);
+
+            // then
+            assertThat(memberFCMRepository.findByMemberIdAndFcmToken(memberId, fcmToken))
+                .isPresent();
+        }
+
+        @Test
+        void 이미_존재하는_유저의_FCM_토큰이라면_저장하지_않는다() {
+            // given
+            String accessToken = "accessToken";
+            String fcmToken = "fcmToken";
+            boolean isNewMember = false;
+            Long memberId = 1L;
+
+            given(authExtractor.extract(any()))
+                .willReturn(new AuthPayload(memberId, Role.MEMBER));
+
+            memberFCMRepository.save(new MemberFCM(memberId, fcmToken));
+
+            // when
+            memberFCMService.saveMemberFCM(isNewMember, accessToken, fcmToken);
+
+            // then
+            assertThat(memberFCMRepository.findByMemberId(memberId))
+                .hasSize(1);
+        }
+
+        @Test
+        void 새로운_유저의_FCM_토큰을_저장한다() {
+            // given
+            String accessToken = "accessToken";
+            String fcmToken = "fcmToken";
+            boolean isNewMember = true;
+            Long memberId = 1L;
+
+            given(authExtractor.extract(any()))
+                .willReturn(new AuthPayload(memberId, Role.MEMBER));
+
+            // when
+            memberFCMService.saveMemberFCM(isNewMember, accessToken, fcmToken);
+
+            // then
+            assertThat(memberFCMRepository.findByMemberId(memberId))
+                .hasSize(1);
+        }
     }
 
-    @Test
-    void 새로운_유저의_FCM_토큰을_저장한다() {
-        // given
-        String accessToken = "accessToken";
-        String fcmToken = "fcmToken";
-        boolean isNewMember = false;
-        Long memberId = 1L;
-        given(authExtractor.extract(any()))
-            .willReturn(new AuthPayload(memberId, Role.MEMBER));
+    @Nested
+    class 사용자의_FCM_토큰_삭제 {
 
-        // when
-        memberFCMService.saveMemberFCM(isNewMember, accessToken, fcmToken);
+        @Test
+        void 성공() {
+            // given
+            Long memberId = 1L;
+            String fcmToken = "fcmToken";
+            memberFCMRepository.save(new MemberFCM(memberId, fcmToken));
 
-        // then
-        verify(memberFCMRepository, times(1))
-            .save(any(MemberFCM.class));
-    }
+            // when
+            memberFCMService.deleteMemberFCM(memberId);
 
-    @Test
-    void 유저의_FCM_삭제() {
-        // given
-        Long memberId = 1L;
-
-        // when
-        memberFCMService.deleteMemberFCM(memberId);
-
-        // then
-        verify(memberFCMRepository, times(1))
-            .deleteAllByMemberId(memberId);
+            // then
+            assertThat(memberFCMRepository.findByMemberId(memberId))
+                .isEmpty();
+        }
     }
 }

--- a/backend/src/test/java/com/festago/fcm/repository/MemoryMemberFCMRepository.java
+++ b/backend/src/test/java/com/festago/fcm/repository/MemoryMemberFCMRepository.java
@@ -1,0 +1,51 @@
+package com.festago.fcm.repository;
+
+import com.festago.fcm.domain.MemberFCM;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.SneakyThrows;
+
+public class MemoryMemberFCMRepository implements MemberFCMRepository {
+
+    private final Map<Long, MemberFCM> memory = new ConcurrentHashMap<>();
+    private final AtomicLong autoIncrement = new AtomicLong();
+
+    @SneakyThrows
+    @Override
+    public MemberFCM save(MemberFCM memberFCM) {
+        Field idField = memberFCM.getClass()
+            .getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(memberFCM, autoIncrement.incrementAndGet());
+        memory.put(memberFCM.getId(), memberFCM);
+        return memberFCM;
+    }
+
+    @Override
+    public List<MemberFCM> findByMemberId(Long memberId) {
+        return memory.values().stream()
+            .filter(memberFCM -> memberFCM.getMemberId().equals(memberId))
+            .toList();
+    }
+
+    @Override
+    public Optional<MemberFCM> findByMemberIdAndFcmToken(Long memberId, String fcmToken) {
+        return memory.values().stream()
+            .filter(memberFCM -> memberFCM.getMemberId().equals(memberId) && memberFCM.getFcmToken().equals(fcmToken))
+            .findAny();
+    }
+
+    @Override
+    public void deleteAllByMemberId(Long memberId) {
+        memory.entrySet()
+            .removeIf(entry -> entry.getValue().getMemberId().equals(memberId));
+    }
+
+    public void clear() {
+        memory.clear();
+    }
+}

--- a/backend/src/test/java/com/festago/festival/repository/MemoryFestivalRepository.java
+++ b/backend/src/test/java/com/festago/festival/repository/MemoryFestivalRepository.java
@@ -1,0 +1,52 @@
+package com.festago.festival.repository;
+
+import com.festago.festival.domain.Festival;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.SneakyThrows;
+
+public class MemoryFestivalRepository implements FestivalRepository {
+
+    private final Map<Long, Festival> memory = new ConcurrentHashMap<>();
+    private final AtomicLong autoIncrement = new AtomicLong();
+
+    @SneakyThrows
+    @Override
+    public Festival save(Festival festival) {
+        Field idField = festival.getClass()
+            .getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(festival, autoIncrement.incrementAndGet());
+        memory.put(festival.getId(), festival);
+        return festival;
+    }
+
+    @Override
+    public Optional<Festival> findById(Long id) {
+        return Optional.ofNullable(memory.get(id));
+    }
+
+    @Override
+    public void deleteById(Long festivalId) {
+        memory.remove(festivalId);
+    }
+
+    @Override
+    public void flush() {
+        // NOOP
+    }
+
+    @Override
+    public List<Festival> findByFilter(FestivalFilter festivalFilter, LocalDate currentTime) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void clear() {
+        memory.clear();
+    }
+}

--- a/backend/src/test/java/com/festago/member/repository/MemoryMemberRepository.java
+++ b/backend/src/test/java/com/festago/member/repository/MemoryMemberRepository.java
@@ -1,0 +1,53 @@
+package com.festago.member.repository;
+
+import com.festago.auth.domain.SocialType;
+import com.festago.member.domain.Member;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.SneakyThrows;
+
+public class MemoryMemberRepository implements MemberRepository {
+
+    private final Map<Long, Member> memory = new ConcurrentHashMap<>();
+    private final AtomicLong autoIncrement = new AtomicLong();
+
+    @Override
+    public Optional<Member> findById(Long id) {
+        return Optional.ofNullable(memory.get(id));
+    }
+
+    @SneakyThrows
+    @Override
+    public Member save(Member member) {
+        Field idField = member.getClass()
+            .getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(member, autoIncrement.incrementAndGet());
+        memory.put(member.getId(), member);
+        return member;
+    }
+
+    @Override
+    public Optional<Member> findBySocialIdAndSocialType(String socialId, SocialType socialType) {
+        return memory.values().stream()
+            .filter(member -> member.getSocialId().equals(socialId) && member.getSocialType().equals(socialType))
+            .findAny();
+    }
+
+    @Override
+    public void delete(Member member) {
+        memory.remove(member.getId());
+    }
+
+    @Override
+    public long count() {
+        return memory.size();
+    }
+
+    public void clear() {
+        memory.clear();
+    }
+}

--- a/backend/src/test/java/com/festago/school/repository/MemorySchoolRepository.java
+++ b/backend/src/test/java/com/festago/school/repository/MemorySchoolRepository.java
@@ -1,0 +1,57 @@
+package com.festago.school.repository;
+
+import com.festago.school.domain.School;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.SneakyThrows;
+
+public class MemorySchoolRepository implements SchoolRepository {
+
+    private final Map<Long, School> memory = new ConcurrentHashMap<>();
+    private final AtomicLong autoIncrement = new AtomicLong();
+
+    @SneakyThrows
+    @Override
+    public School save(School school) {
+        Field idField = school.getClass()
+            .getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(school, autoIncrement.incrementAndGet());
+        memory.put(school.getId(), school);
+        return school;
+    }
+
+    @Override
+    public Optional<School> findById(Long id) {
+        return Optional.ofNullable(memory.get(id));
+    }
+
+    @Override
+    public boolean existsByDomainOrName(String domain, String name) {
+        return memory.values().stream()
+            .anyMatch(school -> school.getDomain().equals(domain) || school.getName().equals(name));
+    }
+
+    @Override
+    public List<School> findAll() {
+        return memory.values().stream().toList();
+    }
+
+    @Override
+    public void deleteById(Long schoolId) {
+        memory.remove(schoolId);
+    }
+
+    @Override
+    public void flush() {
+        // NOOP
+    }
+
+    public void clear() {
+        memory.clear();
+    }
+}

--- a/backend/src/test/java/com/festago/stage/application/FestivalStageServiceImplTest.java
+++ b/backend/src/test/java/com/festago/stage/application/FestivalStageServiceImplTest.java
@@ -3,42 +3,41 @@ package com.festago.stage.application;
 import static com.festago.common.exception.ErrorCode.FESTIVAL_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
 
 import com.festago.common.exception.NotFoundException;
 import com.festago.festival.domain.Festival;
 import com.festago.festival.dto.DetailFestivalResponse;
 import com.festago.festival.dto.DetailFestivalResponse.DetailStageResponse;
-import com.festago.festival.repository.FestivalRepository;
+import com.festago.festival.repository.MemoryFestivalRepository;
 import com.festago.stage.domain.Stage;
-import com.festago.stage.repository.StageRepository;
+import com.festago.stage.repository.MemoryStageRepository;
 import com.festago.support.FestivalFixture;
 import com.festago.support.StageFixture;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-@ExtendWith(MockitoExtension.class)
 class FestivalStageServiceImplTest {
 
-    @Mock
-    private StageRepository stageRepository;
+    MemoryStageRepository stageRepository = new MemoryStageRepository();
 
-    @Mock
-    private FestivalRepository festivalRepository;
+    MemoryFestivalRepository festivalRepository = new MemoryFestivalRepository();
 
-    @InjectMocks
-    private FestivalStageServiceImpl festivalStageService;
+    FestivalStageServiceImpl festivalStageService = new FestivalStageServiceImpl(
+        stageRepository,
+        festivalRepository
+    );
+
+    @BeforeEach
+    void setUp() {
+        stageRepository.clear();
+        festivalRepository.clear();
+    }
 
     @Nested
     class 축제_무대_상세_조회 {
@@ -46,33 +45,50 @@ class FestivalStageServiceImplTest {
         @Test
         void 존재하지_않는_축제에_대한_상세_무대_조희를_하면_예외() {
             // given
-            Long festivalId = 1L;
-            given(festivalRepository.findById(festivalId)).willReturn(Optional.empty());
+            Long invalidFestivalId = 1L;
 
             // when & then
-            assertThatThrownBy(() -> festivalStageService.findDetail(festivalId)).isInstanceOf(NotFoundException.class)
+            assertThatThrownBy(() -> festivalStageService.findDetail(invalidFestivalId))
+                .isInstanceOf(NotFoundException.class)
                 .hasMessage(FESTIVAL_NOT_FOUND.getMessage());
         }
 
         @Test
         void 무대_시작시간순으로_정렬() {
             // given
-            Long festivalId = 1L;
-            Festival festival = FestivalFixture.festival().id(festivalId).build();
-            LocalDateTime now = LocalDateTime.now();
-            Stage stage1 = StageFixture.stage().id(1L).startTime(now).festival(festival).build();
-            Stage stage2 = StageFixture.stage().id(2L).startTime(now.plusDays(1)).festival(festival).build();
+            LocalDateTime now = LocalDateTime.parse("2023-01-10T16:00:00");
+            LocalDateTime ticketOpenTime = now.minusDays(1);
 
-            given(festivalRepository.findById(festivalId)).willReturn(Optional.of(festival));
-            given(stageRepository.findAllDetailByFestivalId(festival.getId())).willReturn(List.of(stage2, stage1));
+            Festival festival = FestivalFixture.festival()
+                .startDate(now.minusDays(1).toLocalDate())
+                .endDate(now.plusDays(1).toLocalDate())
+                .build();
+            festivalRepository.save(festival);
+
+            Stage firstStage = StageFixture.stage()
+                .ticketOpenTime(ticketOpenTime)
+                .startTime(now)
+                .festival(festival)
+                .build();
+            stageRepository.save(firstStage);
+
+            Stage secondStage = StageFixture.stage()
+                .ticketOpenTime(ticketOpenTime)
+                .startTime(now.plusDays(1))
+                .festival(festival)
+                .build();
+            stageRepository.save(secondStage);
 
             // when
-            DetailFestivalResponse response = festivalStageService.findDetail(festivalId);
+            DetailFestivalResponse response = festivalStageService.findDetail(festival.getId());
 
             // then
-            List<Long> stageIds = response.stages().stream().map(DetailStageResponse::id).toList();
-            assertThat(stageIds).containsExactly(1L, 2L);
+            assertThat(response.stages())
+                .map(DetailStageResponse::id)
+                .containsExactly(
+                    firstStage.getId(),
+                    secondStage.getId()
+                );
         }
     }
-
 }

--- a/backend/src/test/java/com/festago/stage/application/StageServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/StageServiceTest.java
@@ -1,56 +1,47 @@
 package com.festago.stage.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
 
 import com.festago.festival.domain.Festival;
-import com.festago.festival.repository.FestivalRepository;
-import com.festago.stage.domain.Stage;
+import com.festago.festival.repository.MemoryFestivalRepository;
 import com.festago.stage.dto.StageCreateRequest;
 import com.festago.stage.dto.StageResponse;
-import com.festago.stage.repository.StageRepository;
+import com.festago.stage.repository.MemoryStageRepository;
 import com.festago.support.FestivalFixture;
 import java.time.LocalDateTime;
-import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-@ExtendWith(MockitoExtension.class)
 class StageServiceTest {
 
-    @Mock
-    StageRepository stageRepository;
+    MemoryStageRepository stageRepository = new MemoryStageRepository();
 
-    @Mock
-    FestivalRepository festivalRepository;
+    MemoryFestivalRepository festivalRepository = new MemoryFestivalRepository();
 
-    @InjectMocks
-    StageService stageService;
+    StageService stageService = new StageService(stageRepository, festivalRepository);
+
+    @BeforeEach
+    void setUp() {
+        stageRepository.clear();
+        festivalRepository.clear();
+    }
 
     @Test
     void 무대_생성() {
         // given
         Festival festival = FestivalFixture.festival()
             .build();
+        festivalRepository.save(festival);
         StageCreateRequest request = new StageCreateRequest(
             LocalDateTime.now(),
             "애쉬,푸우,오리,글렌",
             LocalDateTime.now().minusDays(1),
-            1L
+            festival.getId()
         );
-        given(festivalRepository.findById(anyLong()))
-            .willReturn(Optional.of(festival));
-        given(stageRepository.save(any(Stage.class)))
-            .willAnswer(invocation -> invocation.getArgument(0));
 
         // when
         StageResponse response = stageService.create(request);

--- a/backend/src/test/java/com/festago/stage/repository/MemoryStageRepository.java
+++ b/backend/src/test/java/com/festago/stage/repository/MemoryStageRepository.java
@@ -1,0 +1,58 @@
+package com.festago.stage.repository;
+
+import com.festago.stage.domain.Stage;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.SneakyThrows;
+
+public class MemoryStageRepository implements StageRepository {
+
+    private final Map<Long, Stage> memory = new ConcurrentHashMap<>();
+    private final AtomicLong autoIncrement = new AtomicLong();
+
+    @SneakyThrows
+    @Override
+    public Stage save(Stage stage) {
+        Field idField = stage.getClass()
+            .getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(stage, autoIncrement.incrementAndGet());
+        memory.put(stage.getId(), stage);
+        return stage;
+    }
+
+    @Override
+    public Optional<Stage> findById(Long id) {
+        return Optional.ofNullable(memory.get(id));
+    }
+
+    @Override
+    public void deleteById(Long stageId) {
+        memory.remove(stageId);
+    }
+
+    @Override
+    public void flush() {
+        // NOOP
+    }
+
+    @Override
+    public List<Stage> findAllDetailByFestivalId(Long festivalId) {
+        return memory.values().stream()
+            .filter(stage -> stage.getFestival().getId().equals(festivalId))
+            .toList();
+    }
+
+    @Override
+    public Optional<Stage> findByIdWithFetch(Long id) {
+        return findById(id);
+    }
+
+    public void clear() {
+        memory.clear();
+    }
+}

--- a/backend/src/test/java/com/festago/student/application/StudentServiceTest.java
+++ b/backend/src/test/java/com/festago/student/application/StudentServiceTest.java
@@ -5,20 +5,19 @@ import static com.festago.common.exception.ErrorCode.DUPLICATE_STUDENT_EMAIL;
 import static com.festago.common.exception.ErrorCode.INVALID_STUDENT_VERIFICATION_CODE;
 import static com.festago.common.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static com.festago.common.exception.ErrorCode.SCHOOL_NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
 
 import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.NotFoundException;
 import com.festago.member.domain.Member;
-import com.festago.member.repository.MemberRepository;
+import com.festago.member.repository.MemoryMemberRepository;
 import com.festago.school.domain.School;
-import com.festago.school.repository.SchoolRepository;
+import com.festago.school.repository.MemorySchoolRepository;
 import com.festago.student.domain.Student;
 import com.festago.student.domain.StudentCode;
 import com.festago.student.domain.VerificationCode;
@@ -27,148 +26,177 @@ import com.festago.student.dto.StudentSendMailRequest;
 import com.festago.student.dto.StudentVerificateRequest;
 import com.festago.student.infrastructure.MockMailClient;
 import com.festago.student.infrastructure.RandomVerificationCodeProvider;
-import com.festago.student.repository.StudentCodeRepository;
-import com.festago.student.repository.StudentRepository;
+import com.festago.student.repository.MemoryStudentCodeRepository;
+import com.festago.student.repository.MemoryStudentRepository;
 import com.festago.support.MemberFixture;
 import com.festago.support.SchoolFixture;
-import com.festago.support.SetUpMockito;
-import com.festago.support.StudentFixture;
+import com.festago.support.StudentCodeFixture;
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class StudentServiceTest {
 
-    @Spy
     MailClient mailClient = new MockMailClient();
 
-    @Spy
     VerificationCodeProvider codeProvider = new RandomVerificationCodeProvider();
 
-    @Mock
-    StudentCodeRepository studentCodeRepository;
+    MemoryStudentCodeRepository studentCodeRepository = new MemoryStudentCodeRepository();
 
-    @Mock
-    SchoolRepository schoolRepository;
+    MemorySchoolRepository schoolRepository = new MemorySchoolRepository();
 
-    @Mock
-    MemberRepository memberRepository;
+    MemoryMemberRepository memberRepository = new MemoryMemberRepository();
 
-    @Mock
-    StudentRepository studentRepository;
+    MemoryStudentRepository studentRepository = new MemoryStudentRepository();
 
-    @Spy
-    Clock clock = Clock.systemDefaultZone();
+    Clock clock = spy(Clock.systemDefaultZone());
 
-    @InjectMocks
-    StudentService studentService;
+    StudentService studentService = new StudentService(
+        mailClient,
+        codeProvider,
+        studentCodeRepository,
+        schoolRepository,
+        memberRepository,
+        studentRepository,
+        clock
+    );
+
+    @BeforeEach
+    void setUp() {
+        studentCodeRepository.clear();
+        schoolRepository.clear();
+        memberRepository.clear();
+        studentRepository.clear();
+        reset(clock);
+    }
 
     @Nested
-    class 학생_인증_메일_전송_요청 {
+    class sendVerificationMail {
 
+        Member member = MemberFixture.member().build();
+        School school = SchoolFixture.school().build();
         StudentSendMailRequest request;
 
         @BeforeEach
         void setUp() {
-            request = new StudentSendMailRequest("ash", 1L);
-            Member member = MemberFixture.member().id(1L).build();
-            School school = SchoolFixture.school().id(1L).build();
-
-            SetUpMockito
-                .given(memberRepository.findById(anyLong()))
-                .willReturn(Optional.of(member));
-            SetUpMockito
-                .given(schoolRepository.findById(anyLong()))
-                .willReturn(Optional.of(school));
-            SetUpMockito
-                .given(studentCodeRepository.findByMemberId(anyLong()))
-                .willReturn(Optional.empty());
-            SetUpMockito
-                .given(studentRepository.existsByMemberId(anyLong()))
-                .willReturn(false);
-            SetUpMockito
-                .given(studentRepository.existsByUsernameAndSchoolId(anyString(), anyLong()))
-                .willReturn(false);
+            memberRepository.save(member);
+            schoolRepository.save(school);
+            request = new StudentSendMailRequest("ash", school.getId());
         }
 
-        @Test
-        void 존재하지_않는_멤버이면_예외() {
-            // given
-            given(memberRepository.findById(anyLong()))
-                .willReturn(Optional.empty());
+        @Nested
+        class 실패 {
 
-            // when & then
-            assertThatThrownBy(() -> studentService.sendVerificationMail(1L, request))
-                .isInstanceOf(NotFoundException.class)
-                .hasMessage(MEMBER_NOT_FOUND.getMessage());
+            @Test
+            void 존재하지_않는_멤버이면_예외() {
+                // given
+                Long unsavedMemberId = member.getId() + 1;
+
+                // when & then
+                assertThatThrownBy(() -> studentService.sendVerificationMail(unsavedMemberId, request))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage(MEMBER_NOT_FOUND.getMessage());
+            }
+
+            @Test
+            void 존재하지_않는_학교면_예외() {
+                // given
+                Long memberId = member.getId();
+                var invalidRequest = new StudentSendMailRequest("ash", school.getId() + 1);
+
+                // when & then
+                assertThatThrownBy(() -> studentService.sendVerificationMail(memberId, invalidRequest))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage(SCHOOL_NOT_FOUND.getMessage());
+            }
+
+            @Test
+            void 이미_존재하는_학생이면_예외() {
+                // given
+                Long memberId = member.getId();
+                studentRepository.save(new Student(member, school, "glen"));
+
+                // when & then
+                assertThatThrownBy(() -> studentService.sendVerificationMail(memberId, request))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage(ALREADY_STUDENT_VERIFIED.getMessage());
+            }
+
+            @Test
+            void 이미_존재하는_이메일이면_예외() {
+                // given
+                Long memberId = member.getId();
+                Member otherMember = memberRepository.save(MemberFixture.member().build());
+                studentRepository.save(new Student(otherMember, school, "ash"));
+
+                // when & then
+                assertThatThrownBy(() -> studentService.sendVerificationMail(memberId, request))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage(DUPLICATE_STUDENT_EMAIL.getMessage());
+            }
         }
 
-        @Test
-        void 존재하지_않는_학교면_예외() {
-            // given
-            given(schoolRepository.findById(anyLong()))
-                .willReturn(Optional.empty());
+        @Nested
+        class 성공 {
 
-            // when & then
-            assertThatThrownBy(() -> studentService.sendVerificationMail(1L, request))
-                .isInstanceOf(NotFoundException.class)
-                .hasMessage(SCHOOL_NOT_FOUND.getMessage());
+            @Test
+            void StudentCode가_있으면_갱신된다() {
+                // given
+                LocalDateTime now = LocalDateTime.parse("2023-01-10T16:00:00");
+                doReturn(Instant.parse("2023-01-10T17:00:00Z"))
+                    .when(clock)
+                    .instant();
+                StudentCode studentCode = StudentCodeFixture.studentCode()
+                    .member(member)
+                    .school(school)
+                    .issuedAt(now)
+                    .build();
+                studentCodeRepository.save(studentCode);
+
+                // when
+                studentService.sendVerificationMail(1L, request);
+
+                // then
+                assertThat(studentCode.getIssuedAt()).isAfter(now);
+            }
+
+            @Test
+            void StudentCode가_없으면_저장된다() {
+                // when
+                studentService.sendVerificationMail(1L, request);
+
+                // then
+                assertThat(studentCodeRepository.findByMemberId(member.getId())).isPresent();
+            }
         }
 
-        @Test
-        void 이미_존재하는_학생이면_예외() {
-            // given
-            given(studentRepository.existsByMemberId(anyLong()))
-                .willReturn(true);
-
-            // when & then
-            assertThatThrownBy(() -> studentService.sendVerificationMail(1L, request))
-                .isInstanceOf(BadRequestException.class)
-                .hasMessage(ALREADY_STUDENT_VERIFIED.getMessage());
-        }
-
-        @Test
-        void 이미_존재하는_이메일이면_예외() {
-            // given
-            given(studentRepository.existsByUsernameAndSchoolId(anyString(), anyLong()))
-                .willReturn(true);
-
-            // when & then
-            assertThatThrownBy(() -> studentService.sendVerificationMail(1L, request))
-                .isInstanceOf(BadRequestException.class)
-                .hasMessage(DUPLICATE_STUDENT_EMAIL.getMessage());
-        }
-
-        @Test
-        void 인증메일_전송() {
-            assertThatNoException()
-                .isThrownBy(() -> studentService.sendVerificationMail(1L, request));
-        }
     }
 
     @Nested
     class 학생_인증 {
 
+        Member member = MemberFixture.member().build();
+        School school = SchoolFixture.school().build();
+        StudentVerificateRequest request = new StudentVerificateRequest("123456");
+
+        @BeforeEach
+        void setUp() {
+            memberRepository.save(member);
+            schoolRepository.save(school);
+        }
+
         @Test
         void 이미_학생인증정보가_존재하면_예외() {
             // given
-            Long memberId = 1L;
-            StudentVerificateRequest request = new StudentVerificateRequest("123456");
-            given(studentRepository.existsByMemberId(memberId))
-                .willReturn(true);
+            Long memberId = member.getId();
+            studentRepository.save(new Student(member, school, "glen"));
 
             // when & then
             assertThatThrownBy(() -> studentService.verify(memberId, request))
@@ -179,12 +207,7 @@ class StudentServiceTest {
         @Test
         void 인증_코드가_존재하지_않으면_예외() {
             // given
-            Long memberId = 1L;
-            StudentVerificateRequest request = new StudentVerificateRequest("123456");
-            given(memberRepository.findById(anyLong()))
-                .willReturn(Optional.of(MemberFixture.member().build()));
-            given(studentCodeRepository.findByCodeAndMember(any(), any()))
-                .willReturn(Optional.empty());
+            Long memberId = member.getId();
 
             // when & then
             assertThatThrownBy(() -> studentService.verify(memberId, request))
@@ -193,39 +216,41 @@ class StudentServiceTest {
         }
 
         @Test
-        void 성공() {
+        void 성공하면_학생이_저장되고_StudentCode가_삭제된다() {
             // given
-            Long memberId = 1L;
-            StudentVerificateRequest request = new StudentVerificateRequest("123456");
-            Member member = MemberFixture.member().build();
-            given(memberRepository.findById(anyLong()))
-                .willReturn(Optional.of(member));
-            given(studentCodeRepository.findByCodeAndMember(any(), any()))
-                .willReturn(Optional.of(new StudentCode(
-                    new VerificationCode("123456"),
-                    new School("snu.ac.kr", "서울대학교"),
-                    member,
-                    "ohs",
-                    LocalDateTime.now()
-                )));
+            Long memberId = member.getId();
+            studentCodeRepository.save(
+                new StudentCode(new VerificationCode(request.code()), school, member, "glen",
+                    LocalDateTime.now(clock)));
+
+            // when
+            studentService.verify(memberId, request);
 
             // when & then
-            assertThatNoException()
-                .isThrownBy(() -> studentService.verify(memberId, request));
+            assertSoftly(softly -> {
+                softly.assertThat(studentRepository.existsByMemberId(memberId)).isTrue();
+                softly.assertThat(studentCodeRepository.findByMemberId(memberId)).isEmpty();
+            });
         }
     }
 
     @Nested
     class 멤버_아이디로_인증정보_조회 {
 
+        Member member = MemberFixture.member().build();
+        School school = SchoolFixture.school().build();
+
+        @BeforeEach
+        void setUp() {
+            memberRepository.save(member);
+            schoolRepository.save(school);
+        }
+
         @Test
-        void 학생_인증된_멤버의_경우() {
+        void 학생_인증된_사용자의_경우_verified가_true이고_학교의_식별자가_조회된다() {
             // given
-            Long memberId = 1L;
-            School school = SchoolFixture.school().id(2L).build();
-            Student student = StudentFixture.student().id(3L).school(school).build();
-            given(studentRepository.findByMemberIdWithFetch(memberId))
-                .willReturn(Optional.of(student));
+            Long memberId = member.getId();
+            studentRepository.save(new Student(member, school, "glen"));
 
             // when
             StudentResponse actual = studentService.findVerification(memberId);
@@ -238,11 +263,9 @@ class StudentServiceTest {
         }
 
         @Test
-        void 학생_인증되지_않은_사용자의_경우() {
+        void 학생_인증되지_않은_사용자의_경우_verified가_false이고_학교가_null이다() {
             // given
             Long memberId = 1L;
-            given(studentRepository.findByMemberIdWithFetch(memberId))
-                .willReturn(Optional.empty());
 
             // when
             StudentResponse actual = studentService.findVerification(memberId);

--- a/backend/src/test/java/com/festago/student/repository/MemoryStudentCodeRepository.java
+++ b/backend/src/test/java/com/festago/student/repository/MemoryStudentCodeRepository.java
@@ -1,0 +1,53 @@
+package com.festago.student.repository;
+
+import com.festago.member.domain.Member;
+import com.festago.student.domain.StudentCode;
+import com.festago.student.domain.VerificationCode;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.SneakyThrows;
+
+public class MemoryStudentCodeRepository implements StudentCodeRepository {
+
+    private final Map<Long, StudentCode> memory = new ConcurrentHashMap<>();
+    private final AtomicLong autoIncrement = new AtomicLong();
+
+    @SneakyThrows
+    @Override
+    public StudentCode save(StudentCode studentCode) {
+        Field idField = studentCode.getClass()
+            .getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(studentCode, autoIncrement.incrementAndGet());
+        memory.put(studentCode.getId(), studentCode);
+        return studentCode;
+    }
+
+    @Override
+    public void deleteByMember(Member member) {
+        memory.entrySet()
+            .removeIf(it -> it.getValue().getMember().getId().equals(member.getId()));
+    }
+
+    @Override
+    public Optional<StudentCode> findByCodeAndMember(VerificationCode code, Member member) {
+        return memory.values().stream()
+            .filter(
+                it -> it.getCode().getValue().equals(code.getValue()) && it.getMember().getId().equals(member.getId()))
+            .findAny();
+    }
+
+    @Override
+    public Optional<StudentCode> findByMemberId(Long memberId) {
+        return memory.values().stream()
+            .filter(it -> it.getMember().getId().equals(memberId))
+            .findAny();
+    }
+
+    public void clear() {
+        memory.clear();
+    }
+}

--- a/backend/src/test/java/com/festago/student/repository/MemoryStudentRepository.java
+++ b/backend/src/test/java/com/festago/student/repository/MemoryStudentRepository.java
@@ -1,0 +1,63 @@
+package com.festago.student.repository;
+
+import com.festago.member.domain.Member;
+import com.festago.student.domain.Student;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.SneakyThrows;
+
+public class MemoryStudentRepository implements StudentRepository {
+
+    private final Map<Long, Student> memory = new ConcurrentHashMap<>();
+    private final AtomicLong autoIncrement = new AtomicLong();
+
+    @Override
+    public boolean existsByMemberAndSchoolId(Member member, Long schoolId) {
+        return memory.values().stream()
+            .anyMatch(student -> student.getMember().getId().equals(member.getId()) && student.getSchool().getId()
+                .equals(schoolId));
+    }
+
+    @Override
+    public boolean existsByUsernameAndSchoolId(String username, Long schoolId) {
+        return memory.values().stream()
+            .anyMatch(
+                student -> student.getUsername().equals(username) && student.getSchool().getId().equals(schoolId));
+    }
+
+    @Override
+    public boolean existsByMemberId(Long memberId) {
+        return memory.values().stream()
+            .anyMatch(student -> student.getMember().getId().equals(memberId));
+    }
+
+    @SneakyThrows
+    @Override
+    public Student save(Student student) {
+        Field idField = student.getClass()
+            .getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(student, autoIncrement.incrementAndGet());
+        memory.put(student.getId(), student);
+        return student;
+    }
+
+    @Override
+    public Optional<Student> findById(Long id) {
+        return Optional.ofNullable(memory.get(id));
+    }
+
+    @Override
+    public Optional<Student> findByMemberIdWithFetch(Long memberId) {
+        return memory.values().stream()
+            .filter(student -> student.getMember().getId().equals(memberId))
+            .findAny();
+    }
+
+    public void clear() {
+        memory.clear();
+    }
+}

--- a/backend/src/test/java/com/festago/ticket/repository/MemoryTicketAmountRepository.java
+++ b/backend/src/test/java/com/festago/ticket/repository/MemoryTicketAmountRepository.java
@@ -1,0 +1,40 @@
+package com.festago.ticket.repository;
+
+import com.festago.ticket.domain.Ticket;
+import com.festago.ticket.domain.TicketAmount;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.SneakyThrows;
+
+public class MemoryTicketAmountRepository implements TicketAmountRepository {
+
+    private final Map<Long, TicketAmount> memory = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<TicketAmount> findById(Long id) {
+        return Optional.ofNullable(memory.get(id));
+    }
+
+    @Override
+    public Optional<TicketAmount> findByTicketIdForUpdate(Long ticketId) {
+        return findById(ticketId);
+    }
+
+    @SneakyThrows
+    public TicketAmount save(Ticket ticket) {
+        assert ticket.getId() != null;
+        TicketAmount ticketAmount = ticket.getTicketAmount();
+        Field idField = ticketAmount.getClass()
+            .getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(ticketAmount, ticket.getId());
+        memory.put(ticketAmount.getId(), ticketAmount);
+        return ticketAmount;
+    }
+
+    public void clear() {
+        memory.clear();
+    }
+}

--- a/backend/src/test/java/com/festago/ticket/repository/MemoryTicketRepository.java
+++ b/backend/src/test/java/com/festago/ticket/repository/MemoryTicketRepository.java
@@ -1,0 +1,64 @@
+package com.festago.ticket.repository;
+
+import com.festago.stage.domain.Stage;
+import com.festago.ticket.domain.Ticket;
+import com.festago.ticket.domain.TicketType;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.SneakyThrows;
+
+public class MemoryTicketRepository implements TicketRepository {
+
+    private final MemoryTicketAmountRepository ticketAmountRepository;
+    private final Map<Long, Ticket> memory = new ConcurrentHashMap<>();
+    private final AtomicLong autoIncrement = new AtomicLong();
+
+    public MemoryTicketRepository(MemoryTicketAmountRepository ticketAmountRepository) {
+        this.ticketAmountRepository = ticketAmountRepository;
+    }
+
+    @SneakyThrows
+    @Override
+    public Ticket save(Ticket ticket) {
+        Field idField = ticket.getClass()
+            .getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(ticket, autoIncrement.incrementAndGet());
+        memory.put(ticket.getId(), ticket);
+        ticketAmountRepository.save(ticket);
+        return ticket;
+    }
+
+    @Override
+    public long count() {
+        return memory.size();
+    }
+
+    @Override
+    public List<Ticket> findAllByStageIdWithFetch(Long stageId) {
+        return memory.values().stream()
+            .filter(ticket -> ticket.getStage().getId().equals(stageId))
+            .toList();
+    }
+
+    @Override
+    public Optional<Ticket> findByIdWithFetch(Long ticketId) {
+        return Optional.ofNullable(memory.get(ticketId));
+    }
+
+    @Override
+    public Optional<Ticket> findByTicketTypeAndStage(TicketType ticketType, Stage stage) {
+        return memory.values().stream()
+            .filter(
+                ticket -> ticket.getTicketType().equals(ticketType) && ticket.getStage().getId().equals(stage.getId()))
+            .findAny();
+    }
+
+    public void clear() {
+        memory.clear();
+    }
+}

--- a/backend/src/test/java/com/festago/ticketing/repository/MemberTicketRepositoryTest.java
+++ b/backend/src/test/java/com/festago/ticketing/repository/MemberTicketRepositoryTest.java
@@ -115,7 +115,9 @@ class MemberTicketRepositoryTest {
             for (int i = 0; i < 20; i++) {
                 memberTickets.add(MemberTicketFixture.memberTicket().stage(stage).owner(member).build());
             }
-            memberTicketRepository.saveAll(memberTickets);
+            for (MemberTicket memberTicket : memberTickets) {
+                memberTicketRepository.save(memberTicket);
+            }
 
             Pageable pageable = PageRequest.of(0, 100, Sort.by("entryTime").descending());
 

--- a/backend/src/test/java/com/festago/ticketing/repository/MemoryMemberTicketRepository.java
+++ b/backend/src/test/java/com/festago/ticketing/repository/MemoryMemberTicketRepository.java
@@ -1,0 +1,59 @@
+package com.festago.ticketing.repository;
+
+import com.festago.member.domain.Member;
+import com.festago.stage.domain.Stage;
+import com.festago.ticketing.domain.MemberTicket;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.SneakyThrows;
+import org.springframework.data.domain.Pageable;
+
+public class MemoryMemberTicketRepository implements MemberTicketRepository {
+
+    private final Map<Long, MemberTicket> memory = new ConcurrentHashMap<>();
+    private final AtomicLong autoIncrement = new AtomicLong();
+
+    @SneakyThrows
+    @Override
+    public MemberTicket save(MemberTicket memberTicket) {
+        Field idField = memberTicket.getClass()
+            .getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(memberTicket, autoIncrement.incrementAndGet());
+        memory.put(memberTicket.getId(), memberTicket);
+        return memberTicket;
+    }
+
+    @Override
+    public Optional<MemberTicket> findById(Long id) {
+        return Optional.ofNullable(memory.get(id));
+    }
+
+    @Override
+    public List<MemberTicket> findAllByOwnerId(Long memberId, Pageable pageable) {
+        return memory.values().stream()
+            .filter(memberTicket -> memberTicket.isOwner(memberId))
+            .toList();
+    }
+
+    @Override
+    public boolean existsByOwnerAndStage(Member owner, Stage stage) {
+        return memory.values().stream()
+            .anyMatch(
+                memberTicket -> memberTicket.getOwner().getId().equals(owner.getId()) && memberTicket.getStage().getId()
+                    .equals(stage.getId()));
+    }
+
+    @Override
+    public long count() {
+        return memory.size();
+    }
+
+    public void clear() {
+        memory.clear();
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #648 

## ✨ PR 세부 내용

이슈 내용 그대로 작업했습니다.
그에 따라 서비스 단위 테스트를 모두 새롭게 작성했습니다.

기존 Service 단위 테스트에서 Mock을 사용하므로 인해, 비즈니스 로직을 테스트 하는 것이 아닌 그저 Stub을 테스트하는 테스트가 대다수 였는데, 이번 변화로 인해 Service에서 수행하는 비즈니스 로직을 테스트할 수 있게 되었습니다.

### Before

```java
class StudentServiceTest {
    ...
    @Test
    void 성공() {
        // given
        Long memberId = 1L;
        StudentVerificateRequest request = new StudentVerificateRequest("123456");
        Member member = MemberFixture.member().build();
        given(memberRepository.findById(anyLong()))
            .willReturn(Optional.of(member));
        given(studentCodeRepository.findByCodeAndMember(any(), any()))
            .willReturn(Optional.of(new StudentCode(
                new VerificationCode("123456"),
                new School("snu.ac.kr", "서울대학교"),
                member,
                "ohs",
                LocalDateTime.now()
            )));

        // when & then
        assertThatNoException()
            .isThrownBy(() -> studentService.verify(memberId, request));
    }
    ...
}
``` 

### After

```java
class StudentServiceTest {
    ...
    @Test
    void 성공하면_학생이_저장되고_StudentCode가_삭제된다() {
        // given
        Long memberId = member.getId();
        studentCodeRepository.save(
            new StudentCode(new VerificationCode(request.code()), school, member, "glen",
                LocalDateTime.now(clock)));

        // when
        studentService.verify(memberId, request);

        // when & then
        assertSoftly(softly -> {
            softly.assertThat(studentRepository.existsByMemberId(memberId)).isTrue();
            softly.assertThat(studentCodeRepository.findByMemberId(memberId)).isEmpty();
        });
    }
    ...
}
``` 

단점으로는, Repository를 새롭게 생성할 때 Fake 클래스를 만들어야 합니다.
또한 일부 Repository에 `Pageable`, `Filter` 등이 인자로 받는 경우가 있습니다.
해당 인자를 받는 Fake Repository를 구현하기가 거의 불가능 합니다. (JPA, QueryDSL 등 구현체에 의존적이므로)
따라서 다른 구현체에 의존적인 Repository의 경우 별도의 Repository 클래스로 만드는 것이 좋아보입니다. ex) `QueryRepository`
제안이니까 편하게 의견주세요!!
