### PR TITLE
[AN/USER] 축제 목록 불러오기 API 연동 작업

### DIFF
--- a/android/festago/data/src/main/java/com/festago/festago/data/dto/artist/ArtistResponse.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/dto/artist/ArtistResponse.kt
@@ -1,7 +1,9 @@
 package com.festago.festago.data.dto.artist
 
 import com.festago.festago.domain.model.artist.Artist
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class ArtistResponse(
     val id: Long,
     val name: String,

--- a/android/festago/data/src/main/java/com/festago/festago/data/dto/festival/FestivalResponse.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/dto/festival/FestivalResponse.kt
@@ -3,8 +3,10 @@ package com.festago.festago.data.dto.festival
 import com.festago.festago.data.dto.artist.ArtistResponse
 import com.festago.festago.data.dto.school.SchoolResponse
 import com.festago.festago.domain.model.festival.Festival
+import kotlinx.serialization.Serializable
 import java.time.LocalDate
 
+@Serializable
 data class FestivalResponse(
     val id: Long,
     val name: String,

--- a/android/festago/data/src/main/java/com/festago/festago/data/dto/festival/FestivalsResponse.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/dto/festival/FestivalsResponse.kt
@@ -1,7 +1,9 @@
 package com.festago.festago.data.dto.festival
 
 import com.festago.festago.domain.model.festival.FestivalsPage
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class FestivalsResponse(
     val last: Boolean,
     val content: List<FestivalResponse>,

--- a/android/festago/data/src/main/java/com/festago/festago/data/dto/school/SchoolResponse.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/dto/school/SchoolResponse.kt
@@ -1,7 +1,9 @@
 package com.festago.festago.data.dto.school
 
 import com.festago.festago.domain.model.school.School
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class SchoolResponse(
     val id: Long,
     val name: String,

--- a/android/festago/data/src/main/java/com/festago/festago/data/repository/FestivalDefaultRepository.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/repository/FestivalDefaultRepository.kt
@@ -1,14 +1,13 @@
 package com.festago.festago.data.repository
 
-import com.festago.festago.data.repository.FakeFestivals.festivalList
-import com.festago.festago.data.repository.FakeFestivals.popularFestivals
 import com.festago.festago.data.service.FestivalRetrofitService
+import com.festago.festago.data.util.onSuccessOrCatch
+import com.festago.festago.data.util.runCatchingResponse
 import com.festago.festago.domain.model.festival.Festival
 import com.festago.festago.domain.model.festival.FestivalFilter
 import com.festago.festago.domain.model.festival.FestivalLocation
 import com.festago.festago.domain.model.festival.FestivalsPage
 import com.festago.festago.domain.repository.FestivalRepository
-import kotlinx.coroutines.delay
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -17,12 +16,9 @@ class FestivalDefaultRepository @Inject constructor(
 ) : FestivalRepository {
 
     override suspend fun loadPopularFestivals(): Result<List<Festival>> {
-        // TODO: 서버 배포 후 API 연동 필요
-        // runCatchingResponse {
-        //     festivalRetrofitService.getPopularFestivals()
-        // }.onSuccessOrCatch { it.map { festival -> festival.toDomain() } }
-        delay(5000)
-        return Result.success(popularFestivals)
+        return runCatchingResponse {
+            festivalRetrofitService.getPopularFestivals()
+        }.onSuccessOrCatch { it.map { festival -> festival.toDomain() } }
     }
 
     override suspend fun loadFestivals(
@@ -30,34 +26,25 @@ class FestivalDefaultRepository @Inject constructor(
         festivalFilter: FestivalFilter?,
         lastFestivalId: Long?,
         lastStartDate: LocalDate?,
-        limit: Int?,
+        size: Int?,
     ): Result<FestivalsPage> {
-        // TODO: 서버 배포 후 API 연동 필요
-        // runCatchingResponse {
-        //     festivalRetrofitService.getFestivals(
-        //         location = getFestivalLocationName(festivalLocation),
-        //         filter = festivalFilter.name,
-        //         lastFestivalId = lastFestivalId,
-        //         lastStartDate = lastStartDate.toString(),
-        //         limit = limit,
-        //     )
-        // }.onSuccessOrCatch { it.toDomain() }
-
-        delay(3000)
-        return Result.success(
-            FestivalsPage(
-                isLastPage = true,
-                festivals = festivalList + festivalList + festivalList,
-            ),
-        )
+        return runCatchingResponse {
+            festivalRetrofitService.getFestivals(
+                region = getFestivalLocationName(festivalLocation),
+                filter = festivalFilter?.name,
+                lastFestivalId = lastFestivalId,
+                lastStartDate = lastStartDate,
+                size = size,
+            )
+        }.onSuccessOrCatch { it.toDomain() }
     }
 
-    private fun getFestivalLocationName(festivalLocation: FestivalLocation): String {
+    private fun getFestivalLocationName(festivalLocation: FestivalLocation?): String? {
         return when (festivalLocation) {
             FestivalLocation.BUSAN -> "부산"
             FestivalLocation.SEOUL -> "서울"
             FestivalLocation.GYEONGGI -> "경기"
-            FestivalLocation.ALL -> ""
+            else -> null
         }
     }
 }

--- a/android/festago/data/src/main/java/com/festago/festago/data/service/FestivalRetrofitService.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/service/FestivalRetrofitService.kt
@@ -5,17 +5,18 @@ import com.festago.festago.data.dto.festival.FestivalsResponse
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
+import java.time.LocalDate
 
 interface FestivalRetrofitService {
-    @GET("/v1/popular/festivals")
+    @GET("api/v1/popular/festivals")
     suspend fun getPopularFestivals(): Response<List<FestivalResponse>>
 
-    @GET("/v1/festivals")
+    @GET("api/v1/festivals")
     suspend fun getFestivals(
         @Query("region") region: String?,
         @Query("filter") filter: String?,
         @Query("lastFestivalId") lastFestivalId: Long?,
-        @Query("lastStartDate") lastStartDate: String?,
+        @Query("lastStartDate") lastStartDate: LocalDate?,
         @Query("size") size: Int?,
     ): Response<FestivalsResponse>
 }

--- a/android/festago/domain/src/main/java/com/festago/festago/domain/repository/FestivalRepository.kt
+++ b/android/festago/domain/src/main/java/com/festago/festago/domain/repository/FestivalRepository.kt
@@ -13,6 +13,6 @@ interface FestivalRepository {
         festivalFilter: FestivalFilter? = null,
         lastFestivalId: Long? = null,
         lastStartDate: LocalDate? = null,
-        limit: Int? = null,
+        size: Int? = null,
     ): Result<FestivalsPage>
 }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
@@ -54,18 +54,26 @@ class FestivalListFragment : Fragment() {
     }
 
     private fun initView() {
-        initViewPager()
         vm.loadFestivals()
+        initViewPager()
         initRecyclerView()
+        initRefresh()
+    }
+
+    private fun initRefresh() {
+        binding.srlFestivalList.setOnRefreshListener {
+            vm.loadFestivals()
+            binding.srlFestivalList.isRefreshing = false
+        }
     }
 
     private fun initViewPager() {
         festivalListAdapter = FestivalListAdapter()
-        binding.rvList.adapter = festivalListAdapter
+        binding.rvFestivalList.adapter = festivalListAdapter
     }
 
     private fun initRecyclerView() {
-        binding.rvList.addItemDecoration(object : RecyclerView.ItemDecoration() {
+        binding.rvFestivalList.addItemDecoration(object : RecyclerView.ItemDecoration() {
             override fun getItemOffsets(
                 outRect: Rect,
                 view: View,

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.festago.festago.common.analytics.AnalyticsHelper
 import com.festago.festago.common.analytics.logNetworkFailure
 import com.festago.festago.domain.model.festival.Festival
+import com.festago.festago.domain.model.festival.FestivalFilter
 import com.festago.festago.domain.repository.FestivalRepository
 import com.festago.festago.presentation.ui.home.festivallist.uistate.ArtistUiState
 import com.festago.festago.presentation.ui.home.festivallist.uistate.FestivalItemUiState
@@ -30,7 +31,7 @@ class FestivalListViewModel @Inject constructor(
     fun loadFestivals() {
         viewModelScope.launch {
             val deferredPopularFestivals = async { festivalRepository.loadPopularFestivals() }
-            val deferredFestivals = async { festivalRepository.loadFestivals() }
+            val deferredFestivals = async { festivalRepository.loadFestivals(festivalFilter = FestivalFilter.PROGRESS) }
 
             runCatching {
                 val festivalsPage = deferredFestivals.await().getOrThrow()

--- a/android/festago/presentation/src/main/res/layout/fragment_festival_list.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_festival_list.xml
@@ -60,18 +60,27 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rvList"
-            visibility="@{uiState.shouldShowSuccess}"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/srlFestivalList"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/containerAppBarFestivalList"
-            app:layout_constraintVertical_weight="1"
-            tools:listitem="@layout/item_festival_list_popular" />
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvFestivalList"
+                visibility="@{uiState.shouldShowSuccess}"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/containerAppBarFestivalList"
+                app:layout_constraintVertical_weight="1"
+                tools:listitem="@layout/item_festival_list_popular" />
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
         <ProgressBar
             android:id="@+id/pbLoading"


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #702 

## ✨ PR 세부 내용

축제 목록 불러오기, 인기 축제 목록 불러오기 Data layer 쪽 작업입니다. 
filter 에 null 을 보내면 internal server error 가 떠서 viewModel 에서 PROGRESS 넘겨주었습니다.

Fake 객체는 삭제하지 않았고 새로고침 가능하도록 SwipeRefreshLayout 넣었습니다.

궁금한 점이 두 가지 있습니다.
1. 에러가 발생하면 화면에 메세지 등을 표시할 것 인가? (이전 페스타고와 동일하게)
2. 인기 축제 목록이나 축제 목록의 item 이 0이면 아무것도 보이지 않아서 따로 처리가 필요할까?
  -> 축제 목록은 필터링에 따라서 0인 경우가 필히 발생할 것으로 예상되는데 인기 축제 목록은 모르겠네요.