### PR TITLE
[BE] feat: Admin 로그인 쿠키에 sameSite=None 추가 (#696)

### DIFF
--- a/backend/src/main/java/com/festago/auth/presentation/AdminAuthController.java
+++ b/backend/src/main/java/com/festago/auth/presentation/AdminAuthController.java
@@ -37,6 +37,7 @@ public class AdminAuthController {
         return ResponseCookie.from("token", token)
             .httpOnly(true)
             .secure(true)
+            .sameSite("None")
             .path("/")
             .build().toString();
     }

--- a/backend/src/test/java/com/festago/auth/presentation/AdminAuthControllerTest.java
+++ b/backend/src/test/java/com/festago/auth/presentation/AdminAuthControllerTest.java
@@ -31,6 +31,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @SuppressWarnings("NonAsciiCharacters")
 class AdminAuthControllerTest {
 
+    private static final String AUTH_TOKEN_KEY = "token";
+
     @Autowired
     MockMvc mockMvc;
 
@@ -55,7 +57,11 @@ class AdminAuthControllerTest {
                     .content(objectMapper.writeValueAsString(request))
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(cookie().exists("token"));
+                .andExpect(cookie().exists(AUTH_TOKEN_KEY))
+                .andExpect(cookie().path(AUTH_TOKEN_KEY, "/"))
+                .andExpect(cookie().secure(AUTH_TOKEN_KEY, true))
+                .andExpect(cookie().httpOnly(AUTH_TOKEN_KEY, true))
+                .andExpect(cookie().sameSite(AUTH_TOKEN_KEY, "None"));
         }
     }
 

--- a/backend/src/test/java/com/festago/auth/presentation/AdminAuthControllerTest.java
+++ b/backend/src/test/java/com/festago/auth/presentation/AdminAuthControllerTest.java
@@ -18,6 +18,7 @@ import com.festago.auth.dto.RootAdminInitializeRequest;
 import com.festago.support.CustomWebMvcTest;
 import com.festago.support.WithMockAuth;
 import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
@@ -31,7 +32,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SuppressWarnings("NonAsciiCharacters")
 class AdminAuthControllerTest {
 
-    private static final String AUTH_TOKEN_KEY = "token";
+    private static final Cookie AUTH_TOKEN = new Cookie("token", "token");
 
     @Autowired
     MockMvc mockMvc;
@@ -45,86 +46,111 @@ class AdminAuthControllerTest {
     @Nested
     class 어드민_로그인 {
 
-        @Test
-        void 유효한_요청이_보내지면_200_응답과_쿠키에_token이_있어야한다() throws Exception {
-            // given
-            var request = new AdminLoginRequest("admin", "1234");
-            given(adminAuthService.login(any(AdminLoginRequest.class)))
-                .willReturn("token");
+        final String uri = "/admin/api/login";
 
-            // when & then
-            mockMvc.perform(post("/admin/api/login")
-                    .content(objectMapper.writeValueAsString(request))
-                    .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(cookie().exists(AUTH_TOKEN_KEY))
-                .andExpect(cookie().path(AUTH_TOKEN_KEY, "/"))
-                .andExpect(cookie().secure(AUTH_TOKEN_KEY, true))
-                .andExpect(cookie().httpOnly(AUTH_TOKEN_KEY, true))
-                .andExpect(cookie().sameSite(AUTH_TOKEN_KEY, "None"));
+        @Nested
+        @DisplayName("POST " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            void 요청을_보내면_200_응답과_로그인_토큰이_담긴_쿠키가_반환된다() throws Exception {
+                // given
+                var request = new AdminLoginRequest("admin", "1234");
+                given(adminAuthService.login(any(AdminLoginRequest.class)))
+                    .willReturn("token");
+
+                // when & then
+                mockMvc.perform(post(uri)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(cookie().exists(AUTH_TOKEN.getName()))
+                    .andExpect(cookie().path(AUTH_TOKEN.getName(), "/"))
+                    .andExpect(cookie().secure(AUTH_TOKEN.getName(), true))
+                    .andExpect(cookie().httpOnly(AUTH_TOKEN.getName(), true))
+                    .andExpect(cookie().sameSite(AUTH_TOKEN.getName(), "None"));
+            }
         }
     }
 
     @Nested
     class 어드민_회원가입 {
 
-        @Test
-        void 쿠키에_토큰이_없으면_401_응답이_반환된다() throws Exception {
-            // given
-            var request = new AdminSignupRequest("newAdmin", "1234");
+        final String uri = "/admin/api/signup";
 
-            // when & then
-            mockMvc.perform(post("/admin/api/signup")
-                    .content(objectMapper.writeValueAsString(request))
-                    .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isUnauthorized());
-        }
+        @Nested
+        @DisplayName("POST " + uri)
+        class 올바른_주소로 {
 
-        @Test
-        @WithMockAuth(role = Role.MEMBER)
-        void 쿠키에_토큰의_권한이_올바르지_않으면_404_응답이_반환된다() throws Exception {
-            // given
-            var request = new AdminSignupRequest("newAdmin", "1234");
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답과_생성한_계정이_반환된다() throws Exception {
+                var request = new AdminSignupRequest("newAdmin", "1234");
+                var response = new AdminSignupResponse("newAdmin");
+                given(adminAuthService.signup(anyLong(), any(AdminSignupRequest.class)))
+                    .willReturn(response);
 
-            // when & then
-            mockMvc.perform(post("/admin/api/signup")
-                    .cookie(new Cookie("token", "token"))
-                    .content(objectMapper.writeValueAsString(request))
-                    .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound());
-        }
+                // when & then
+                Cookie token = new Cookie("token", "token");
+                mockMvc.perform(post(uri)
+                        .cookie(token)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.username").value("newAdmin"));
+            }
 
-        @Test
-        @WithMockAuth(role = Role.ADMIN)
-        void 유효한_요청이_보내지면_200_응답과_생성한_계정이_반환된다() throws Exception {
-            var request = new AdminSignupRequest("newAdmin", "1234");
-            var response = new AdminSignupResponse("newAdmin");
-            given(adminAuthService.signup(anyLong(), any(AdminSignupRequest.class)))
-                .willReturn(response);
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri))
+                    .andExpect(status().isUnauthorized());
+            }
 
-            // when & then
-            mockMvc.perform(post("/admin/api/signup")
-                    .cookie(new Cookie("token", "token"))
-                    .content(objectMapper.writeValueAsString(request))
-                    .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.username").value("newAdmin"));
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri)
+                        .cookie(AUTH_TOKEN))
+                    .andExpect(status().isNotFound());
+            }
         }
     }
 
     @Nested
     class 루트_어드민_활성화 {
 
-        @Test
-        void 유효한_요청이_보내지면_200_응답이_반환된다() throws Exception {
-            // given
-            var request = new RootAdminInitializeRequest("1234");
+        final String uri = "/admin/api/initialize";
 
-            // when & then
-            mockMvc.perform(post("/admin/api/initialize")
-                    .content(objectMapper.writeValueAsString(request))
-                    .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+        @Nested
+        @DisplayName("POST " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                // given
+                var request = new RootAdminInitializeRequest("1234");
+
+                // when & then
+                mockMvc.perform(post(uri)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.ANONYMOUS)
+            void 권한이_없어도_200_응답이_반환된다() throws Exception {
+                // given
+                var request = new RootAdminInitializeRequest("1234");
+
+                // when & then
+                mockMvc.perform(post(uri)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #696

## ✨ PR 세부 내용

이슈 내용과 같이 로그인 토큰 쿠키에 `sameSite=None` 속성을 추가했습니다.

추가로 관련 Controller 테스트 코드를 이전에 얘기했던 Controller 테스트 코드 컨벤션에 맞게 수정했습니다.

그리고 인증 관련 URI가 다음과 같이 되어있습니다.
`/admin/api/login`, `/admin/api/signup`, `/admin/api/initialize`

혼란을 방지하기 위해 다음과 같이 중간에 `/auth`를 추가해야 할 것 같습니다.

`/admin/api/auth/login`

지금 변경하게 되면 기존 어드민 사이트가 동작하지 않게 되므로 추후 새로운 백오피스 페이지가 기존 백오피스 페이지를 대체할 기능이 완성되면 변경하면 좋을 것 같습니다.