### PR TITLE
[BE] feat: FesitvalQueryInfo에 BaseTimeEntity 상속, 유니크 인덱스 추가 (#685)

### DIFF
--- a/backend/src/main/java/com/festago/festival/domain/FestivalQueryInfo.java
+++ b/backend/src/main/java/com/festago/festival/domain/FestivalQueryInfo.java
@@ -1,6 +1,7 @@
 package com.festago.festival.domain;
 
 import com.festago.artist.domain.Artist;
+import com.festago.common.domain.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FestivalQueryInfo {
+public class FestivalQueryInfo extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/resources/db/migration/V11__modify_school_and_festival_query_info.sql
+++ b/backend/src/main/resources/db/migration/V11__modify_school_and_festival_query_info.sql
@@ -6,12 +6,15 @@ alter table school
 
 create table if not exists festival_query_info
 (
-    id              bigint not null auto_increment,
-    festival_id     bigint  not null,
-    created_at      datetime(6),
-    updated_at      datetime(6),
-    artist_info     text not null,
+    id          bigint not null auto_increment,
+    festival_id bigint not null,
+    created_at  datetime(6),
+    updated_at  datetime(6),
+    artist_info text   not null,
     primary key (id)
 ) engine innodb
   default charset = utf8mb4
   collate = utf8mb4_0900_ai_ci;
+
+alter table festival_query_info
+    add constraint UNIQUE_FESTIVAL_ID unique (festival_id);

--- a/backend/src/main/resources/db/migration/V12__add_festival_startdate_desc_index.sql
+++ b/backend/src/main/resources/db/migration/V12__add_festival_startdate_desc_index.sql
@@ -1,0 +1,2 @@
+create index festival_start_date_desc_index
+    on festival (start_date desc);


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #685 

## ✨ PR 세부 내용

이슈 내용 그대로 `FesitvalQueryInfo`에 BaseTimeEntity 상속, `festival_id`에 대해 유니크 인덱스를 추가했습니다.

또한 `festival` 테이블에 대해 `start_date` 내림차순 인덱스를 추가했습니다.
이유는 다음과 같습니다.
```sql
explain
select f1_0.id,
       f1_0.name,
       f1_0.start_date,
       f1_0.end_date,
       f1_0.thumbnail,
       s1_0.id,
       s1_0.name,
       s1_0.region,
       f2_0.artist_info
from festival f1_0
         join school s1_0
              on f1_0.school_id = s1_0.id
         join festival_query_info f2_0
              on f2_0.festival_id = f1_0.id
where f1_0.start_date <= '2024-02-07'
  and f1_0.end_date >= '2024-02-07'
order by f1_0.start_date desc,
               f1_0.id
limit 6;
```

`start_date`는 이미 인덱스로 적용되어 있기 때문에 다음과 같이 `Backward index scan`이 적용될 것으로 예상할 수 있습니다.

<img width="401" alt="image" src="https://github.com/woowacourse-teams/2023-festa-go/assets/116627736/78134dc0-4a03-4457-a227-4b86a0609521">

하지만 `order by`에서 festival.id로 추가 정렬 조건 때문에 `using filesort`가 적용됩니다.

<img width="396" alt="image" src="https://github.com/woowacourse-teams/2023-festa-go/assets/116627736/dfe54c3c-11c3-4e5a-aa6c-d42dcf6b68d5">

`festival` 테이블은 추가와 수정이 빈번하지 않은 테이블이기 때문에 인덱스 추가에 대한 부담이 적습니다. 
따라서 `start_date` 내림차순 인덱스를 추가하여 효율적인 조회가 가능하도록 합니다.

