### PR TITLE
[BE] fix: "/api/v1/festivals"의 "filter" 쿼리 파리미터 기본 값 지정 및 핸들러 메서드의 형식 변경 (#705)

### DIFF
--- a/backend/src/main/java/com/festago/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/festago/common/exception/ErrorCode.java
@@ -34,7 +34,6 @@ public enum ErrorCode {
     SCHOOL_DELETE_CONSTRAINT_EXISTS_FESTIVAL("축제가 등록된 학교는 삭제할 수 없습니다."),
     DUPLICATE_SCHOOL_NAME("이미 존재하는 학교의 이름입니다."),
     DUPLICATE_SCHOOL_DOMAIN("이미 존재하는 학교의 도메인입니다."),
-    INVALID_REGION("유효하지 않은 지역입니다."),
     INVALID_PAGING_MAX_SIZE("최대 size 값을 초과했습니다."),
     INVALID_NUMBER_FORMAT_PAGING_SIZE("size는 1 이상의 정수 형식이어야 합니다."),
 

--- a/backend/src/main/java/com/festago/festival/presentation/v1/FestivalV1Controller.java
+++ b/backend/src/main/java/com/festago/festival/presentation/v1/FestivalV1Controller.java
@@ -1,5 +1,6 @@
 package com.festago.festival.presentation.v1;
 
+import com.festago.common.aop.ValidPageable;
 import com.festago.common.exception.ValidException;
 import com.festago.festival.application.FestivalV1QueryService;
 import com.festago.festival.dto.FestivalV1QueryRequest;
@@ -28,6 +29,7 @@ public class FestivalV1Controller {
     private final FestivalV1QueryService festivalV1QueryService;
 
     @GetMapping
+    @ValidPageable(maxSize = 20)
     @Operation(description = "축제 목록를 조건별로 조회한다. PROGRESS: 진행 중, PLANNED: 진행 예정, END: 종료, 기본값 -> 진행 중, limit의 크기는 0 < limit < 21 이며 기본 값 10이다.", summary = "축제 목록 조회")
     public ResponseEntity<Slice<FestivalV1Response>> findFestivals(
         @PageableDefault(size = 10) Pageable pageable,
@@ -36,15 +38,10 @@ public class FestivalV1Controller {
         @RequestParam(required = false) Long lastFestivalId,
         @RequestParam(required = false) LocalDate lastStartDate
     ) {
-        validate(lastFestivalId, lastStartDate, pageable.getPageSize());
+        validateCursor(lastFestivalId, lastStartDate);
         var request = new FestivalV1QueryRequest(region, filter, lastFestivalId, lastStartDate);
         var response = festivalV1QueryService.findFestivals(pageable, request);
         return ResponseEntity.ok(response);
-    }
-
-    private void validate(Long lastFestivalId, LocalDate lastStartDate, Integer limit) {
-        validateCursor(lastFestivalId, lastStartDate);
-        validateLimit(limit);
     }
 
     private void validateCursor(Long lastFestivalId, LocalDate lastStartDate) {
@@ -55,11 +52,5 @@ public class FestivalV1Controller {
             return;
         }
         throw new ValidException("festivalId, lastStartDate 두 값 모두 요청하거나 요청하지 않아야합니다.");
-    }
-
-    private void validateLimit(Integer limit) {
-        if (limit > 20 || limit < 1) {
-            throw new ValidException("페이지 갯수의 제한을 벗어납니다.");
-        }
     }
 }

--- a/backend/src/main/java/com/festago/festival/presentation/v1/FestivalV1Controller.java
+++ b/backend/src/main/java/com/festago/festival/presentation/v1/FestivalV1Controller.java
@@ -31,13 +31,13 @@ public class FestivalV1Controller {
     @Operation(description = "축제 목록를 조건별로 조회한다. PROGRESS: 진행 중, PLANNED: 진행 예정, END: 종료, 기본값 -> 진행 중, limit의 크기는 0 < limit < 21 이며 기본 값 10이다.", summary = "축제 목록 조회")
     public ResponseEntity<Slice<FestivalV1Response>> findFestivals(
         @PageableDefault(size = 10) Pageable pageable,
-        @RequestParam(defaultValue = "ANY") SchoolRegion location,
+        @RequestParam(defaultValue = "ANY") SchoolRegion region,
         @RequestParam(defaultValue = "PROGRESS") FestivalFilter filter,
         @RequestParam(required = false) Long lastFestivalId,
         @RequestParam(required = false) LocalDate lastStartDate
     ) {
         validate(lastFestivalId, lastStartDate, pageable.getPageSize());
-        var request = new FestivalV1QueryRequest(location, filter, lastFestivalId, lastStartDate);
+        var request = new FestivalV1QueryRequest(region, filter, lastFestivalId, lastStartDate);
         var response = festivalV1QueryService.findFestivals(pageable, request);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/festago/festival/presentation/v1/FestivalV1Controller.java
+++ b/backend/src/main/java/com/festago/festival/presentation/v1/FestivalV1Controller.java
@@ -4,6 +4,8 @@ import com.festago.common.exception.ValidException;
 import com.festago.festival.application.FestivalV1QueryService;
 import com.festago.festival.dto.FestivalV1QueryRequest;
 import com.festago.festival.dto.FestivalV1Response;
+import com.festago.festival.repository.FestivalFilter;
+import com.festago.school.domain.SchoolRegion;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
@@ -14,6 +16,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -28,9 +31,13 @@ public class FestivalV1Controller {
     @Operation(description = "축제 목록를 조건별로 조회한다. PROGRESS: 진행 중, PLANNED: 진행 예정, END: 종료, 기본값 -> 진행 중, limit의 크기는 0 < limit < 21 이며 기본 값 10이다.", summary = "축제 목록 조회")
     public ResponseEntity<Slice<FestivalV1Response>> findFestivals(
         @PageableDefault(size = 10) Pageable pageable,
-        FestivalV1QueryRequest request
+        @RequestParam(defaultValue = "ANY") SchoolRegion location,
+        @RequestParam(defaultValue = "PROGRESS") FestivalFilter filter,
+        @RequestParam(required = false) Long lastFestivalId,
+        @RequestParam(required = false) LocalDate lastStartDate
     ) {
-        validate(request.lastFestivalId(), request.lastStartDate(), pageable.getPageSize());
+        validate(lastFestivalId, lastStartDate, pageable.getPageSize());
+        var request = new FestivalV1QueryRequest(location, filter, lastFestivalId, lastStartDate);
         var response = festivalV1QueryService.findFestivals(pageable, request);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/festago/festival/repository/FestivalV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/festival/repository/FestivalV1QueryDslRepository.java
@@ -96,7 +96,7 @@ public class FestivalV1QueryDslRepository {
     }
 
     private BooleanExpression addRegion(BooleanExpression filterResult, SchoolRegion region) {
-        if (region == null || region == SchoolRegion.기타) {
+        if (region == null || region == SchoolRegion.ANY) {
             return filterResult;
         }
         return filterResult.and(school.region.eq(region));

--- a/backend/src/main/java/com/festago/school/domain/SchoolRegion.java
+++ b/backend/src/main/java/com/festago/school/domain/SchoolRegion.java
@@ -1,19 +1,8 @@
 package com.festago.school.domain;
 
-import com.festago.common.exception.BadRequestException;
-import com.festago.common.exception.ErrorCode;
-
 public enum SchoolRegion {
     서울,
     부산,
     대구,
     ANY;
-
-    public static SchoolRegion from(String regionName) {
-        try {
-            return SchoolRegion.valueOf(regionName);
-        } catch (IllegalArgumentException e) {
-            throw new BadRequestException(ErrorCode.INVALID_REGION);
-        }
-    }
 }

--- a/backend/src/main/java/com/festago/school/domain/SchoolRegion.java
+++ b/backend/src/main/java/com/festago/school/domain/SchoolRegion.java
@@ -7,7 +7,7 @@ public enum SchoolRegion {
     서울,
     부산,
     대구,
-    기타;
+    ANY;
 
     public static SchoolRegion from(String regionName) {
         try {

--- a/backend/src/test/java/com/festago/festival/presentation/v1/FestivalV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/festival/presentation/v1/FestivalV1ControllerTest.java
@@ -1,7 +1,6 @@
 package com.festago.festival.presentation.v1;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -69,19 +68,8 @@ class FestivalV1ControllerTest {
             void 쿼리_파라미터에_size가_20을_초과하면_400_응답이_반환된다(String size) throws Exception {
                 mockMvc.perform(get(uri)
                         .param(SIZE_KEY, size))
-                    .andDo(print())
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").value("페이지 갯수의 제한을 벗어납니다."));
-            }
-
-            // PageableDefault 때문에 default 값으로 설정됨
-            @ParameterizedTest
-            @ValueSource(strings = {"-1", "0"})
-            void 쿼리_파라미터에_size가_0_또는_음수여도_200_응답이_반환된다(String size) throws Exception {
-                // given && when && then
-                mockMvc.perform(get(uri)
-                        .param(SIZE_KEY, size))
-                    .andExpect(status().isOk());
+                    .andExpect(jsonPath("$.message").value("최대 size 값을 초과했습니다."));
             }
 
             @ParameterizedTest

--- a/backend/src/test/java/com/festago/festival/presentation/v1/FestivalV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/festival/presentation/v1/FestivalV1ControllerTest.java
@@ -1,14 +1,18 @@
 package com.festago.festival.presentation.v1;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.festago.support.CustomWebMvcTest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,70 +22,76 @@ import org.springframework.test.web.servlet.MockMvc;
 @SuppressWarnings("NonAsciiCharacters")
 class FestivalV1ControllerTest {
 
-    private static final String LAST_FESTIVAL_ID = "lastFestivalId";
-    private static final String LAST_START_DATE = "lastStartDate";
-    private static final String SIZE = "size";
+    private static final String LAST_FESTIVAL_ID_KEY = "lastFestivalId";
+    private static final String LAST_START_DATE_KEY = "lastStartDate";
+    private static final String SIZE_KEY = "size";
 
     @Autowired
     MockMvc mockMvc;
 
     @Nested
-    class 축제의_식별자와_마지막_축제_시작일 {
+    class 축제_목록_커서_기반_페이징_조회 {
 
-        @Test
-        void 은_들다_보내면_성공한다() throws Exception {
-            // given && when && then
-            mockMvc.perform(get("/api/v1/festivals")
-                    .param(LAST_FESTIVAL_ID, "1")
-                    .param(LAST_START_DATE, "1999-10-01"))
-                .andExpect(status().isOk());
-        }
+        final String uri = "/api/v1/festivals";
 
-        @Test
-        void 은_들다_안_보내면_성공한다() throws Exception {
-            // given && when && then
-            mockMvc.perform(get("/api/v1/festivals"))
-                .andExpect(status().isOk());
-        }
+        @Nested
+        @DisplayName("GET " + uri)
+        class 올바른_주소로 {
 
-        @Test
-        void 은_하나만_보내면_실패한다() throws Exception {
-            // given && when && then
-            mockMvc.perform(get("/api/v1/festivals")
-                    .param(LAST_FESTIVAL_ID, "1"))
-                .andExpect(status().isBadRequest());
-        }
-    }
+            @Test
+            void 쿼리_파라미터에_festivalId와_lastStartDate를_모두_보내면_200_응답이_반환된다() throws Exception {
+                mockMvc.perform(get(uri)
+                        .param(LAST_FESTIVAL_ID_KEY, "1")
+                        .param(LAST_START_DATE_KEY, "1999-10-01"))
+                    .andExpect(status().isOk());
+            }
 
-    @Nested
-    class 축제_페이지_갯수는 {
+            @Test
+            void 쿼리_파라미터에_festivalId와_lastStartDate를_보내지_않아도_200_응답이_반환된다() throws Exception {
+                mockMvc.perform(get(uri))
+                    .andExpect(status().isOk());
+            }
 
-        @ParameterizedTest
-        @ValueSource(longs = {21})
-        void _21_이상이면_실패한다(long value) throws Exception {
-            // given && when && then
-            mockMvc.perform(get("/api/v1/festivals")
-                    .param(SIZE, String.valueOf(value)))
-                .andExpect(status().isBadRequest());
-        }
+            @CsvSource(value = {"1,''", "'',2077-06-30"})
+            @ParameterizedTest
+            void 쿼리_파라미터에_festivalId_또는_lastStartDate_중_하나만_보내면_400_응답이_반환된다(
+                String festivalId, String lastStartDate
+            ) throws Exception {
+                mockMvc.perform(get(uri)
+                        .param(LAST_FESTIVAL_ID_KEY, festivalId)
+                        .param(LAST_START_DATE_KEY, lastStartDate))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("festivalId, lastStartDate 두 값 모두 요청하거나 요청하지 않아야합니다."));
+            }
 
-        // PageableDefault 때문에 default 값으로 설정됨
-        @ParameterizedTest
-        @ValueSource(longs = {-1, 0})
-        void 음수_또는_0이면_성공한다(long value) throws Exception {
-            // given && when && then
-            mockMvc.perform(get("/api/v1/festivals")
-                    .param(SIZE, String.valueOf(value)))
-                .andExpect(status().isOk());
-        }
+            @ParameterizedTest
+            @ValueSource(strings = {"21"})
+            void 쿼리_파라미터에_size가_20을_초과하면_400_응답이_반환된다(String size) throws Exception {
+                mockMvc.perform(get(uri)
+                        .param(SIZE_KEY, size))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("페이지 갯수의 제한을 벗어납니다."));
+            }
 
-        @ParameterizedTest
-        @ValueSource(longs = {1, 20})
-        void 최소_1과_최대_20_사이면_성공한다(long value) throws Exception {
-            // given && when && then
-            mockMvc.perform(get("/api/v1/festivals")
-                    .param(SIZE, String.valueOf(value)))
-                .andExpect(status().isOk());
+            // PageableDefault 때문에 default 값으로 설정됨
+            @ParameterizedTest
+            @ValueSource(strings = {"-1", "0"})
+            void 쿼리_파라미터에_size가_0_또는_음수여도_200_응답이_반환된다(String size) throws Exception {
+                // given && when && then
+                mockMvc.perform(get(uri)
+                        .param(SIZE_KEY, size))
+                    .andExpect(status().isOk());
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"1", "20"})
+            void 쿼리_파라미터에_size가_1_에서_20_사이면_200_응답이_반환된다(String size) throws Exception {
+                // given && when && then
+                mockMvc.perform(get(uri)
+                        .param(SIZE_KEY, size))
+                    .andExpect(status().isOk());
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #705

## ✨ PR 세부 내용

이슈 내용과 같이 `filter` 쿼리 파라미터 기본 값을 설정했습니다.

기본 값을 설정하는 방법은 회의에서 결정한 2번 방법을 사용해서 명시적으로 쿼리 파라미터를 표시했습니다.

최대 페이징 사이즈 검증 또한 `@ValidPageable` 어노테이션을 활용한 검증을 사용하도록 변경했습니다.

추가로 API 스펙에서는 지역이 `location`이 아닌, `region` 이므로 파라미터의 변수명 또한 변경했고, nullable 하지 않도록 default 값을 추가했습니다.

다만 추가로 문제가 발생할 우려가 있는 것이 기본 값을 지정하는 경우, Controller 단위 테스트로 완벽한 검증이 불가능합니다.

지금처럼 쿼리가 `location`에서 다른 값으로 변경되는 경우 실제 응답 값을 받아야 검증이 가능합니다.

예) 기존 쿼리가 location인데, region으로 바뀐 상황에서 특정 지역의 학교의 축제만 반환되길 기대하지만 모든 축제가 반환

따라서 Controller 단위 테스트만으로 검증을 할 수 없습니다.

하지만 이러한 변경은 현재 서비스가 실제 운영중이 아니므로 문제가 없지만, 운영중인 상황에서는 큰 문제가 될 수 있습니다.

따라서 쿼리 파라미터의 이름이 변경되는 경우에는 수정하지 않고, 새로운 버전의 컨트롤러를 만들어야 합니다.

그렇기 때문에 변경이 불가능한 상황에서 쿼리 파라미터의 유무를 테스트하는 것이 의문이 들기도 하네요.

물론 오타가 발생하여 `region`을 `regoin`으로 적을 수 있으나.. IDE의 오타 하이라이팅, 코드 리뷰로 해결할 수 있을 것 같기도 하여 불필요한 테스트가 생기는 것이 아닌가 하는 생각이 듭니다. 
