### PR TITLE
[BE] feat: School 도메인 region 검증, 수정 메서드 추가 및 주석 처리된 기능 활성화  (#689)

### DIFF
--- a/backend/src/main/java/com/festago/school/application/SchoolCommandService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolCommandService.java
@@ -38,15 +38,14 @@ public class SchoolCommandService {
     }
 
     /**
-     * 학교를 인증한 학생이 있다면, domain을 변경하는 것은 문제가 될 수 있지 않을까?
+     * TODO 학교를 인증한 학생이 있다면, domain을 변경하는 것은 문제가 될 수 있지 않을까?
      */
     public void updateSchool(Long schoolId, SchoolUpdateCommand command) {
         School school = schoolRepository.getOrThrow(schoolId);
         validateUpdate(school, command.domain(), command.name());
         school.changeName(command.name());
         school.changeDomain(command.domain());
-        // TODO School 도메인 이슈에서 주석 해제할 것!
-        // school.changeRegion(command.region());
+        school.changeRegion(command.region());
     }
 
     private void validateUpdate(School school, String domain, String name) {

--- a/backend/src/main/java/com/festago/school/domain/School.java
+++ b/backend/src/main/java/com/festago/school/domain/School.java
@@ -43,16 +43,17 @@ public class School extends BaseTimeEntity {
     }
 
     public School(Long id, String domain, String name, SchoolRegion region) {
-        validate(domain, name);
+        validate(domain, name, region);
         this.id = id;
         this.domain = domain;
         this.name = name;
         this.region = region;
     }
 
-    private void validate(String domain, String name) {
+    private void validate(String domain, String name, SchoolRegion region) {
         validateDomain(domain);
         validateName(name);
+        validateRegion(region);
     }
 
     private void validateDomain(String domain) {
@@ -67,6 +68,10 @@ public class School extends BaseTimeEntity {
         Validator.maxLength(name, MAX_NAME_LENGTH, fieldName);
     }
 
+    private void validateRegion(SchoolRegion region) {
+        Validator.notNull(region, "region");
+    }
+
     public void changeDomain(String domain) {
         validateDomain(domain);
         this.domain = domain;
@@ -75,6 +80,11 @@ public class School extends BaseTimeEntity {
     public void changeName(String name) {
         validateName(name);
         this.name = name;
+    }
+
+    public void changeRegion(SchoolRegion region) {
+        validateRegion(region);
+        this.region = region;
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/festago/school/presentation/v1/SchoolV1Controller.java
+++ b/backend/src/main/java/com/festago/school/presentation/v1/SchoolV1Controller.java
@@ -24,7 +24,7 @@ public class SchoolV1Controller {
     private final SchoolV1QueryService schoolQueryService;
 
     @GetMapping
-    @ValidPageable(maxSize = 20)
+    @ValidPageable(maxSize = 50)
     public ResponseEntity<Page<SchoolV1Response>> findAllSchools(
         @RequestParam(defaultValue = "") String searchFilter,
         @RequestParam(defaultValue = "") String searchKeyword,

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
@@ -143,10 +143,6 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
             assertThat(updatedSchool.getDomain()).isEqualTo(school.getDomain());
         }
 
-        /**
-         * 여기서 통합 테스트의 단점이 드러난다. 변경된 School은 위의 변수로 선언한 School과 같은 인스턴스이다. 하지만 updateSchool() 메서드로 변경된 School은 변수로 선언된
-         * School과 다르다. 따라서 변경을 확인하려면 SchoolRepository에서 영속된 School을 찾아야한다.
-         */
         @Test
         void 예외가_발생하지_않으면_학교가_수정된다() {
             // given
@@ -160,8 +156,7 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
             assertSoftly(softly -> {
                 softly.assertThat(updatedSchool.getName()).isEqualTo("테코대학교");
                 softly.assertThat(updatedSchool.getDomain()).isEqualTo("teco.ac.kr");
-                // TODO School 도메인 이슈에서 주석 해제할 것!
-                // assertThat(updatedSchool.getRegion()).isEqualTo(SchoolRegion.서울);
+                softly.assertThat(updatedSchool.getRegion()).isEqualTo(SchoolRegion.서울);
             });
         }
     }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #689

## ✨ PR 세부 내용

이슈 내용 그대로 region 검증, 수정 기능, 주석 처리된 기능에 대해 활성화를 하였습니다.
추가로 `SchoolV1Controller`의 `findAllSchools` 메서드의 경우 `@ValidPageable`의 최대 사이즈를 50으로 변경하였습니다.
`Pageable`을 사용하는 일부 핸들러 메서드에도 해당 어노테이션을 붙여 검증을 단순화하는게 좋을 것 같습니다.
