### PR TITLE
[BE] feat: 헬스 체크용 PingController 추가 (#703)

### DIFF
--- a/backend/src/main/java/com/festago/common/presentation/PingController.java
+++ b/backend/src/main/java/com/festago/common/presentation/PingController.java
@@ -1,0 +1,15 @@
+package com.festago.common.presentation;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/ping")
+public class PingController {
+
+    @GetMapping
+    public String ping() {
+        return "pong";
+    }
+}

--- a/backend/src/test/java/com/festago/common/presentation/PingControllerTest.java
+++ b/backend/src/test/java/com/festago/common/presentation/PingControllerTest.java
@@ -1,0 +1,39 @@
+package com.festago.common.presentation;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.festago.support.CustomWebMvcTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class PingControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Nested
+    class 핑_요청 {
+
+        final String uri = "/ping";
+
+        @Nested
+        @DisplayName("GET " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                mockMvc.perform(get(uri))
+                    .andExpect(status().isOk());
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #703

## ✨ PR 세부 내용

이슈 내용과 같이 헬스 체크용 API를 추가했습니다.
경로는 다음과 같이 매핑됩니다.

`/ping`

응답은 200 상태 코드와 Body에 `pong`이 반환됩니다.
