### PR TITLE
feat: CORS 설정을 추가한다. (#654)

### DIFF
--- a/backend/src/main/java/com/festago/auth/config/LoginConfig.java
+++ b/backend/src/main/java/com/festago/auth/config/LoginConfig.java
@@ -7,10 +7,12 @@ import com.festago.auth.application.AuthExtractor;
 import com.festago.auth.domain.Role;
 import com.festago.auth.infrastructure.CookieTokenExtractor;
 import com.festago.auth.infrastructure.HeaderTokenExtractor;
+import com.festago.common.interceptor.HttpMethodDelegateInterceptor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -30,10 +32,16 @@ public class LoginConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(adminAuthInterceptor())
+        registry.addInterceptor(HttpMethodDelegateInterceptor.builder()
+                .allowMethod(HttpMethod.GET, HttpMethod.POST, HttpMethod.DELETE, HttpMethod.PUT, HttpMethod.PATCH)
+                .interceptor(adminAuthInterceptor())
+                .build())
             .addPathPatterns("/admin/**", "/js/admin/**")
             .excludePathPatterns("/admin/login", "/admin/api/login", "/admin/api/initialize");
-        registry.addInterceptor(memberAuthInterceptor())
+        registry.addInterceptor(HttpMethodDelegateInterceptor.builder()
+                .allowMethod(HttpMethod.GET, HttpMethod.POST, HttpMethod.DELETE, HttpMethod.PUT, HttpMethod.PATCH)
+                .interceptor(memberAuthInterceptor())
+                .build())
             .addPathPatterns("/member-tickets/**", "/members/**", "/auth/**", "/students/**")
             .excludePathPatterns("/auth/oauth2");
     }

--- a/backend/src/main/java/com/festago/common/interceptor/HttpMethodDelegateInterceptor.java
+++ b/backend/src/main/java/com/festago/common/interceptor/HttpMethodDelegateInterceptor.java
@@ -1,0 +1,58 @@
+package com.festago.common.interceptor;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class HttpMethodDelegateInterceptor implements HandlerInterceptor {
+
+    private final Set<String> allowMethods;
+    private final HandlerInterceptor interceptor;
+
+    protected HttpMethodDelegateInterceptor(Set<String> allowMethods, HandlerInterceptor interceptor) {
+        this.allowMethods = allowMethods;
+        this.interceptor = interceptor;
+    }
+
+    public static HttpMethodDelegateInterceptorBuilder builder() {
+        return new HttpMethodDelegateInterceptorBuilder();
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+        throws Exception {
+        if (allowMethods.contains(request.getMethod())) {
+            return interceptor.preHandle(request, response, handler);
+        }
+        return true;
+    }
+
+    public static class HttpMethodDelegateInterceptorBuilder {
+
+        private final Set<HttpMethod> allowMethod = new HashSet<>();
+        private HandlerInterceptor interceptor;
+
+        public HttpMethodDelegateInterceptorBuilder allowMethod(HttpMethod... httpMethods) {
+            allowMethod.addAll(Arrays.asList(httpMethods));
+            return this;
+        }
+
+        public HttpMethodDelegateInterceptorBuilder interceptor(HandlerInterceptor interceptor) {
+            this.interceptor = interceptor;
+            return this;
+        }
+
+        public HttpMethodDelegateInterceptor build() {
+            Set<String> methods = allowMethod.stream()
+                .map(HttpMethod::name)
+                .collect(toUnmodifiableSet());
+            return new HttpMethodDelegateInterceptor(methods, interceptor);
+        }
+    }
+}

--- a/backend/src/main/java/com/festago/config/WebConfig.java
+++ b/backend/src/main/java/com/festago/config/WebConfig.java
@@ -1,0 +1,33 @@
+package com.festago.config;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final List<String> allowUrls;
+
+    public WebConfig(@Value("${festago.cors-allow-urls}") List<String> allowUrls) {
+        this.allowUrls = allowUrls;
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOriginPatterns(getAllowedOriginPatterns())
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true)
+            .maxAge(3600);
+    }
+
+    private String[] getAllowedOriginPatterns() {
+        return allowUrls.stream()
+            .map(it -> it + "**")
+            .toArray(String[]::new);
+    }
+}

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -30,3 +30,4 @@ logging:
 festago:
   qr-secret-key: festagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestago
   auth-secret-key: festagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestago
+  cors-allow-urls: http://localhost:3000

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -16,3 +16,4 @@ logging:
 festago:
   qr-secret-key: festagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestago
   auth-secret-key: festagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestago
+  cors-allow-urls: http://localhost:3000


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #654

## ✨ PR 세부 내용

CORS 설정을 추가했습니다.

CORS 설정을 `LoginConfig`에 두기는 애매해서, 새롭게 `WebConfig` 클래스를 만들었습니다.

URL 설정은 `application.yml`의 `festago.cors-allow-urls` 필드에 추가하면 됩니다.
`,`로 구분되니 새로운 도메인이 생기면 `http://foo.com,http://bar.com`과 같이 등록하면 됩니다.

---

preflight 요청에서 CORS 문제가 발생하여 `HttpMethodDelegateInterceptor`를 추가하고 적용했습니다.

prefilght 요청에는 쿠키와 헤더가 포함되지 않으므로 CORS 설정을 올바르게 하여도, 인증과 관련된 path로 요청이 오게 되면 CORS 문제가 발생합니다.
따라서 인증과 관련된 인터셉터에서는 `OPTIONS` HTTP 메서드를 제외한 요청만 검사해야 합니다.

`CorsUtils.isPreFlightRequest()` 메서드를 사용하는 방법도 있지만, 같은 path라도, HTTP 메서드 별로 인증 권한을 다르게 해야 할 일이 생길 것 같아 `HttpMethodDelegateInterceptor`를 적용했습니다.