### PR TITLE
fix: 잘못된 CORS 설정 수정 (#659)

### DIFF
--- a/backend/src/main/java/com/festago/config/WebConfig.java
+++ b/backend/src/main/java/com/festago/config/WebConfig.java
@@ -1,6 +1,5 @@
 package com.festago.config;
 
-import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -9,25 +8,19 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    private final List<String> allowUrls;
+    private final String allowOrigins;
 
-    public WebConfig(@Value("${festago.cors-allow-urls}") List<String> allowUrls) {
-        this.allowUrls = allowUrls;
+    public WebConfig(@Value("${festago.cors-allow-origins}") String allowOrigins) {
+        this.allowOrigins = allowOrigins;
     }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedOriginPatterns(getAllowedOriginPatterns())
+            .allowedOriginPatterns(allowOrigins)
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowedHeaders("*")
             .allowCredentials(true)
             .maxAge(3600);
-    }
-
-    private String[] getAllowedOriginPatterns() {
-        return allowUrls.stream()
-            .map(it -> it + "**")
-            .toArray(String[]::new);
     }
 }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -30,4 +30,4 @@ logging:
 festago:
   qr-secret-key: festagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestago
   auth-secret-key: festagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestago
-  cors-allow-urls: http://localhost:3000
+  cors-allow-origins: http://localhost:3000

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -16,4 +16,4 @@ logging:
 festago:
   qr-secret-key: festagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestago
   auth-secret-key: festagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestagofestago
-  cors-allow-urls: http://localhost:3000
+  cors-allow-origins: http://localhost:3000


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #659

## ✨ PR 세부 내용

이슈 내용과 같이 잘못된 CORS 설정을 수정했습니다.
`allowedOriginPatterns`의 인자로 들어가는 문자열은 `,`로 구분할 수 있기에 굳이 다시 배열로 만들어 넣어주는 작업은 하지 않았습니다.
