### PR TITLE
fix: AdminAuthController API 경로 수정 (#652)

### DIFF
--- a/backend/src/main/java/com/festago/auth/presentation/AdminAuthController.java
+++ b/backend/src/main/java/com/festago/auth/presentation/AdminAuthController.java
@@ -25,7 +25,7 @@ public class AdminAuthController {
 
     private final AdminAuthService adminAuthService;
 
-    @PostMapping("/admin/login")
+    @PostMapping("/login")
     @Hidden
     public ResponseEntity<Void> login(@RequestBody @Valid AdminLoginRequest request) {
         String token = adminAuthService.login(request);
@@ -41,7 +41,7 @@ public class AdminAuthController {
             .build().toString();
     }
 
-    @PostMapping("/admin/signup")
+    @PostMapping("/signup")
     @Hidden
     public ResponseEntity<AdminSignupResponse> signupAdminAccount(@RequestBody @Valid AdminSignupRequest request,
                                                                   @Admin Long adminId) {
@@ -50,7 +50,7 @@ public class AdminAuthController {
             .body(response);
     }
 
-    @PostMapping("/admin/initialize")
+    @PostMapping("/initialize")
     @Hidden
     public ResponseEntity<Void> initializeRootAdmin(@RequestBody @Valid RootAdminInitializeRequest request) {
         adminAuthService.initializeRootAdmin(request.password());

--- a/backend/src/test/java/com/festago/auth/presentation/AdminAuthControllerTest.java
+++ b/backend/src/test/java/com/festago/auth/presentation/AdminAuthControllerTest.java
@@ -1,0 +1,122 @@
+package com.festago.auth.presentation;
+
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.auth.application.AdminAuthService;
+import com.festago.auth.domain.Role;
+import com.festago.auth.dto.AdminLoginRequest;
+import com.festago.auth.dto.AdminSignupRequest;
+import com.festago.auth.dto.AdminSignupResponse;
+import com.festago.auth.dto.RootAdminInitializeRequest;
+import com.festago.support.CustomWebMvcTest;
+import com.festago.support.WithMockAuth;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTest
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class AdminAuthControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    AdminAuthService adminAuthService;
+
+    @Nested
+    class 어드민_로그인 {
+
+        @Test
+        void 유효한_요청이_보내지면_200_응답과_쿠키에_token이_있어야한다() throws Exception {
+            // given
+            var request = new AdminLoginRequest("admin", "1234");
+            given(adminAuthService.login(any(AdminLoginRequest.class)))
+                .willReturn("token");
+
+            // when & then
+            mockMvc.perform(post("/admin/api/login")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("token"));
+        }
+    }
+
+    @Nested
+    class 어드민_회원가입 {
+
+        @Test
+        void 쿠키에_토큰이_없으면_401_응답이_반환된다() throws Exception {
+            // given
+            var request = new AdminSignupRequest("newAdmin", "1234");
+
+            // when & then
+            mockMvc.perform(post("/admin/api/signup")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @WithMockAuth(role = Role.MEMBER)
+        void 쿠키에_토큰의_권한이_올바르지_않으면_404_응답이_반환된다() throws Exception {
+            // given
+            var request = new AdminSignupRequest("newAdmin", "1234");
+
+            // when & then
+            mockMvc.perform(post("/admin/api/signup")
+                    .cookie(new Cookie("token", "token"))
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @WithMockAuth(role = Role.ADMIN)
+        void 유효한_요청이_보내지면_200_응답과_생성한_계정이_반환된다() throws Exception {
+            var request = new AdminSignupRequest("newAdmin", "1234");
+            var response = new AdminSignupResponse("newAdmin");
+            given(adminAuthService.signup(anyLong(), any(AdminSignupRequest.class)))
+                .willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/admin/api/signup")
+                    .cookie(new Cookie("token", "token"))
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    class 루트_어드민_활성화 {
+
+        @Test
+        void 유효한_요청이_보내지면_200_응답이_반환된다() throws Exception {
+            // given
+            var request = new RootAdminInitializeRequest("1234");
+
+            // when & then
+            mockMvc.perform(post("/admin/api/initialize")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/auth/presentation/AdminAuthControllerTest.java
+++ b/backend/src/test/java/com/festago/auth/presentation/AdminAuthControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -100,7 +101,8 @@ class AdminAuthControllerTest {
                     .cookie(new Cookie("token", "token"))
                     .content(objectMapper.writeValueAsString(request))
                     .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("newAdmin"));
         }
     }
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #652

## ✨ PR 세부 내용

이슈 내용 그대로 잘못된 API의 경로를 수정했습니다.
이번 테스트에서 `@Nested`를 사용했는데, 가독성이 좋다면 다른 테스트도 다음과 같은 방법으로 작성해보는 것은 어떠신가요?
또한 `var` 타입을 테스트에서 사용하는 것 또한 좋아 보입니다.
(기존에 `AdminAuthController`가 없어서 소 잃고 외양간 고친 느낌이네요. 😂)