### PR TITLE
[BE] 잘못된 flyway 스크립트 수정  (#707-hotfix1)

### DIFF
--- a/backend/src/main/resources/db/migration/V13__add_socialmedia.sql
+++ b/backend/src/main/resources/db/migration/V13__add_socialmedia.sql
@@ -1,16 +1,16 @@
 create table if not exists social_media
 (
-    id            bigint not null auto_increment,
-    owner_id      bigint,
-    owner_type    varchar(255),
-    media_type    varchar(255),
-    name          varchar(255),
-    logo_url      varchar(255),
-    url           varchar(255),
-    created_at    datetime(6),
-    updated_at    datetime(6),
+    id         bigint not null auto_increment,
+    owner_id   bigint,
+    owner_type varchar(255),
+    media_type varchar(255),
+    name       varchar(255),
+    logo_url   varchar(255),
+    url        varchar(255),
+    created_at datetime(6),
+    updated_at datetime(6),
     primary key (id)
 );
 
 alter table social_media
-    add constraint UNIQUE_OWNERTYPE_OWNERID unique (owner_id, owner_type, media_type);
+    add constraint UNIQUE_OWNER_ID_OWNER_TYPE_MEDIA_TYPE unique (owner_id, owner_type, media_type);

--- a/backend/src/main/resources/db/migration/V14__add_imageurl_school_artist.sql
+++ b/backend/src/main/resources/db/migration/V14__add_imageurl_school_artist.sql
@@ -1,9 +1,9 @@
 alter table school
-    add column logoUrl varchar(255);
+    add column logo_url varchar(255);
 
 alter table school
-    add column backgroundUrl varchar(255);
+    add column background_url varchar(255);
 
 alter table artist
-    add column backgroundUrl varchar(255);
+    add column background_image_url varchar(255);
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #707

## ✨ PR 세부 내용

`V14__add_imageurl_school_artist`에서 다음과 같이 잘못된 컬럼명을 추가하고 있습니다.

```sql
alter table school
    add column logoUrl varchar(255);

alter table school
    add column backgroundUrl varchar(255);

alter table artist
    add column backgroundUrl varchar(255);
```

해당 컬럼명은 카멜 케이스가 아닌, 스네이크 케이스 형식이 되어야 합니다.

또한 `artist` 테이블의 `backgroundUrl` 컬럼은 `backgound_url`이 아닌 `background_image_url`이 되어야 합니다.

`school`은 `background_url` 이지만, `artist`가 `background_image_url`인 것이 좋아 보이진 않네요.

나중에 하나의 형식으로 통일해야 할 것 같습니다. (`@Embeddable`을 사용한 값타입도 좋아보이네요)

또한 머지가 되기 전 최종으로 V14와 V15의 내용을 합쳐도 좋을 것 같습니다.
