### PR TITLE
[BE] refactor: AdminAuthService 도메인 상수 도메인으로 이동 (#612)

### DIFF
--- a/backend/src/main/java/com/festago/admin/domain/Admin.java
+++ b/backend/src/main/java/com/festago/admin/domain/Admin.java
@@ -25,6 +25,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Admin extends BaseTimeEntity {
 
+    public static final String ROOT_ADMIN_NAME = "admin";
     private static final int MIN_USERNAME_LENGTH = 4;
     private static final int MAX_USERNAME_LENGTH = 20;
     private static final int MIN_PASSWORD_LENGTH = 4;

--- a/backend/src/main/java/com/festago/auth/application/AdminAuthService.java
+++ b/backend/src/main/java/com/festago/auth/application/AdminAuthService.java
@@ -22,8 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AdminAuthService {
 
-    private static final String ROOT_ADMIN = "admin";
-
     private final AuthProvider authProvider;
     private final AdminRepository adminRepository;
     private final PasswordEncoder passwordEncoder;
@@ -42,9 +40,9 @@ public class AdminAuthService {
     }
 
     public void initializeRootAdmin(String password) {
-        adminRepository.findByUsername(ROOT_ADMIN).ifPresentOrElse(admin -> {
+        adminRepository.findByUsername(Admin.ROOT_ADMIN_NAME).ifPresentOrElse(admin -> {
             throw new BadRequestException(ErrorCode.DUPLICATE_ACCOUNT_USERNAME);
-        }, () -> adminRepository.save(new Admin(ROOT_ADMIN, passwordEncoder.encode(password))));
+        }, () -> adminRepository.save(new Admin(Admin.ROOT_ADMIN_NAME, passwordEncoder.encode(password))));
     }
 
     public AdminSignupResponse signup(Long adminId, AdminSignupRequest request) {
@@ -65,7 +63,7 @@ public class AdminAuthService {
     private void validateRootAdmin(Long adminId) {
         adminRepository.findById(adminId)
             .map(Admin::getUsername)
-            .filter(username -> Objects.equals(username, ROOT_ADMIN))
+            .filter(username -> Objects.equals(username, Admin.ROOT_ADMIN_NAME))
             .ifPresentOrElse(username -> {
             }, () -> {
                 throw new ForbiddenException(ErrorCode.NOT_ENOUGH_PERMISSION);


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #612

## ✨ PR 세부 내용

`AdminAuthService`에 있던 `ROOT_ADMIN` 상수를 더 관련있는 `Admin` 도메인 클래스로 이동시켰습니다.