### PR TITLE
[AN/USER] feat: 축제 목록 화면 인기 축제 목록에 무한 스크롤을 적용한다(#735)

### DIFF
--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
@@ -126,19 +126,27 @@ class FestivalListFragment : Fragment() {
     }
 
     private fun handleSuccess(uiState: FestivalListUiState.Success) {
-        festivalListAdapter.submitList(
-            listOf(
-                uiState.popularFestivals,
-                FestivalTabUiState {
-                    val festivalFilter = when (it) {
-                        0 -> FestivalFilterUiState.PROGRESS
-                        1 -> FestivalFilterUiState.PLANNED
-                        else -> FestivalFilterUiState.PROGRESS
-                    }
-                    vm.loadFestivals(festivalFilter)
-                },
-            ) + uiState.festivals,
+        val items = uiState.getItems()
+        festivalListAdapter.submitList(items)
+    }
+
+    private fun FestivalListUiState.Success.getItems(): List<Any> {
+        val items = mutableListOf<Any>()
+        if (popularFestivalUiState.festivals.isNotEmpty()) {
+            items.add(popularFestivalUiState)
+        }
+        items.add(
+            FestivalTabUiState {
+                val festivalFilter = when (it) {
+                    0 -> FestivalFilterUiState.PROGRESS
+                    1 -> FestivalFilterUiState.PLANNED
+                    else -> FestivalFilterUiState.PROGRESS
+                }
+                vm.loadFestivals(festivalFilter)
+            },
         )
+        items.addAll(festivals)
+        return items.toList()
     }
 
     override fun onDestroyView() {

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModel.kt
@@ -49,7 +49,7 @@ class FestivalListViewModel @Inject constructor(
                 _uiState.value = FestivalListUiState.Success(
                     PopularFestivalUiState(
                         title = popularFestivals.title,
-                        popularFestivals = popularFestivals.festivals.map { it.toUiState() },
+                        festivals = popularFestivals.festivals.map { it.toUiState() },
                     ),
                     festivals = festivalsPage.festivals.map { it.toUiState() },
                     isLastPage = festivalsPage.isLastPage,

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/festival/FestivalListPopularViewHolder.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/festival/FestivalListPopularViewHolder.kt
@@ -22,8 +22,10 @@ class FestivalListPopularViewHolder(val binding: ItemFestivalListPopularBinding)
     init {
         TabLayoutMediator(
             binding.tlDotIndicator,
-            binding.vpPopularFestivalForeground,
-        ) { tab, position -> }.attach()
+            binding.vpPopularFestivalBackground,
+        ) { tab, position ->
+            tab.view.isClickable = false
+        }.attach()
     }
 
     fun bind(popularFestivalUiState: PopularFestivalUiState) {

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/festival/FestivalListPopularViewHolder.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/festival/FestivalListPopularViewHolder.kt
@@ -30,7 +30,7 @@ class FestivalListPopularViewHolder(val binding: ItemFestivalListPopularBinding)
 
     fun bind(popularFestivalUiState: PopularFestivalUiState) {
         binding.tvPopularFestivalTitle.text = popularFestivalUiState.title
-        popularFestivalViewPager.submitList(popularFestivalUiState.popularFestivals)
+        popularFestivalViewPager.submitList(popularFestivalUiState.festivals)
     }
 
     companion object {

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/PopularFestivalViewPagerAdapter.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/PopularFestivalViewPagerAdapter.kt
@@ -103,7 +103,7 @@ class PopularFestivalViewPagerAdapter(
     }
 
     companion object {
-        private const val ALREADY_LOAD_POSITION_CONDITION = 4
+        private const val ALREADY_LOAD_POSITION_CONDITION = 2
         private const val RATE_SELECT_BY_UNSELECT = 0.81f
         private const val PAGE_LIMIT = 4
         private const val IMAGE_SIZE = 220.0f

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/PopularFestivalViewPagerAdapter.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/PopularFestivalViewPagerAdapter.kt
@@ -86,16 +86,24 @@ class PopularFestivalViewPagerAdapter(
     }
 
     fun submitList(festivals: List<FestivalItemUiState>) {
+        val lastFestivals = popularFestivals.toList()
         popularFestivals.clear()
         popularFestivals.addAll(festivals)
         foregroundAdapter.submitList(festivals)
         backgroundAdapter.submitList(festivals)
+
+        if (lastFestivals != festivals) {
+            initItemPosition()
+        }
+    }
+
+    private fun initItemPosition() {
         val initialPosition = Int.MAX_VALUE / 2 - (Int.MAX_VALUE / 2 % popularFestivals.size)
         foregroundViewPager.setCurrentItem(initialPosition, false)
     }
 
     companion object {
-        private const val ALREADY_LOAD_POSITION_CONDITION = 2
+        private const val ALREADY_LOAD_POSITION_CONDITION = 4
         private const val RATE_SELECT_BY_UNSELECT = 0.81f
         private const val PAGE_LIMIT = 4
         private const val IMAGE_SIZE = 220.0f

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/PopularFestivalViewPagerAdapter.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/PopularFestivalViewPagerAdapter.kt
@@ -90,10 +90,8 @@ class PopularFestivalViewPagerAdapter(
         popularFestivals.addAll(festivals)
         foregroundAdapter.submitList(festivals)
         backgroundAdapter.submitList(festivals)
-        foregroundViewPager.setCurrentItem(
-            /* item = */ Int.MAX_VALUE / 2 - (Int.MAX_VALUE / 2 % popularFestivals.size),
-            /* smoothScroll = */ false,
-        )
+        val initialPosition = Int.MAX_VALUE / 2 - (Int.MAX_VALUE / 2 % popularFestivals.size)
+        foregroundViewPager.setCurrentItem(initialPosition, false)
     }
 
     companion object {

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/PopularFestivalViewPagerAdapter.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/PopularFestivalViewPagerAdapter.kt
@@ -9,7 +9,7 @@ import com.festago.festago.presentation.ui.home.festivallist.uistate.FestivalIte
 import kotlin.math.abs
 
 class PopularFestivalViewPagerAdapter(
-    foregroundViewPager: ViewPager2,
+    private val foregroundViewPager: ViewPager2,
     backgroundViewPager: ViewPager2,
     private val onPopularFestivalSelected: (FestivalItemUiState) -> Unit,
 ) {
@@ -35,8 +35,9 @@ class PopularFestivalViewPagerAdapter(
         val onPageChangeCallback = object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
-                target.setCurrentItem(position, false)
-                onPopularFestivalSelected(popularFestivals[position])
+                val itemIndex = position % popularFestivals.size
+                target.setCurrentItem(itemIndex, false)
+                onPopularFestivalSelected(popularFestivals[itemIndex])
             }
         }
         viewpager.registerOnPageChangeCallback(onPageChangeCallback)
@@ -89,6 +90,10 @@ class PopularFestivalViewPagerAdapter(
         popularFestivals.addAll(festivals)
         foregroundAdapter.submitList(festivals)
         backgroundAdapter.submitList(festivals)
+        foregroundViewPager.setCurrentItem(
+            /* item = */ Int.MAX_VALUE / 2 - (Int.MAX_VALUE / 2 % popularFestivals.size),
+            /* smoothScroll = */ false,
+        )
     }
 
     companion object {

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/PopularFestivalViewPagerAdapter.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/PopularFestivalViewPagerAdapter.kt
@@ -24,14 +24,14 @@ class PopularFestivalViewPagerAdapter(
         foregroundViewPager.adapter = foregroundAdapter
         backgroundViewPager.adapter = backgroundAdapter
 
-        setTargetItemOnPageSelected(viewpager = foregroundViewPager, target = backgroundViewPager)
+        setTargetItemOnPageSelected(viewPager = foregroundViewPager, target = backgroundViewPager)
         narrowSpaceViewPager(viewPager = foregroundViewPager)
         setOffscreenPagesLimit(foregroundViewPager, PAGE_LIMIT)
         setOffscreenPagesLimit(backgroundViewPager, PAGE_LIMIT)
         backgroundViewPager.isUserInputEnabled = false
     }
 
-    private fun setTargetItemOnPageSelected(viewpager: ViewPager2, target: ViewPager2) {
+    private fun setTargetItemOnPageSelected(viewPager: ViewPager2, target: ViewPager2) {
         val onPageChangeCallback = object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
@@ -40,7 +40,7 @@ class PopularFestivalViewPagerAdapter(
                 onPopularFestivalSelected(popularFestivals[itemIndex])
             }
         }
-        viewpager.registerOnPageChangeCallback(onPageChangeCallback)
+        viewPager.registerOnPageChangeCallback(onPageChangeCallback)
     }
 
     private fun narrowSpaceViewPager(viewPager: ViewPager2) {

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/foreground/PopularFestivalForegroundAdapter.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/foreground/PopularFestivalForegroundAdapter.kt
@@ -1,36 +1,30 @@
 package com.festago.festago.presentation.ui.home.festivallist.popularfestival.foreground
 
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
 import com.festago.festago.presentation.ui.home.festivallist.uistate.FestivalItemUiState
 
-class PopularFestivalForegroundAdapter :
-    ListAdapter<FestivalItemUiState, PopularFestivalForegroundViewHolder>(diffUtil) {
+class PopularFestivalForegroundAdapter(festivals: List<FestivalItemUiState> = listOf()) :
+    RecyclerView.Adapter<PopularFestivalForegroundViewHolder>() {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PopularFestivalForegroundViewHolder {
+    private val _festivals = festivals.toMutableList()
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): PopularFestivalForegroundViewHolder {
         return PopularFestivalForegroundViewHolder.of(parent)
     }
 
     override fun onBindViewHolder(holder: PopularFestivalForegroundViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(_festivals[position % _festivals.size])
     }
 
-    companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<FestivalItemUiState>() {
-            override fun areItemsTheSame(
-                oldItem: FestivalItemUiState,
-                newItem: FestivalItemUiState,
-            ): Boolean {
-                return oldItem.id == newItem.id
-            }
+    override fun getItemCount(): Int = Int.MAX_VALUE
 
-            override fun areContentsTheSame(
-                oldItem: FestivalItemUiState,
-                newItem: FestivalItemUiState,
-            ): Boolean {
-                return oldItem == newItem
-            }
-        }
+    fun submitList(festivals: List<FestivalItemUiState>) {
+        _festivals.clear()
+        _festivals.addAll(festivals)
+        notifyDataSetChanged()
     }
 }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/foreground/PopularFestivalForegroundAdapter.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/popularfestival/foreground/PopularFestivalForegroundAdapter.kt
@@ -23,6 +23,9 @@ class PopularFestivalForegroundAdapter(festivals: List<FestivalItemUiState> = li
     override fun getItemCount(): Int = Int.MAX_VALUE
 
     fun submitList(festivals: List<FestivalItemUiState>) {
+        if (_festivals.toList() == festivals) {
+            return
+        }
         _festivals.clear()
         _festivals.addAll(festivals)
         notifyDataSetChanged()

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/uistate/FestivalListUiState.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/uistate/FestivalListUiState.kt
@@ -4,7 +4,7 @@ sealed interface FestivalListUiState {
     object Loading : FestivalListUiState
 
     data class Success(
-        val popularFestivals: PopularFestivalUiState,
+        val popularFestivalUiState: PopularFestivalUiState,
         val festivals: List<FestivalItemUiState>,
         val isLastPage: Boolean,
     ) : FestivalListUiState

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/uistate/PopularFestivalUiState.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/uistate/PopularFestivalUiState.kt
@@ -2,5 +2,5 @@ package com.festago.festago.presentation.ui.home.festivallist.uistate
 
 data class PopularFestivalUiState(
     val title: String,
-    val popularFestivals: List<FestivalItemUiState>,
+    val festivals: List<FestivalItemUiState>,
 )


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #735 

## ✨ PR 세부 내용

1. PopularFestivalForegroundAdapter 를 리스트 어댑터에서 리사이클러뷰 어댑터로 변경합니다.
2. 아이템 개수를 Int.MaxValue 로 변경합니다.
3. 축제 목록에서 아이템 찾는 방법은 다음과 같습니다.

```kotlin
   // 포지션을 총 아이템 개수로 나눈 나머지
   val item = _festivals[position % _festivals.size]
```
4. 첫 시작을 전체 position 중간에서 시작합니다.
```kotlin
    val initialPosition = Int.MAX_VALUE / 2 - (Int.MAX_VALUE / 2 % popularFestivals.size)
    foregroundViewPager.setCurrentItem(initialPosition, false)
```
 - (절반 - (절반을 아이템 개수로 나눈 나머지))
     ex: 2147483647 / 2 는 1073741823
     1073741823 을 5(아이템 개수)로 나눈 나머지 는 3
     initialPosition 은 1073741823 - 3 인 1073741820 가 됩니다.
     그럼 5로 나누어 떨어지므로 아이템은 0번째 index 부터 시작합니다.

 - 여기서 2는 따로 상수화하지 않았습니다. 


5. DotIndicator 의 개수가 무한 개가 되어서 이를 BackgroundViewPager 와 연결시켰습니다.
 - background 혼자 움직이면 안되니깐 터치 이벤트를 막았습니다.

## 시연 영상

https://github.com/woowacourse-teams/2023-festa-go/assets/108349655/2da7c583-e11a-44de-bc4b-774a7a574fa2

