### PR TITLE
[BE] feat: 새로운 학교 CRUD 기능 추가 (#658)

### DIFF
--- a/.github/workflows/ci-back.yml
+++ b/.github/workflows/ci-back.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - dev
       - main
-    paths: 'backend/**'
+      - feat/**
+    paths:
+      - backend/**
 
 defaults:
   run:

--- a/backend/src/main/java/com/festago/admin/presentation/AdminController.java
+++ b/backend/src/main/java/com/festago/admin/presentation/AdminController.java
@@ -98,6 +98,10 @@ public class AdminController {
             .body(response);
     }
 
+    /**
+     * @deprecated API 버저닝이 적용되면 해당 메서드 삭제
+     */
+    @Deprecated(forRemoval = true)
     @PostMapping("/schools")
     public ResponseEntity<SchoolResponse> createSchool(@RequestBody @Valid SchoolCreateRequest request) {
         SchoolResponse response = schoolService.create(request);
@@ -105,6 +109,10 @@ public class AdminController {
             .body(response);
     }
 
+    /**
+     * @deprecated API 버저닝이 적용되면 해당 메서드 삭제
+     */
+    @Deprecated(forRemoval = true)
     @PatchMapping("/schools/{schoolId}")
     public ResponseEntity<Void> updateSchool(@RequestBody @Valid SchoolUpdateRequest request,
                                              @PathVariable Long schoolId) {
@@ -113,6 +121,10 @@ public class AdminController {
             .build();
     }
 
+    /**
+     * @deprecated API 버저닝이 적용되면 해당 메서드 삭제
+     */
+    @Deprecated(forRemoval = true)
     @DeleteMapping("/schools/{schoolId}")
     public ResponseEntity<Void> deleteSchool(@PathVariable Long schoolId) {
         schoolService.delete(schoolId);

--- a/backend/src/main/java/com/festago/admin/presentation/v1/AdminSchoolV1Controller.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/AdminSchoolV1Controller.java
@@ -1,0 +1,55 @@
+package com.festago.admin.presentation.v1;
+
+import com.festago.admin.presentation.v1.dto.SchoolV1CreateRequest;
+import com.festago.admin.presentation.v1.dto.SchoolV1UpdateRequest;
+import com.festago.school.application.SchoolCommandService;
+import com.festago.school.application.SchoolDeleteService;
+import io.swagger.v3.oas.annotations.Hidden;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/api/v1/schools")
+@RequiredArgsConstructor
+@Hidden
+public class AdminSchoolV1Controller {
+
+    private final SchoolCommandService schoolCommandService;
+    private final SchoolDeleteService schoolDeleteService;
+
+    @PostMapping
+    public ResponseEntity<Void> createSchool(
+        @RequestBody SchoolV1CreateRequest request
+    ) {
+        Long schoolId = schoolCommandService.createSchool(request.toCommand());
+        return ResponseEntity.created(URI.create("/api/v1/schools/" + schoolId))
+            .build();
+    }
+
+    @PatchMapping("/{schoolId}")
+    public ResponseEntity<Void> updateSchool(
+        @PathVariable Long schoolId,
+        @RequestBody SchoolV1UpdateRequest request
+    ) {
+        schoolCommandService.updateSchool(schoolId, request.toCommand());
+        return ResponseEntity.ok()
+            .build();
+    }
+
+    @DeleteMapping("/{schoolId}")
+    public ResponseEntity<Void> deleteSchool(
+        @PathVariable Long schoolId
+    ) {
+        schoolDeleteService.deleteSchool(schoolId);
+        return ResponseEntity.noContent()
+            .build();
+    }
+}

--- a/backend/src/main/java/com/festago/admin/presentation/v1/dto/SchoolV1CreateRequest.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/dto/SchoolV1CreateRequest.java
@@ -1,0 +1,20 @@
+package com.festago.admin.presentation.v1.dto;
+
+import com.festago.school.domain.SchoolRegion;
+import com.festago.school.dto.SchoolCreateCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SchoolV1CreateRequest(
+    @NotBlank(message = "name은 공백일 수 없습니다.")
+    String name,
+    @NotBlank(message = "domain은 공백일 수 없습니다.")
+    String domain,
+    @NotNull(message = "region은 null일 수 없습니다.")
+    SchoolRegion region
+) {
+
+    public SchoolCreateCommand toCommand() {
+        return new SchoolCreateCommand(name, domain, region);
+    }
+}

--- a/backend/src/main/java/com/festago/admin/presentation/v1/dto/SchoolV1UpdateRequest.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/dto/SchoolV1UpdateRequest.java
@@ -1,0 +1,20 @@
+package com.festago.admin.presentation.v1.dto;
+
+import com.festago.school.domain.SchoolRegion;
+import com.festago.school.dto.SchoolUpdateCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SchoolV1UpdateRequest(
+    @NotBlank(message = "name은 공백일 수 없습니다.")
+    String name,
+    @NotBlank(message = "domain은 공백일 수 없습니다.")
+    String domain,
+    @NotNull(message = "region은 null일 수 없습니다.")
+    SchoolRegion region
+) {
+
+    public SchoolUpdateCommand toCommand() {
+        return new SchoolUpdateCommand(name, domain, region);
+    }
+}

--- a/backend/src/main/java/com/festago/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/festago/common/exception/ErrorCode.java
@@ -26,11 +26,12 @@ public enum ErrorCode {
     INVALID_STUDENT_VERIFICATION_CODE("올바르지 않은 학생 인증 코드입니다."),
     DELETE_CONSTRAINT_FESTIVAL("공연이 등록된 축제는 삭제할 수 없습니다."),
     DELETE_CONSTRAINT_STAGE("티켓이 등록된 공연은 삭제할 수 없습니다."),
-    DELETE_CONSTRAINT_SCHOOL("학생 또는 축제에 등록된 학교는 삭제할 수 없습니다."),
+    DELETE_CONSTRAINT_SCHOOL("학생 또는 축제에 등록된 학교는 삭제할 수 없습니다."), // @deprecate
     DUPLICATE_SCHOOL("이미 존재하는 학교 정보입니다."),
     VALIDATION_FAIL("검증이 실패하였습니다."),
     INVALID_FESTIVAL_FILTER("유효하지 않은 축제의 필터 값입니다."),
-
+    SCHOOL_DELETE_CONSTRAINT_EXISTS_STUDENT("학생이 등록된 학교는 삭제할 수 없습니다."),
+    SCHOOL_DELETE_CONSTRAINT_EXISTS_FESTIVAL("축제가 등록된 학교는 삭제할 수 없습니다."),
 
     // 401
     EXPIRED_AUTH_TOKEN("만료된 로그인 토큰입니다."),

--- a/backend/src/main/java/com/festago/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/festago/common/exception/ErrorCode.java
@@ -27,11 +27,13 @@ public enum ErrorCode {
     DELETE_CONSTRAINT_FESTIVAL("공연이 등록된 축제는 삭제할 수 없습니다."),
     DELETE_CONSTRAINT_STAGE("티켓이 등록된 공연은 삭제할 수 없습니다."),
     DELETE_CONSTRAINT_SCHOOL("학생 또는 축제에 등록된 학교는 삭제할 수 없습니다."), // @deprecate
-    DUPLICATE_SCHOOL("이미 존재하는 학교 정보입니다."),
+    DUPLICATE_SCHOOL("이미 존재하는 학교 정보입니다."), // @deprecate
     VALIDATION_FAIL("검증이 실패하였습니다."),
     INVALID_FESTIVAL_FILTER("유효하지 않은 축제의 필터 값입니다."),
     SCHOOL_DELETE_CONSTRAINT_EXISTS_STUDENT("학생이 등록된 학교는 삭제할 수 없습니다."),
     SCHOOL_DELETE_CONSTRAINT_EXISTS_FESTIVAL("축제가 등록된 학교는 삭제할 수 없습니다."),
+    DUPLICATE_SCHOOL_NAME("이미 존재하는 학교의 이름입니다."),
+    DUPLICATE_SCHOOL_DOMAIN("이미 존재하는 학교의 도메인입니다."),
 
     // 401
     EXPIRED_AUTH_TOKEN("만료된 로그인 토큰입니다."),

--- a/backend/src/main/java/com/festago/common/querydsl/QueryDslRepositorySupport.java
+++ b/backend/src/main/java/com/festago/common/querydsl/QueryDslRepositorySupport.java
@@ -1,0 +1,83 @@
+package com.festago.common.querydsl;
+
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
+import org.springframework.data.jpa.repository.support.JpaEntityInformationSupport;
+import org.springframework.data.jpa.repository.support.Querydsl;
+import org.springframework.data.querydsl.SimpleEntityPathResolver;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.Assert;
+
+@Repository
+public abstract class QueryDslRepositorySupport {
+
+    private final Class<?> domainClass;
+    private Querydsl querydsl;
+    private EntityManager entityManager;
+    private JPAQueryFactory queryFactory;
+
+    protected QueryDslRepositorySupport(Class<?> domainClass) {
+        this.domainClass = domainClass;
+    }
+
+    @Autowired
+    protected void setQueryFactory(EntityManager entityManager) {
+        Assert.notNull(entityManager, "EntityManager must not be null!");
+        JpaEntityInformation<?, ?> entityInformation =
+            JpaEntityInformationSupport.getEntityInformation(domainClass, entityManager);
+        SimpleEntityPathResolver resolver = SimpleEntityPathResolver.INSTANCE;
+        EntityPath<?> path = resolver.createPath(entityInformation.getJavaType());
+        this.entityManager = entityManager;
+        this.querydsl = new Querydsl(entityManager, new PathBuilder<>(path.getType(), path.getMetadata()));
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @PostConstruct
+    protected void validate() {
+        Assert.notNull(entityManager, "EntityManager must not be null!");
+        Assert.notNull(querydsl, "Querydsl must not be null!");
+        Assert.notNull(queryFactory, "QueryFactory must not be null!");
+    }
+
+    protected <T> JPAQuery<T> select(Expression<T> expr) {
+        return queryFactory.select(expr);
+    }
+
+    protected <T> JPAQuery<T> selectFrom(EntityPath<T> from) {
+        return queryFactory.selectFrom(from);
+    }
+
+    protected <T, X extends Throwable> T fetchOneOrThrow(
+        Function<JPAQueryFactory, JPAQuery<T>> queryFunction,
+        Supplier<? extends X> exceptionSupplier
+    ) throws X {
+        JPAQuery<T> query = queryFunction.apply(queryFactory);
+        T result = query.fetchOne();
+        if (result == null) {
+            throw exceptionSupplier.get();
+        }
+        return result;
+    }
+
+    protected <T> Page<T> applyPagination(Pageable pageable,
+                                          Function<JPAQueryFactory, JPAQuery<T>> contentQueryFunction,
+                                          Function<JPAQueryFactory, JPAQuery<Long>> countQueryFunction
+    ) {
+        var contentQuery = contentQueryFunction.apply(queryFactory);
+        var content = querydsl.applyPagination(pageable, contentQuery).fetch();
+        JPAQuery<Long> countQuery = countQueryFunction.apply(queryFactory);
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+}

--- a/backend/src/main/java/com/festago/common/querydsl/QueryDslRepositorySupport.java
+++ b/backend/src/main/java/com/festago/common/querydsl/QueryDslRepositorySupport.java
@@ -7,6 +7,7 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,12 +65,13 @@ public abstract class QueryDslRepositorySupport {
         return Optional.ofNullable(query.fetchOne());
     }
 
-    protected <T> Page<T> applyPagination(Pageable pageable,
-                                          Function<JPAQueryFactory, JPAQuery<T>> contentQueryFunction,
-                                          Function<JPAQueryFactory, JPAQuery<Long>> countQueryFunction
+    protected <T> Page<T> applyPagination(
+        Pageable pageable,
+        Function<JPAQueryFactory, JPAQuery<T>> contentQueryFunction,
+        Function<JPAQueryFactory, JPAQuery<Long>> countQueryFunction
     ) {
-        var contentQuery = contentQueryFunction.apply(queryFactory);
-        var content = querydsl.applyPagination(pageable, contentQuery).fetch();
+        JPAQuery<T> contentQuery = contentQueryFunction.apply(queryFactory);
+        List<T> content = querydsl.applyPagination(pageable, contentQuery).fetch();
         JPAQuery<Long> countQuery = countQueryFunction.apply(queryFactory);
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }

--- a/backend/src/main/java/com/festago/common/querydsl/QueryDslRepositorySupport.java
+++ b/backend/src/main/java/com/festago/common/querydsl/QueryDslRepositorySupport.java
@@ -7,8 +7,8 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
+import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -57,16 +57,11 @@ public abstract class QueryDslRepositorySupport {
         return queryFactory.selectFrom(from);
     }
 
-    protected <T, X extends Throwable> T fetchOneOrThrow(
-        Function<JPAQueryFactory, JPAQuery<T>> queryFunction,
-        Supplier<? extends X> exceptionSupplier
-    ) throws X {
+    protected <T> Optional<T> fetchOne(
+        Function<JPAQueryFactory, JPAQuery<T>> queryFunction
+    ) {
         JPAQuery<T> query = queryFunction.apply(queryFactory);
-        T result = query.fetchOne();
-        if (result == null) {
-            throw exceptionSupplier.get();
-        }
-        return result;
+        return Optional.ofNullable(query.fetchOne());
     }
 
     protected <T> Page<T> applyPagination(Pageable pageable,

--- a/backend/src/main/java/com/festago/common/querydsl/QueryDslRepositorySupport.java
+++ b/backend/src/main/java/com/festago/common/querydsl/QueryDslRepositorySupport.java
@@ -17,10 +17,8 @@ import org.springframework.data.jpa.repository.support.JpaEntityInformationSuppo
 import org.springframework.data.jpa.repository.support.Querydsl;
 import org.springframework.data.querydsl.SimpleEntityPathResolver;
 import org.springframework.data.support.PageableExecutionUtils;
-import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
 
-@Repository
 public abstract class QueryDslRepositorySupport {
 
     private final Class<?> domainClass;

--- a/backend/src/main/java/com/festago/common/querydsl/QueryDslRepositorySupport.java
+++ b/backend/src/main/java/com/festago/common/querydsl/QueryDslRepositorySupport.java
@@ -5,7 +5,6 @@ import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
@@ -24,7 +23,6 @@ public abstract class QueryDslRepositorySupport {
 
     private final Class<?> domainClass;
     private Querydsl querydsl;
-    private EntityManager entityManager;
     private JPAQueryFactory queryFactory;
 
     protected QueryDslRepositorySupport(Class<?> domainClass) {
@@ -38,24 +36,16 @@ public abstract class QueryDslRepositorySupport {
             JpaEntityInformationSupport.getEntityInformation(domainClass, entityManager);
         SimpleEntityPathResolver resolver = SimpleEntityPathResolver.INSTANCE;
         EntityPath<?> path = resolver.createPath(entityInformation.getJavaType());
-        this.entityManager = entityManager;
         this.querydsl = new Querydsl(entityManager, new PathBuilder<>(path.getType(), path.getMetadata()));
         this.queryFactory = new JPAQueryFactory(entityManager);
-    }
-
-    @PostConstruct
-    protected void validate() {
-        Assert.notNull(entityManager, "EntityManager must not be null!");
-        Assert.notNull(querydsl, "Querydsl must not be null!");
-        Assert.notNull(queryFactory, "QueryFactory must not be null!");
     }
 
     protected <T> JPAQuery<T> select(Expression<T> expr) {
         return queryFactory.select(expr);
     }
 
-    protected <T> JPAQuery<T> selectFrom(EntityPath<T> from) {
-        return queryFactory.selectFrom(from);
+    protected <T> JPAQuery<T> selectFrom(EntityPath<T> expr) {
+        return queryFactory.selectFrom(expr);
     }
 
     protected <T> Optional<T> fetchOne(

--- a/backend/src/main/java/com/festago/common/querydsl/SearchCondition.java
+++ b/backend/src/main/java/com/festago/common/querydsl/SearchCondition.java
@@ -1,0 +1,25 @@
+package com.festago.common.querydsl;
+
+import com.festago.common.util.Validator;
+import org.springframework.data.domain.Pageable;
+
+public record SearchCondition(
+    String searchFilter,
+    String searchKeyword,
+    Pageable pageable
+) {
+
+    public SearchCondition {
+        Validator.notNull(pageable, "pageable");
+    }
+
+    @Override
+    public String searchFilter() {
+        return searchFilter != null ? searchFilter : "";
+    }
+
+    @Override
+    public String searchKeyword() {
+        return searchKeyword != null ? searchKeyword : "";
+    }
+}

--- a/backend/src/main/java/com/festago/festival/application/FestivalSchoolDeleteValidator.java
+++ b/backend/src/main/java/com/festago/festival/application/FestivalSchoolDeleteValidator.java
@@ -1,0 +1,24 @@
+package com.festago.festival.application;
+
+import com.festago.common.exception.BadRequestException;
+import com.festago.common.exception.ErrorCode;
+import com.festago.festival.repository.FestivalRepository;
+import com.festago.school.application.SchoolDeleteValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FestivalSchoolDeleteValidator implements SchoolDeleteValidator {
+
+    private final FestivalRepository festivalRepository;
+
+    @Override
+    public void validate(Long schoolId) {
+        if (festivalRepository.existsBySchoolId(schoolId)) {
+            throw new BadRequestException(ErrorCode.SCHOOL_DELETE_CONSTRAINT_EXISTS_FESTIVAL);
+        }
+    }
+}

--- a/backend/src/main/java/com/festago/festival/repository/FestivalRepository.java
+++ b/backend/src/main/java/com/festago/festival/repository/FestivalRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FestivalRepository extends JpaRepository<Festival, Long>, FestivalRepositoryCustom {
 
+    boolean existsBySchoolId(Long schoolId);
 }

--- a/backend/src/main/java/com/festago/school/application/SchoolCommandService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolCommandService.java
@@ -1,0 +1,25 @@
+package com.festago.school.application;
+
+import com.festago.school.dto.SchoolCreateCommand;
+import com.festago.school.dto.SchoolUpdateCommand;
+import com.festago.school.repository.SchoolRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SchoolCommandService {
+
+    private final SchoolRepository schoolRepository;
+
+    public Long createSchool(SchoolCreateCommand command) {
+        // TODO
+        return null;
+    }
+
+    public void updateSchool(Long schoolId, SchoolUpdateCommand command) {
+        // TODO
+    }
+}

--- a/backend/src/main/java/com/festago/school/application/SchoolCommandService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolCommandService.java
@@ -44,6 +44,7 @@ public class SchoolCommandService {
         School school = schoolRepository.getOrThrow(schoolId);
         school.changeName(command.name());
         school.changeDomain(command.domain());
-        school.changeRegion(command.region());
+        // TODO School 도메인 이슈에서 주석 해제할 것!
+        // school.changeRegion(command.region());
     }
 }

--- a/backend/src/main/java/com/festago/school/application/SchoolCommandService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolCommandService.java
@@ -7,6 +7,7 @@ import com.festago.school.domain.SchoolRegion;
 import com.festago.school.dto.SchoolCreateCommand;
 import com.festago.school.dto.SchoolUpdateCommand;
 import com.festago.school.repository.SchoolRepository;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,12 +23,12 @@ public class SchoolCommandService {
         String domain = command.domain();
         String name = command.name();
         SchoolRegion region = command.region();
-        validateExistsDomainOrName(domain, name);
+        validateCreate(domain, name);
         School school = schoolRepository.save(new School(domain, name, region));
         return school.getId();
     }
 
-    private void validateExistsDomainOrName(String domain, String name) {
+    private void validateCreate(String domain, String name) {
         if (schoolRepository.existsByDomain(domain)) {
             throw new BadRequestException(ErrorCode.DUPLICATE_SCHOOL_DOMAIN);
         }
@@ -40,11 +41,20 @@ public class SchoolCommandService {
      * 학교를 인증한 학생이 있다면, domain을 변경하는 것은 문제가 될 수 있지 않을까?
      */
     public void updateSchool(Long schoolId, SchoolUpdateCommand command) {
-        validateExistsDomainOrName(command.domain(), command.name());
         School school = schoolRepository.getOrThrow(schoolId);
+        validateUpdate(school, command.domain(), command.name());
         school.changeName(command.name());
         school.changeDomain(command.domain());
         // TODO School 도메인 이슈에서 주석 해제할 것!
         // school.changeRegion(command.region());
+    }
+
+    private void validateUpdate(School school, String domain, String name) {
+        if (!Objects.equals(school.getDomain(), domain) && schoolRepository.existsByDomain(domain)) {
+            throw new BadRequestException(ErrorCode.DUPLICATE_SCHOOL_DOMAIN);
+        }
+        if (!Objects.equals(school.getName(), name) && schoolRepository.existsByName(name)) {
+            throw new BadRequestException(ErrorCode.DUPLICATE_SCHOOL_NAME);
+        }
     }
 }

--- a/backend/src/main/java/com/festago/school/application/SchoolDeleteService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolDeleteService.java
@@ -3,20 +3,19 @@ package com.festago.school.application;
 import com.festago.school.repository.SchoolRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
-@Slf4j
 public class SchoolDeleteService {
 
     private final SchoolRepository schoolRepository;
     private final List<SchoolDeleteValidator> validators;
 
     public void deleteSchool(Long schoolId) {
-        // TODO
+        validators.forEach(validator -> validator.validate(schoolId));
+        schoolRepository.deleteById(schoolId);
     }
 }

--- a/backend/src/main/java/com/festago/school/application/SchoolDeleteService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolDeleteService.java
@@ -1,0 +1,22 @@
+package com.festago.school.application;
+
+import com.festago.school.repository.SchoolRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class SchoolDeleteService {
+
+    private final SchoolRepository schoolRepository;
+    private final List<SchoolDeleteValidator> validators;
+
+    public void deleteSchool(Long schoolId) {
+        // TODO
+    }
+}

--- a/backend/src/main/java/com/festago/school/application/SchoolDeleteValidator.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolDeleteValidator.java
@@ -1,0 +1,6 @@
+package com.festago.school.application;
+
+public interface SchoolDeleteValidator {
+
+    void validate(Long schoolId);
+}

--- a/backend/src/main/java/com/festago/school/application/SchoolV1QueryService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolV1QueryService.java
@@ -1,0 +1,22 @@
+package com.festago.school.application;
+
+import com.festago.school.presentation.v1.dto.SchoolV1Response;
+import com.festago.school.presentation.v1.dto.SchoolsV1Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SchoolV1QueryService {
+
+    public SchoolsV1Response findAll(String searchFilter, String searchKeyword, Pageable pageable) {
+        return null;
+    }
+
+    public SchoolV1Response findById(Long schoolId) {
+        return null;
+    }
+}

--- a/backend/src/main/java/com/festago/school/application/SchoolV1QueryService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolV1QueryService.java
@@ -1,5 +1,7 @@
 package com.festago.school.application;
 
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
 import com.festago.common.querydsl.SearchCondition;
 import com.festago.school.presentation.v1.dto.SchoolV1Response;
 import com.festago.school.repository.SchoolV1QueryDslRepository;
@@ -20,6 +22,7 @@ public class SchoolV1QueryService {
     }
 
     public SchoolV1Response findById(Long schoolId) {
-        return schoolQueryDslRepository.findById(schoolId);
+        return schoolQueryDslRepository.findById(schoolId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.SCHOOL_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/com/festago/school/application/SchoolV1QueryService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolV1QueryService.java
@@ -1,9 +1,10 @@
 package com.festago.school.application;
 
+import com.festago.common.querydsl.SearchCondition;
 import com.festago.school.presentation.v1.dto.SchoolV1Response;
-import com.festago.school.presentation.v1.dto.SchoolsV1Response;
+import com.festago.school.repository.SchoolV1QueryDslRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,11 +13,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SchoolV1QueryService {
 
-    public SchoolsV1Response findAll(String searchFilter, String searchKeyword, Pageable pageable) {
-        return null;
+    private final SchoolV1QueryDslRepository schoolQueryDslRepository;
+
+    public Page<SchoolV1Response> findAll(SearchCondition searchCondition) {
+        return schoolQueryDslRepository.findAll(searchCondition);
     }
 
     public SchoolV1Response findById(Long schoolId) {
-        return null;
+        return schoolQueryDslRepository.findById(schoolId);
     }
 }

--- a/backend/src/main/java/com/festago/school/dto/SchoolCreateCommand.java
+++ b/backend/src/main/java/com/festago/school/dto/SchoolCreateCommand.java
@@ -1,0 +1,17 @@
+package com.festago.school.dto;
+
+import com.festago.common.util.Validator;
+import com.festago.school.domain.SchoolRegion;
+
+public record SchoolCreateCommand(
+    String name,
+    String domain,
+    SchoolRegion region
+) {
+
+    public SchoolCreateCommand {
+        Validator.notNull(name, "name");
+        Validator.notNull(domain, "domain");
+        Validator.notNull(region, "region");
+    }
+}

--- a/backend/src/main/java/com/festago/school/dto/SchoolCreateRequest.java
+++ b/backend/src/main/java/com/festago/school/dto/SchoolCreateRequest.java
@@ -2,10 +2,15 @@ package com.festago.school.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+/**
+ * @deprecated API 버저닝이 적용되면 해당 클래스 삭제
+ */
+@Deprecated(forRemoval = true)
 public record SchoolCreateRequest(
     @NotBlank(message = "domain은 공백일 수 없습니다.")
     String domain,
     @NotBlank(message = "name은 공백일 수 없습니다.")
     String name
 ) {
+
 }

--- a/backend/src/main/java/com/festago/school/dto/SchoolResponse.java
+++ b/backend/src/main/java/com/festago/school/dto/SchoolResponse.java
@@ -2,6 +2,10 @@ package com.festago.school.dto;
 
 import com.festago.school.domain.School;
 
+/**
+ * @deprecated API 버저닝이 적용되면 해당 클래스 삭제
+ */
+@Deprecated(forRemoval = true)
 public record SchoolResponse(
     Long id,
     String domain,

--- a/backend/src/main/java/com/festago/school/dto/SchoolUpdateCommand.java
+++ b/backend/src/main/java/com/festago/school/dto/SchoolUpdateCommand.java
@@ -1,0 +1,17 @@
+package com.festago.school.dto;
+
+import com.festago.common.util.Validator;
+import com.festago.school.domain.SchoolRegion;
+
+public record SchoolUpdateCommand(
+    String name,
+    String domain,
+    SchoolRegion region
+) {
+
+    public SchoolUpdateCommand {
+        Validator.notNull(name, "name");
+        Validator.notNull(domain, "domain");
+        Validator.notNull(region, "region");
+    }
+}

--- a/backend/src/main/java/com/festago/school/dto/SchoolUpdateRequest.java
+++ b/backend/src/main/java/com/festago/school/dto/SchoolUpdateRequest.java
@@ -2,6 +2,10 @@ package com.festago.school.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+/**
+ * @deprecated API 버저닝이 적용되면 해당 클래스 삭제
+ */
+@Deprecated(forRemoval = true)
 public record SchoolUpdateRequest(
     @NotBlank(message = "domain은 공백일 수 없습니다.") String domain,
     @NotBlank(message = "name은 공백일 수 없습니다.") String name

--- a/backend/src/main/java/com/festago/school/dto/SchoolsResponse.java
+++ b/backend/src/main/java/com/festago/school/dto/SchoolsResponse.java
@@ -6,6 +6,10 @@ import static java.util.stream.Collectors.toList;
 import com.festago.school.domain.School;
 import java.util.List;
 
+/**
+ * @deprecated API 버저닝이 적용되면 해당 클래스 삭제
+ */
+@Deprecated(forRemoval = true)
 public record SchoolsResponse(
     List<SchoolResponse> schools) {
 

--- a/backend/src/main/java/com/festago/school/presentation/SchoolController.java
+++ b/backend/src/main/java/com/festago/school/presentation/SchoolController.java
@@ -12,6 +12,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * @deprecated API 버저닝이 적용되면 해당 클래스 삭제
+ */
+@Deprecated(forRemoval = true)
 @RestController
 @RequestMapping("/schools")
 @Tag(name = "학교 정보 요청")

--- a/backend/src/main/java/com/festago/school/presentation/v1/SchoolV1Controller.java
+++ b/backend/src/main/java/com/festago/school/presentation/v1/SchoolV1Controller.java
@@ -1,10 +1,11 @@
 package com.festago.school.presentation.v1;
 
+import com.festago.common.querydsl.SearchCondition;
 import com.festago.school.application.SchoolV1QueryService;
 import com.festago.school.presentation.v1.dto.SchoolV1Response;
-import com.festago.school.presentation.v1.dto.SchoolsV1Response;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,13 +23,13 @@ public class SchoolV1Controller {
     private final SchoolV1QueryService schoolQueryService;
 
     @GetMapping
-    public ResponseEntity<SchoolsV1Response> findAllSchools(
-        @RequestParam(required = false) String searchFilter,
-        @RequestParam(required = false) String searchKeyword,
+    public ResponseEntity<Page<SchoolV1Response>> findAllSchools(
+        @RequestParam(defaultValue = "") String searchFilter,
+        @RequestParam(defaultValue = "") String searchKeyword,
         Pageable pageable
     ) {
         return ResponseEntity.ok()
-            .body(schoolQueryService.findAll(searchFilter, searchKeyword, pageable));
+            .body(schoolQueryService.findAll(new SearchCondition(searchFilter, searchKeyword, pageable)));
     }
 
     @GetMapping("/{schoolId}")

--- a/backend/src/main/java/com/festago/school/presentation/v1/SchoolV1Controller.java
+++ b/backend/src/main/java/com/festago/school/presentation/v1/SchoolV1Controller.java
@@ -1,0 +1,41 @@
+package com.festago.school.presentation.v1;
+
+import com.festago.school.application.SchoolV1QueryService;
+import com.festago.school.presentation.v1.dto.SchoolV1Response;
+import com.festago.school.presentation.v1.dto.SchoolsV1Response;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/schools")
+@Tag(name = "학교 정보 요청 V1")
+@RequiredArgsConstructor
+public class SchoolV1Controller {
+
+    private final SchoolV1QueryService schoolQueryService;
+
+    @GetMapping
+    public ResponseEntity<SchoolsV1Response> findAllSchools(
+        @RequestParam(required = false) String searchFilter,
+        @RequestParam(required = false) String searchKeyword,
+        Pageable pageable
+    ) {
+        return ResponseEntity.ok()
+            .body(schoolQueryService.findAll(searchFilter, searchKeyword, pageable));
+    }
+
+    @GetMapping("/{schoolId}")
+    public ResponseEntity<SchoolV1Response> findSchoolById(
+        @PathVariable Long schoolId
+    ) {
+        return ResponseEntity.ok()
+            .body(schoolQueryService.findById(schoolId));
+    }
+}

--- a/backend/src/main/java/com/festago/school/presentation/v1/dto/SchoolV1Response.java
+++ b/backend/src/main/java/com/festago/school/presentation/v1/dto/SchoolV1Response.java
@@ -1,6 +1,7 @@
 package com.festago.school.presentation.v1.dto;
 
 import com.festago.school.domain.SchoolRegion;
+import com.querydsl.core.annotations.QueryProjection;
 
 public record SchoolV1Response(
     Long id,
@@ -9,4 +10,8 @@ public record SchoolV1Response(
     SchoolRegion region
 ) {
 
+    @QueryProjection
+    public SchoolV1Response {
+        // for QueryProjection
+    }
 }

--- a/backend/src/main/java/com/festago/school/presentation/v1/dto/SchoolV1Response.java
+++ b/backend/src/main/java/com/festago/school/presentation/v1/dto/SchoolV1Response.java
@@ -1,0 +1,12 @@
+package com.festago.school.presentation.v1.dto;
+
+import com.festago.school.domain.SchoolRegion;
+
+public record SchoolV1Response(
+    Long id,
+    String domain,
+    String name,
+    SchoolRegion region
+) {
+
+}

--- a/backend/src/main/java/com/festago/school/presentation/v1/dto/SchoolsV1Response.java
+++ b/backend/src/main/java/com/festago/school/presentation/v1/dto/SchoolsV1Response.java
@@ -1,9 +1,0 @@
-package com.festago.school.presentation.v1.dto;
-
-import java.util.List;
-
-public record SchoolsV1Response(
-    List<SchoolV1Response> schools
-) {
-
-}

--- a/backend/src/main/java/com/festago/school/presentation/v1/dto/SchoolsV1Response.java
+++ b/backend/src/main/java/com/festago/school/presentation/v1/dto/SchoolsV1Response.java
@@ -1,0 +1,9 @@
+package com.festago.school.presentation.v1.dto;
+
+import java.util.List;
+
+public record SchoolsV1Response(
+    List<SchoolV1Response> schools
+) {
+
+}

--- a/backend/src/main/java/com/festago/school/repository/SchoolRepository.java
+++ b/backend/src/main/java/com/festago/school/repository/SchoolRepository.java
@@ -1,9 +1,24 @@
 package com.festago.school.repository;
 
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
 import com.festago.school.domain.School;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SchoolRepository extends JpaRepository<School, Long> {
 
+    default School getOrThrow(Long schoolId) {
+        return findById(schoolId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.SCHOOL_NOT_FOUND));
+    }
+
+    /**
+     * @deprecated API 버저닝이 적용되면 해당 메서드 삭제
+     */
+    @Deprecated(forRemoval = true)
     boolean existsByDomainOrName(String domain, String name);
+
+    boolean existsByDomain(String domain);
+
+    boolean existsByName(String name);
 }

--- a/backend/src/main/java/com/festago/school/repository/SchoolV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/school/repository/SchoolV1QueryDslRepository.java
@@ -1,0 +1,95 @@
+package com.festago.school.repository;
+
+import static com.festago.school.domain.QSchool.school;
+
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
+import com.festago.common.querydsl.QueryDslRepositorySupport;
+import com.festago.common.querydsl.SearchCondition;
+import com.festago.school.domain.School;
+import com.festago.school.presentation.v1.dto.QSchoolV1Response;
+import com.festago.school.presentation.v1.dto.SchoolV1Response;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+public class SchoolV1QueryDslRepository extends QueryDslRepositorySupport {
+
+    protected SchoolV1QueryDslRepository() {
+        super(School.class);
+    }
+
+    public Page<SchoolV1Response> findAll(SearchCondition searchCondition) {
+        Pageable pageable = searchCondition.pageable();
+        String searchFilter = searchCondition.searchFilter();
+        String searchKeyword = searchCondition.searchKeyword();
+        return applyPagination(pageable,
+            queryFactory -> queryFactory.select(
+                    new QSchoolV1Response(
+                        school.id,
+                        school.domain,
+                        school.name,
+                        school.region
+                    ))
+                .from(school)
+                .where(containSearchFilter(searchFilter, searchKeyword))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize()),
+            queryFactory -> queryFactory.select(school.count())
+                .where(containSearchFilter(searchFilter, searchKeyword))
+                .from(school));
+    }
+
+    private BooleanExpression containSearchFilter(String searchFilter, String searchKeyword) {
+        return switch (searchFilter) {
+            case "id" -> eqId(searchKeyword);
+            case "domain" -> containsDomain(searchKeyword);
+            case "name" -> containsName(searchKeyword);
+            case "region" -> eqRegion(searchKeyword);
+            default -> null;
+        };
+    }
+
+    private BooleanExpression eqId(String id) {
+        if (StringUtils.hasText(id)) {
+            return school.id.stringValue().eq(id);
+        }
+        return null;
+    }
+
+    private BooleanExpression containsDomain(String domain) {
+        if (StringUtils.hasText(domain)) {
+            return school.domain.contains(domain);
+        }
+        return null;
+    }
+
+    private BooleanExpression containsName(String name) {
+        if (StringUtils.hasText(name)) {
+            return school.name.contains(name);
+        }
+        return null;
+    }
+
+    private BooleanExpression eqRegion(String region) {
+        if (StringUtils.hasText(region)) {
+            return school.region.stringValue().eq(region);
+        }
+        return null;
+    }
+
+    public SchoolV1Response findById(Long schoolId) {
+        return fetchOneOrThrow(queryFactory -> queryFactory.select(
+                new QSchoolV1Response(
+                    school.id,
+                    school.domain,
+                    school.name,
+                    school.region
+                ))
+            .from(school)
+            .where(school.id.eq(schoolId)), () -> new NotFoundException(ErrorCode.SCHOOL_NOT_FOUND));
+    }
+}

--- a/backend/src/main/java/com/festago/school/repository/SchoolV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/school/repository/SchoolV1QueryDslRepository.java
@@ -2,14 +2,13 @@ package com.festago.school.repository;
 
 import static com.festago.school.domain.QSchool.school;
 
-import com.festago.common.exception.ErrorCode;
-import com.festago.common.exception.NotFoundException;
 import com.festago.common.querydsl.QueryDslRepositorySupport;
 import com.festago.common.querydsl.SearchCondition;
 import com.festago.school.domain.School;
 import com.festago.school.presentation.v1.dto.QSchoolV1Response;
 import com.festago.school.presentation.v1.dto.SchoolV1Response;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -81,8 +80,8 @@ public class SchoolV1QueryDslRepository extends QueryDslRepositorySupport {
         return null;
     }
 
-    public SchoolV1Response findById(Long schoolId) {
-        return fetchOneOrThrow(queryFactory -> queryFactory.select(
+    public Optional<SchoolV1Response> findById(Long schoolId) {
+        return fetchOne(queryFactory -> queryFactory.select(
                 new QSchoolV1Response(
                     school.id,
                     school.domain,
@@ -90,6 +89,6 @@ public class SchoolV1QueryDslRepository extends QueryDslRepositorySupport {
                     school.region
                 ))
             .from(school)
-            .where(school.id.eq(schoolId)), () -> new NotFoundException(ErrorCode.SCHOOL_NOT_FOUND));
+            .where(school.id.eq(schoolId)));
     }
 }

--- a/backend/src/main/java/com/festago/student/application/StudentSchoolDeleteValidator.java
+++ b/backend/src/main/java/com/festago/student/application/StudentSchoolDeleteValidator.java
@@ -1,0 +1,24 @@
+package com.festago.student.application;
+
+import com.festago.common.exception.BadRequestException;
+import com.festago.common.exception.ErrorCode;
+import com.festago.school.application.SchoolDeleteValidator;
+import com.festago.student.repository.StudentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class StudentSchoolDeleteValidator implements SchoolDeleteValidator {
+
+    private final StudentRepository studentRepository;
+
+    @Override
+    public void validate(Long schoolId) {
+        if (studentRepository.existsBySchoolId(schoolId)) {
+            throw new BadRequestException(ErrorCode.SCHOOL_DELETE_CONSTRAINT_EXISTS_STUDENT);
+        }
+    }
+}

--- a/backend/src/main/java/com/festago/student/repository/StudentRepository.java
+++ b/backend/src/main/java/com/festago/student/repository/StudentRepository.java
@@ -11,4 +11,6 @@ public interface StudentRepository extends JpaRepository<Student, Long>, Student
     boolean existsByUsernameAndSchoolId(String username, Long id);
 
     boolean existsByMemberId(Long id);
+
+    boolean existsBySchoolId(Long schoolId);
 }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -16,6 +16,10 @@ spring:
     enabled: true
     baseline-on-migrate: true
     baseline-version: 1
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true
 
 logging:
   file:

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminSchoolV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminSchoolV1ControllerTest.java
@@ -1,0 +1,122 @@
+package com.festago.admin.presentation.v1;
+
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.admin.presentation.v1.dto.SchoolV1CreateRequest;
+import com.festago.admin.presentation.v1.dto.SchoolV1UpdateRequest;
+import com.festago.auth.domain.Role;
+import com.festago.school.application.SchoolCommandService;
+import com.festago.school.application.SchoolDeleteService;
+import com.festago.school.domain.SchoolRegion;
+import com.festago.school.dto.SchoolCreateCommand;
+import com.festago.support.CustomWebMvcTest;
+import com.festago.support.WithMockAuth;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class AdminSchoolV1ControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    SchoolCommandService schoolCommandService;
+
+    @Autowired
+    SchoolDeleteService schoolDeleteService;
+
+    @Nested
+    class 학교_생성 {
+
+        final String uri = "/admin/api/v1/schools";
+
+        @Nested
+        @DisplayName("POST " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_201_응답과_Location_헤더에_식별자가_반환된다() throws Exception {
+                // given
+                var request = new SchoolV1CreateRequest("테코대학교", "teco.ac.kr", SchoolRegion.서울);
+                given(schoolCommandService.createSchool(any(SchoolCreateCommand.class)))
+                    .willReturn(1L);
+
+                // when & then
+                mockMvc.perform(post(uri)
+                        .cookie(new Cookie("token", "Bearer token"))
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isCreated())
+                    .andExpect(header().string(HttpHeaders.LOCATION, "/api/v1/schools/1"));
+            }
+        }
+    }
+
+    @Nested
+    class 학교_수정 {
+
+        final String uri = "/admin/api/v1/schools/{schoolId}";
+
+        @Nested
+        @DisplayName("PATCH " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                // given
+                var request = new SchoolV1UpdateRequest("테코대학교", "teco.ac.kr", SchoolRegion.서울);
+
+                // when & then
+                mockMvc.perform(patch(uri, 1L)
+                        .cookie(new Cookie("token", "Bearer token"))
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+        }
+    }
+
+    @Nested
+    class 학교_삭제 {
+
+        final String uri = "/admin/api/v1/schools/{schoolId}";
+
+        @Nested
+        @DisplayName("DELETE " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_204_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(delete(uri, 1L)
+                        .cookie(new Cookie("token", "Bearer token"))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNoContent());
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
@@ -1,0 +1,139 @@
+package com.festago.school.application.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.festago.common.exception.BadRequestException;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
+import com.festago.school.application.SchoolCommandService;
+import com.festago.school.domain.School;
+import com.festago.school.domain.SchoolRegion;
+import com.festago.school.dto.SchoolCreateCommand;
+import com.festago.school.dto.SchoolUpdateCommand;
+import com.festago.school.repository.SchoolRepository;
+import com.festago.support.ApplicationIntegrationTest;
+import com.festago.support.SchoolFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
+
+    @Autowired
+    SchoolCommandService schoolCommandService;
+
+    @Autowired
+    SchoolRepository schoolRepository;
+
+    @Nested
+    class createSchool {
+
+        SchoolCreateCommand command = new SchoolCreateCommand("테코대학교", "teco.ac.kr", SchoolRegion.서울);
+
+        @Test
+        void 같은_도메인의_학교가_저장되어_있으면_예외가_발생한다() {
+            // given
+            schoolRepository.save(SchoolFixture.school().domain("teco.ac.kr").build());
+
+            // when & then
+            assertThatThrownBy(() -> schoolCommandService.createSchool(command))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.DUPLICATE_SCHOOL_DOMAIN.getMessage());
+        }
+
+        @Test
+        void 같은_이름의_학교가_저장되어_있으면_예외가_발생한다() {
+            // given
+            schoolRepository.save(SchoolFixture.school().name("테코대학교").build());
+
+            // when & then
+            assertThatThrownBy(() -> schoolCommandService.createSchool(command))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.DUPLICATE_SCHOOL_NAME.getMessage());
+        }
+
+        @Test
+        void 예외가_발생하지_않으면_학교가_저장된다() {
+            // when
+            Long schoolId = schoolCommandService.createSchool(command);
+
+            // then
+            assertThat(schoolRepository.findById(schoolId)).isPresent();
+        }
+    }
+
+    @Nested
+    class updateSchool {
+
+        SchoolUpdateCommand command = new SchoolUpdateCommand("테코대학교", "teco.ac.kr", SchoolRegion.서울);
+        School school;
+
+        @BeforeEach
+        void setUp() {
+            school = schoolRepository.save(new School("wote.ac.kr", "우테대학교", SchoolRegion.대구));
+        }
+
+        @Test
+        void 식별자에_대한_학교를_찾을수_없으면_예외가_발생한다() {
+            // given
+            Long schoolId = 4885L;
+
+            // when & then
+            assertThatThrownBy(() -> schoolCommandService.updateSchool(schoolId, command))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.SCHOOL_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 같은_도메인의_학교가_저장되어_있으면_예외가_발생한다() {
+            // given
+            Long schoolId = school.getId();
+            schoolRepository.save(SchoolFixture.school().domain("teco.ac.kr").build());
+
+            // when & then
+            assertThatThrownBy(() -> schoolCommandService.updateSchool(schoolId, command))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.DUPLICATE_SCHOOL_DOMAIN.getMessage());
+        }
+
+        @Test
+        void 같은_이름의_학교가_저장되어_있으면_예외가_발생한다() {
+            // given
+            Long schoolId = school.getId();
+            schoolRepository.save(SchoolFixture.school().name("테코대학교").build());
+
+            // when & then
+            assertThatThrownBy(() -> schoolCommandService.updateSchool(schoolId, command))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.DUPLICATE_SCHOOL_NAME.getMessage());
+        }
+
+        /**
+         * 여기서 통합 테스트의 단점이 드러난다. 변경된 School은 위의 변수로 선언한 School과 같은 인스턴스이다. 하지만 updateSchool() 메서드로 변경된 School은 변수로 선언된
+         * School과 다르다. 따라서 변경을 확인하려면 SchoolRepository에서 영속된 School을 찾아야한다.
+         */
+        @Test
+        void 예외가_발생하지_않으면_학교가_수정된다() {
+            // given
+            Long schoolId = school.getId();
+
+            // when
+            schoolCommandService.updateSchool(schoolId, command);
+
+            // then
+            School updatedSchool = schoolRepository.getOrThrow(schoolId);
+            assertSoftly(softly -> {
+                assertThat(updatedSchool.getName()).isEqualTo("테코대학교");
+                assertThat(updatedSchool.getDomain()).isEqualTo("teco.ac.kr");
+                assertThat(updatedSchool.getRegion()).isEqualTo(SchoolRegion.서울);
+            });
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
@@ -130,8 +130,8 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
             // then
             School updatedSchool = schoolRepository.getOrThrow(schoolId);
             assertSoftly(softly -> {
-                assertThat(updatedSchool.getName()).isEqualTo("테코대학교");
-                assertThat(updatedSchool.getDomain()).isEqualTo("teco.ac.kr");
+                softly.assertThat(updatedSchool.getName()).isEqualTo("테코대학교");
+                softly.assertThat(updatedSchool.getDomain()).isEqualTo("teco.ac.kr");
                 // TODO School 도메인 이슈에서 주석 해제할 것!
                 // assertThat(updatedSchool.getRegion()).isEqualTo(SchoolRegion.서울);
             });

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
@@ -132,7 +132,8 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
             assertSoftly(softly -> {
                 assertThat(updatedSchool.getName()).isEqualTo("테코대학교");
                 assertThat(updatedSchool.getDomain()).isEqualTo("teco.ac.kr");
-                assertThat(updatedSchool.getRegion()).isEqualTo(SchoolRegion.서울);
+                // TODO School 도메인 이슈에서 주석 해제할 것!
+                // assertThat(updatedSchool.getRegion()).isEqualTo(SchoolRegion.서울);
             });
         }
     }

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
@@ -115,6 +115,34 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
                 .hasMessage(ErrorCode.DUPLICATE_SCHOOL_NAME.getMessage());
         }
 
+        @Test
+        void 수정할_이름이_수정할_학교의_이름과_같으면_이름은_수정되지_않는다() {
+            // given
+            Long schoolId = school.getId();
+            SchoolUpdateCommand command = new SchoolUpdateCommand(school.getName(), "teco.ac.kr", SchoolRegion.서울);
+
+            // when
+            schoolCommandService.updateSchool(schoolId, command);
+
+            // then
+            School updatedSchool = schoolRepository.getOrThrow(schoolId);
+            assertThat(updatedSchool.getName()).isEqualTo(school.getName());
+        }
+
+        @Test
+        void 수정할_도메인이_수정할_학교의_도메인과_같으면_도메인은_수정되지_않는다() {
+            // given
+            Long schoolId = school.getId();
+            SchoolUpdateCommand command = new SchoolUpdateCommand("테코대학교", school.getDomain(), SchoolRegion.서울);
+
+            // when
+            schoolCommandService.updateSchool(schoolId, command);
+
+            // then
+            School updatedSchool = schoolRepository.getOrThrow(schoolId);
+            assertThat(updatedSchool.getDomain()).isEqualTo(school.getDomain());
+        }
+
         /**
          * 여기서 통합 테스트의 단점이 드러난다. 변경된 School은 위의 변수로 선언한 School과 같은 인스턴스이다. 하지만 updateSchool() 메서드로 변경된 School은 변수로 선언된
          * School과 다르다. 따라서 변경을 확인하려면 SchoolRepository에서 영속된 School을 찾아야한다.

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolDeleteServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolDeleteServiceIntegrationTest.java
@@ -1,0 +1,103 @@
+package com.festago.school.application.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.festago.common.exception.BadRequestException;
+import com.festago.common.exception.ErrorCode;
+import com.festago.festival.domain.Festival;
+import com.festago.festival.repository.FestivalRepository;
+import com.festago.member.domain.Member;
+import com.festago.member.repository.MemberRepository;
+import com.festago.school.application.SchoolDeleteService;
+import com.festago.school.domain.School;
+import com.festago.school.repository.SchoolRepository;
+import com.festago.student.domain.Student;
+import com.festago.student.repository.StudentRepository;
+import com.festago.support.ApplicationIntegrationTest;
+import com.festago.support.FestivalFixture;
+import com.festago.support.MemberFixture;
+import com.festago.support.SchoolFixture;
+import com.festago.support.StudentFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * TODO
+ * 서비스 통합 테스트 시 필요한 의존이 너무 많은 것 같다. 차라리 Cucumber를 사용한 통합 테스트로 해당 테스트가 하는 역할을 옮기고, 서비스 통합 테스트는 Stub을 사용한 단위 테스트로 변경하여
+ * 서비스가 행하고자 하는 비즈니스 로직을 나타내는 테스트로 하는게 어떨까 deleteSchool() 메서드의 행위는 Validator.validate()를 호출하여, 던져진 예외가 있으면 삭제에 실패한다. 라고
+ * 볼 수 있다.
+ */
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SchoolDeleteServiceIntegrationTest extends ApplicationIntegrationTest {
+
+    @Autowired
+    SchoolDeleteService schoolDeleteService;
+
+    @Autowired
+    SchoolRepository schoolRepository;
+
+    @Autowired
+    FestivalRepository festivalRepository;
+
+    @Autowired
+    StudentRepository studentRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Nested
+    class deleteSchool {
+
+        School school;
+
+        @BeforeEach
+        void setUp() {
+            school = schoolRepository.save(SchoolFixture.school().build());
+        }
+
+        @Test
+        void 학교에_등록된_축제가_있으면_삭제에_실패한다() {
+            // given
+            Long schoolId = school.getId();
+            Festival festival = FestivalFixture.festival().school(school).build();
+            festivalRepository.save(festival);
+
+            // when & then
+            assertThatThrownBy(() -> schoolDeleteService.deleteSchool(schoolId))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.SCHOOL_DELETE_CONSTRAINT_EXISTS_FESTIVAL.getMessage());
+        }
+
+        @Test
+        void 학교에_등록된_학생이_있으면_삭제에_실패한다() {
+            // given
+            Long schoolId = school.getId();
+            Member member = memberRepository.save(MemberFixture.member().build());
+            Student student = StudentFixture.student().member(member).school(school).build();
+            studentRepository.save(student);
+
+            // when & then
+            assertThatThrownBy(() -> schoolDeleteService.deleteSchool(schoolId))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.SCHOOL_DELETE_CONSTRAINT_EXISTS_STUDENT.getMessage());
+        }
+
+        @Test
+        void Validator의_검증이_정상이면_학교가_삭제된다() {
+            // given
+            Long schoolId = school.getId();
+
+            // when
+            schoolDeleteService.deleteSchool(schoolId);
+
+            // then
+            assertThat(schoolRepository.findById(1L)).isEmpty();
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolV1QueryServiceIntegrationTest.java
@@ -1,0 +1,191 @@
+package com.festago.school.application.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
+import com.festago.common.querydsl.SearchCondition;
+import com.festago.school.application.SchoolV1QueryService;
+import com.festago.school.domain.School;
+import com.festago.school.domain.SchoolRegion;
+import com.festago.school.presentation.v1.dto.SchoolV1Response;
+import com.festago.school.repository.SchoolRepository;
+import com.festago.support.ApplicationIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class SchoolV1QueryServiceIntegrationTest extends ApplicationIntegrationTest {
+
+    @Autowired
+    SchoolV1QueryService schoolV1QueryService;
+
+    @Autowired
+    SchoolRepository schoolRepository;
+
+    School 테코대학교;
+    School 우테대학교;
+    School 글렌대학교;
+
+    @BeforeEach
+    void setUp() {
+        테코대학교 = schoolRepository.save(new School("teco.ac.kr", "테코대학교", SchoolRegion.서울));
+        우테대학교 = schoolRepository.save(new School("wote.ac.kr", "우테대학교", SchoolRegion.서울));
+        글렌대학교 = schoolRepository.save(new School("glen.ac.kr", "글렌대학교", SchoolRegion.대구));
+    }
+
+    @Nested
+    class findAll {
+
+        @Test
+        void 정렬이_되어야_한다() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "name"));
+            SearchCondition searchCondition = new SearchCondition("", "", pageable);
+
+            // when
+            Page<SchoolV1Response> response = schoolV1QueryService.findAll(searchCondition);
+
+            assertThat(response.getContent())
+                .map(SchoolV1Response::name)
+                .containsExactly(글렌대학교.getName(), 우테대학교.getName(), 테코대학교.getName());
+        }
+
+        @Test
+        void 식별자로_검색이_되어야_한다() {
+            // given
+            Pageable pageable = Pageable.ofSize(10);
+            SearchCondition searchCondition = new SearchCondition("id", 글렌대학교.getId().toString(), pageable);
+
+            // when
+            Page<SchoolV1Response> response = schoolV1QueryService.findAll(searchCondition);
+
+            assertThat(response.getContent())
+                .map(SchoolV1Response::name)
+                .containsExactlyInAnyOrder(글렌대학교.getName());
+        }
+
+        @Test
+        void 지역으로_검색이_되어야_한다() {
+            // given
+            Pageable pageable = Pageable.ofSize(10);
+            SearchCondition searchCondition = new SearchCondition("region", "서울", pageable);
+
+            // when
+            Page<SchoolV1Response> response = schoolV1QueryService.findAll(searchCondition);
+
+            assertThat(response.getContent())
+                .map(SchoolV1Response::name)
+                .containsExactlyInAnyOrder(우테대학교.getName(), 테코대학교.getName());
+        }
+
+        @Test
+        void 도메인이_포함된_검색이_되어야_한다() {
+            // given
+            Pageable pageable = Pageable.ofSize(10);
+            SearchCondition searchCondition = new SearchCondition("domain", "wote", pageable);
+
+            // when
+            Page<SchoolV1Response> response = schoolV1QueryService.findAll(searchCondition);
+
+            assertThat(response.getContent())
+                .map(SchoolV1Response::name)
+                .containsExactly(우테대학교.getName());
+        }
+
+        @Test
+        void 이름이_포함된_검색이_되어야_한다() {
+            // given
+            Pageable pageable = Pageable.ofSize(10);
+            SearchCondition searchCondition = new SearchCondition("name", "글렌", pageable);
+
+            // when
+            Page<SchoolV1Response> response = schoolV1QueryService.findAll(searchCondition);
+
+            assertThat(response.getContent())
+                .map(SchoolV1Response::name)
+                .containsExactly(글렌대학교.getName());
+        }
+
+        @Test
+        void 검색_필터가_비어있으면_필터링이_적용되지_않는다() {
+            // given
+            Pageable pageable = Pageable.ofSize(10);
+            SearchCondition searchCondition = new SearchCondition("", "글렌", pageable);
+
+            // when
+            Page<SchoolV1Response> response = schoolV1QueryService.findAll(searchCondition);
+
+            assertThat(response.getContent())
+                .hasSize(3);
+        }
+
+        @Test
+        void 검색어가_비어있으면_필터링이_적용되지_않는다() {
+            // given
+            Pageable pageable = Pageable.ofSize(10);
+            SearchCondition searchCondition = new SearchCondition("id", "", pageable);
+
+            // when
+            Page<SchoolV1Response> response = schoolV1QueryService.findAll(searchCondition);
+
+            assertThat(response.getContent())
+                .hasSize(3);
+        }
+
+        @Test
+        void 페이지네이션이_적용_되어야_한다() {
+            // given
+            Pageable pageable = PageRequest.of(0, 2);
+            SearchCondition searchCondition = new SearchCondition("", "", pageable);
+
+            // when
+            Page<SchoolV1Response> response = schoolV1QueryService.findAll(searchCondition);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.getSize()).isEqualTo(2);
+                softly.assertThat(response.getTotalPages()).isEqualTo(2);
+                softly.assertThat(response.getTotalElements()).isEqualTo(3);
+            });
+        }
+    }
+
+    @Nested
+    class findById {
+
+        @Test
+        void 식별자로_조회가_되어야_한다() {
+            // given
+            Long 테코대학교_식별자 = 테코대학교.getId();
+
+            // when
+            SchoolV1Response response = schoolV1QueryService.findById(테코대학교_식별자);
+
+            // then
+            assertThat(response.name()).isEqualTo("테코대학교");
+        }
+
+        @Test
+        void 식별자로_찾을_수_없으면_예외가_발생한다() {
+            // given
+            Long invalidId = 4885L;
+
+            // when
+            assertThatThrownBy(() -> schoolV1QueryService.findById(invalidId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.SCHOOL_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/school/presentation/v1/SchoolV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/school/presentation/v1/SchoolV1ControllerTest.java
@@ -1,0 +1,106 @@
+package com.festago.school.presentation.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.school.application.SchoolV1QueryService;
+import com.festago.school.domain.SchoolRegion;
+import com.festago.school.presentation.v1.dto.SchoolV1Response;
+import com.festago.school.presentation.v1.dto.SchoolsV1Response;
+import com.festago.support.CustomWebMvcTest;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class SchoolV1ControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    SchoolV1QueryService schoolV1QueryService;
+
+    @Nested
+    class 모든_학교_정보_조회 {
+
+        final String uri = "/api/v1/schools";
+
+        @Nested
+        @DisplayName("GET " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            void 요청을_하면_200_응답과_학교_정보_목록이_반환된다() throws Exception {
+                // given
+                var expected = new SchoolsV1Response(
+                    List.of(
+                        new SchoolV1Response(1L, "teco.ac.kr", "테코대학교", SchoolRegion.서울),
+                        new SchoolV1Response(2L, "wote.ac.kr", "우테대학교", SchoolRegion.부산)
+                    )
+                );
+                given(schoolV1QueryService.findAll(any(), any(), any(Pageable.class)))
+                    .willReturn(expected);
+
+                // when & then
+                String content = mockMvc.perform(get(uri)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString(StandardCharsets.UTF_8);
+                var actual = objectMapper.readValue(content, SchoolsV1Response.class);
+
+                assertThat(actual).isEqualTo(expected);
+            }
+        }
+    }
+
+    @Nested
+    class 단일_학교_정보_조회 {
+
+        final String uri = "/api/v1/schools/{schoolId}";
+
+        @Nested
+        @DisplayName("GET " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            void 요청을_하면_200_응답과_학교_정보가_반환된다() throws Exception {
+                // given
+                var expected = new SchoolV1Response(1L, "teco.ac.kr", "테코대학교", SchoolRegion.서울);
+                given(schoolV1QueryService.findById(anyLong()))
+                    .willReturn(expected);
+
+                // when & then
+                String content = mockMvc.perform(get(uri, 1L)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString(StandardCharsets.UTF_8);
+                var actual = objectMapper.readValue(content, SchoolV1Response.class);
+
+                assertThat(actual).isEqualTo(expected);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #658

## ✨ PR 세부 내용

담당하기로 했던 학교 CRUD 기능을 새롭게 추가했습니다.

중점으로 볼 것은 다음과 같습니다.

###  Command, Query 서비스 분리

CQRS 패턴을 적용했습니다.

Command 서비스는 `SchoolCommandService`, `SchoolDeleteService`
Query 서비스는 `SchoolV1QueryService` 입니다.

Command 서비스를 Command와 Delete로 나눈 이유는 Delete 처리 시 정합성 유지를 위해 Validator를 통해 검증이 필요하기 때문입니다.
(이벤트를 사용하는 방법도 있으나, 정합성을 유지하기 위한 검증이 필요하므로 명시적으로 처리하기 위해 인터페이스를 활용한 Validator를 사용했습니다.)

분리하지 않는다면 Create와 Update 기능에도 Delete를 위한 Validator의 의존이 발생하므로 분리하였습니다.

또한 Create, Update도 분리를 해야할 것 같습니다. (Update의 경우 도메인이 바뀌게 되면 학생의 이메일 주소가 바뀌게 됩니다.)

처음 사용하는 방법인 만큼 의견이 필요합니다! (모두 분리한다면 Facade 패턴을 적용해서 하나로 묶어 사용하면 좋을 것 같네요.)

### QueryService

`QueryService`는 비즈니스 로직과 전혀 연관도 없고 단순한 조회 기능만을 제공합니다.

또한 API의 응답 명세에 매우 강하게 의존하고 있으므로 네이밍을 `SchoolV1QueryService`으로 하였고, 반환 타입을 `Presentation` 계층에 속한 `SchoolV1Response`를 반환하도록 했습니다.

의존하고 있는 `SchoolV1QueryDslRepository`은 `Repository` 계층으로 볼 수 있지만 마찬가지로 DTO Projection을 위해 `SchoolV1Response`을 반환합니다.

`SchoolV1QueryDslRepository`는 `XxxRepositoryCustom`을 구현하지 않는 그저 단순한 클래스 입니다.

이렇게 만든 이유는 비즈니스 로직과 전혀 연관이 없고, API 응답 명세에 매우 의존적이기 때문입니다.

기존 `XxxRepositoryCustom`과 같이 QueryDSL을 사용하는 Repository 또한 별도의 `QueryRepository`로 분리하는 것에 대해 어떻게 생각하시나요? (명확한 책임의 분리를 위해)

### Pagination

`/api/v1/schools`에 페이지네이션을 적용했습니다.
컬럼으로 검색을 할 필요가 있기에 `searchFilter`, `searchKeyword`를 인자로 받습니다.
그리고 서비스의 인자로 넘길 때는 `SearchCondition`을 만들어 전달합니다.
다른 방법이 있다면 의견 주세요!

다른 의견에 대해서는 코멘트로 남기겠습니다!
