### PR TITLE
[ALL] 추상적 의미를 가지는 API 필드 이름을 수정 (#723)

### DIFF
--- a/backend/src/main/java/com/festago/artist/dto/ArtistDetailV1Response.java
+++ b/backend/src/main/java/com/festago/artist/dto/ArtistDetailV1Response.java
@@ -5,9 +5,9 @@ import java.util.List;
 
 public record ArtistDetailV1Response(
     Long id,
-    String artistName,
-    String logoUrl,
-    String backgroundUrl,
+    String name,
+    String profileImageUrl,
+    String backgroundImageUrl,
     List<ArtistMediaV1Response> socialMedias
 ) {
 

--- a/backend/src/main/java/com/festago/artist/dto/ArtistFestivalDetailV1Response.java
+++ b/backend/src/main/java/com/festago/artist/dto/ArtistFestivalDetailV1Response.java
@@ -9,7 +9,7 @@ public record ArtistFestivalDetailV1Response(
     String name,
     LocalDate startDate,
     LocalDate endDate,
-    String imageUrl,
+    String posterImageUrl,
     @JsonRawValue String artists
 ) {
 

--- a/backend/src/main/java/com/festago/festival/dto/FestivalDetailV1Response.java
+++ b/backend/src/main/java/com/festago/festival/dto/FestivalDetailV1Response.java
@@ -10,7 +10,7 @@ public record FestivalDetailV1Response(
     SchoolV1Response school,
     LocalDate startDate,
     LocalDate endDate,
-    String imageUrl,
+    String posterImageUrl,
     Set<SocialMediaV1Response> socialMedias,
     Set<StageV1Response> stages
 ) {

--- a/backend/src/main/java/com/festago/festival/dto/FestivalV1Response.java
+++ b/backend/src/main/java/com/festago/festival/dto/FestivalV1Response.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDate;
 
+//TODO: 아티스트 필드명을 변경할려면 JsonRawValue 형식이라 DB에 저장할 필드이름을 다르게 해야함
 public record FestivalV1Response(
     Long id,
     String name,
     LocalDate startDate,
     LocalDate endDate,
-    String imageUrl,
+    String posterImageUrl,
     SchoolV1Response school,
     @JsonRawValue String artists) {
 

--- a/backend/src/main/java/com/festago/festival/dto/StageV1Response.java
+++ b/backend/src/main/java/com/festago/festival/dto/StageV1Response.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 
+//TODO: 필드명 변경으로 변경 불가
 public record StageV1Response(
     Long id,
     LocalDateTime startDateTime,

--- a/backend/src/main/java/com/festago/school/dto/v1/SchoolDetailV1Response.java
+++ b/backend/src/main/java/com/festago/school/dto/v1/SchoolDetailV1Response.java
@@ -5,9 +5,9 @@ import java.util.List;
 
 public record SchoolDetailV1Response(
     Long id,
-    String schoolName,
+    String name,
     String logoUrl,
-    String backgroundUrl,
+    String backgroundImageUrl,
     List<SchoolSocialMediaV1Response> socialMedias
 ) {
 

--- a/backend/src/main/java/com/festago/school/dto/v1/SchoolFestivalV1Response.java
+++ b/backend/src/main/java/com/festago/school/dto/v1/SchoolFestivalV1Response.java
@@ -9,7 +9,7 @@ public record SchoolFestivalV1Response(
     String name,
     LocalDate startDate,
     LocalDate endDate,
-    String imageUrl,
+    String posterImageUrl,
     @JsonRawValue String artists
 ) {
 

--- a/backend/src/test/java/com/festago/artist/application/ArtistDetailV1QueryServiceTest.java
+++ b/backend/src/test/java/com/festago/artist/application/ArtistDetailV1QueryServiceTest.java
@@ -127,7 +127,7 @@ class ArtistDetailV1QueryServiceTest extends ApplicationIntegrationTest {
 
         SocialMedia makeArtistSocialMedia(Long id, OwnerType ownerType, SocialMediaType socialMediaType) {
             return socialMediaRepository.save(
-                new SocialMedia(id, ownerType, socialMediaType, "총학생회", "logoUrl", "url"));
+                new SocialMedia(id, ownerType, socialMediaType, "총학생회", "profileImageUrl", "url"));
         }
     }
 

--- a/backend/src/test/java/com/festago/festival/application/integration/FestivalDetailV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/festival/application/integration/FestivalDetailV1QueryServiceIntegrationTest.java
@@ -123,7 +123,7 @@ class FestivalDetailV1QueryServiceIntegrationTest extends ApplicationIntegration
             softly.assertThat(response.name()).isEqualTo("테코대학교 축제");
             softly.assertThat(response.startDate()).isEqualTo("2077-06-30");
             softly.assertThat(response.endDate()).isEqualTo("2077-07-02");
-            softly.assertThat(response.imageUrl()).isEqualTo("https://school.com/image.com");
+            softly.assertThat(response.posterImageUrl()).isEqualTo("https://school.com/image.com");
             softly.assertThat(response.school().name()).isEqualTo("테코대학교");
             softly.assertThat(response.socialMedias())
                 .map(SocialMediaV1Response::name)

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolV1QueryServiceIntegrationTest.java
@@ -104,7 +104,7 @@ class SchoolV1QueryServiceIntegrationTest extends ApplicationIntegrationTest {
         private void saveSocialMedia(Long ownerId, OwnerType ownerType, SocialMediaType mediaType) {
             socialMediaRepository.save(
                 new SocialMedia(ownerId, ownerType, mediaType,
-                    "defaultName", "www.logoUrl.com", "www.url.com")
+                    "defaultName", "www.profileImageUrl.com", "www.url.com")
             );
         }
     }


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #723 

## ✨ PR 세부 내용

완전히 변경하지 못했습니다.
왜냐하면 현재 StageQueryInfo의 String 값으로 아티스트 정보를 던져주기 때문에, DB에 박혀있는 필드명에 의존합니다.

이 방법을 객체에서 Json이 아닌 자바 필드로 가져야한다고 생각해요.

구체적으로
```
@Entity
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class StageQueryInfo {
    private List<StageInfo> artists ...

        private class StageInfo {
            private Long id;
            private String name;
            private String profileImageUrl;
            private String backgroundImageUrl;
      } 
```
이런 느낌으로요

방법은 
1. JPA Convert 사용 (https://joont92.github.io/jpa/%EC%97%94%ED%8B%B0%ED%8B%B0-%EA%B0%92%EC%9D%84-%EB%B3%80%ED%99%98%ED%95%B4%EC%84%9C-%EC%A0%80%EC%9E%A5%ED%95%98%EA%B8%B0-Converter/)
2. 라이브러리 활용 (https://velog.io/@happyjamy/JPA-%EC%97%90%EC%84%9C-MySql-Json-%ED%83%80%EC%9E%85-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0-hibernate-6-%EC%9D%B4%EC%83%81)

이 부분의 변경이 필요하다고 생각되는게 지금 StageQueryInfo에선 어떤 필드가 존재하는지 알수가 없어서 나중에 response를 내려줄 때 부담이 된다고 생각합니다.

  
따라서 이런 변경을 가지거나

아니면 굳이 이러한 캐싱 테이블을 사용하지 않고 그냥 조회를 하는 것도 괜찮다고 생각해요. 데이터가 적고 인덱스 타면 유의미한 성능 문제는 안날거라 생각합니다.
