### PR TITLE
[BE] feat: Controller에 누락된 @Valid 어노테이션 추가, Admin Controller 테스트에 권한 검증 테스트 추가 (#693)

### DIFF
--- a/backend/src/main/java/com/festago/admin/presentation/v1/AdminSchoolV1Controller.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/AdminSchoolV1Controller.java
@@ -5,6 +5,7 @@ import com.festago.admin.presentation.v1.dto.SchoolV1UpdateRequest;
 import com.festago.school.application.SchoolCommandService;
 import com.festago.school.application.SchoolDeleteService;
 import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +28,7 @@ public class AdminSchoolV1Controller {
 
     @PostMapping
     public ResponseEntity<Void> createSchool(
-        @RequestBody SchoolV1CreateRequest request
+        @RequestBody @Valid SchoolV1CreateRequest request
     ) {
         Long schoolId = schoolCommandService.createSchool(request.toCommand());
         return ResponseEntity.created(URI.create("/api/v1/schools/" + schoolId))
@@ -37,7 +38,7 @@ public class AdminSchoolV1Controller {
     @PatchMapping("/{schoolId}")
     public ResponseEntity<Void> updateSchool(
         @PathVariable Long schoolId,
-        @RequestBody SchoolV1UpdateRequest request
+        @RequestBody @Valid SchoolV1UpdateRequest request
     ) {
         schoolCommandService.updateSchool(schoolId, request.toCommand());
         return ResponseEntity.ok()

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminArtistV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminArtistV1ControllerTest.java
@@ -37,6 +37,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @SuppressWarnings("NonAsciiCharacters")
 class AdminArtistV1ControllerTest {
 
+    private static final Cookie TOKEN_COOKIE = new Cookie("token", "token");
+
     @Autowired
     MockMvc mockMvc;
 
@@ -49,7 +51,6 @@ class AdminArtistV1ControllerTest {
     @Autowired
     ArtistCommandService artistCommandService;
 
-    private static final Cookie COOKIE = new Cookie("token", "token");
 
     @Nested
     class 아티스트_생성 {
@@ -66,16 +67,32 @@ class AdminArtistV1ControllerTest {
                 // given
                 ArtistCreateRequest request = new ArtistCreateRequest("윤서연", "https://image.com/image.png");
                 given(artistCommandService.save(any(ArtistCreateRequest.class)))
-                        .willReturn(1L);
+                    .willReturn(1L);
 
                 // when & then
                 mockMvc.perform(post(uri)
-                                .cookie(COOKIE)
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON))
-                        .andDo(print())
-                        .andExpect(status().isCreated())
-                        .andExpect(header().string(HttpHeaders.LOCATION, uri + "/1"));
+                        .cookie(TOKEN_COOKIE)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(header().string(HttpHeaders.LOCATION, uri + "/1"));
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
             }
         }
     }
@@ -97,11 +114,27 @@ class AdminArtistV1ControllerTest {
 
                 // when & then
                 mockMvc.perform(put(uri, 1L)
-                                .cookie(COOKIE)
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON))
-                        .andDo(print())
-                        .andExpect(status().isOk());
+                        .cookie(TOKEN_COOKIE)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(put(uri, 1L))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(put(uri, 1L)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
             }
         }
     }
@@ -120,10 +153,26 @@ class AdminArtistV1ControllerTest {
             void 요청을_보내면_204_응답이_반환된다() throws Exception {
                 // when & then
                 mockMvc.perform(delete(uri, 1L)
-                                .cookie(COOKIE)
-                                .contentType(MediaType.APPLICATION_JSON))
-                        .andDo(print())
-                        .andExpect(status().isNoContent());
+                        .cookie(TOKEN_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(delete(uri, 1L))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(delete(uri, 1L)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
             }
         }
     }
@@ -143,15 +192,31 @@ class AdminArtistV1ControllerTest {
                 // given
                 ArtistV1Response expected = new ArtistV1Response(1L, "윤하", "https://image.com/image.png");
                 given(artistV1QueryService.findById(expected.id()))
-                        .willReturn(expected);
+                    .willReturn(expected);
 
                 // when & then
-                mockMvc.perform(get(uri , 1L)
-                                .cookie(COOKIE)
-                                .contentType(MediaType.APPLICATION_JSON))
-                        .andDo(print())
-                        .andExpect(status().isOk())
-                        .andExpect(content().json(objectMapper.writeValueAsString(expected)));
+                mockMvc.perform(get(uri, 1L)
+                        .cookie(TOKEN_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(content().json(objectMapper.writeValueAsString(expected)));
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri, 1L))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri, 1L)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
             }
         }
     }
@@ -170,19 +235,35 @@ class AdminArtistV1ControllerTest {
             void 요청을_보내면_200_응답과_body가_반환된다() throws Exception {
                 // given
                 List<ArtistV1Response> expected = List.of(
-                        new ArtistV1Response(1L, "윤하", "https://image.com/image1.png"),
-                        new ArtistV1Response(2L, "고윤하", "https://image.com/image2.png")
+                    new ArtistV1Response(1L, "윤하", "https://image.com/image1.png"),
+                    new ArtistV1Response(2L, "고윤하", "https://image.com/image2.png")
                 );
                 given(artistV1QueryService.findAll())
-                        .willReturn(expected);
+                    .willReturn(expected);
 
                 // when & then
                 mockMvc.perform(get(uri)
-                                .cookie(COOKIE)
-                                .contentType(MediaType.APPLICATION_JSON))
-                        .andDo(print())
-                        .andExpect(status().isOk())
-                        .andExpect(content().json(objectMapper.writeValueAsString(expected)));
+                        .cookie(TOKEN_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(content().json(objectMapper.writeValueAsString(expected)));
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
             }
         }
     }

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminSchoolV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminSchoolV1ControllerTest.java
@@ -34,6 +34,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @SuppressWarnings("NonAsciiCharacters")
 class AdminSchoolV1ControllerTest {
 
+    private static final Cookie TOKEN_COOKIE = new Cookie("token", "token");
+
     @Autowired
     MockMvc mockMvc;
 
@@ -65,11 +67,27 @@ class AdminSchoolV1ControllerTest {
 
                 // when & then
                 mockMvc.perform(post(uri)
-                        .cookie(new Cookie("token", "Bearer token"))
+                        .cookie(TOKEN_COOKIE)
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isCreated())
                     .andExpect(header().string(HttpHeaders.LOCATION, "/api/v1/schools/1"));
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
             }
         }
     }
@@ -96,6 +114,22 @@ class AdminSchoolV1ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk());
             }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(patch(uri, 1L))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(patch(uri, 1L)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
         }
     }
 
@@ -116,6 +150,22 @@ class AdminSchoolV1ControllerTest {
                         .cookie(new Cookie("token", "Bearer token"))
                         .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isNoContent());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(delete(uri, 1L))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(delete(uri, 1L)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
             }
         }
     }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #693

## ✨ PR 세부 내용

이슈 내용 그대로 `@Valid` 어노테이션을 추가했고, Admin Controller 테스트에 권한 검증 테스트를 추가했습니다.
