### PR TITLE
[BE] feat: 관리자 로그아웃 API 추가 (#740)

### DIFF
--- a/backend/src/main/java/com/festago/auth/presentation/AdminAuthController.java
+++ b/backend/src/main/java/com/festago/auth/presentation/AdminAuthController.java
@@ -28,7 +28,6 @@ public class AdminAuthController {
     private final AdminAuthService adminAuthService;
 
     @PostMapping("/login")
-    @Hidden
     public ResponseEntity<Void> login(@RequestBody @Valid AdminLoginRequest request) {
         String token = adminAuthService.login(request);
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, createLoginCookie(token))
@@ -48,7 +47,6 @@ public class AdminAuthController {
      * 클라이언트 측에서 httpOnly 쿠키를 조작할 수 없기 때문에, 서버 측에서 쿠키를 관리해주어야 함
      */
     @GetMapping("/logout")
-    @Hidden
     public ResponseEntity<Void> logout() {
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, createLogoutCookie())
             .build();
@@ -65,7 +63,6 @@ public class AdminAuthController {
     }
 
     @PostMapping("/signup")
-    @Hidden
     public ResponseEntity<AdminSignupResponse> signupAdminAccount(@RequestBody @Valid AdminSignupRequest request,
                                                                   @Admin Long adminId) {
         AdminSignupResponse response = adminAuthService.signup(adminId, request);
@@ -74,7 +71,6 @@ public class AdminAuthController {
     }
 
     @PostMapping("/initialize")
-    @Hidden
     public ResponseEntity<Void> initializeRootAdmin(@RequestBody @Valid RootAdminInitializeRequest request) {
         adminAuthService.initializeRootAdmin(request.password());
         return ResponseEntity.ok()

--- a/backend/src/main/java/com/festago/auth/presentation/AdminAuthController.java
+++ b/backend/src/main/java/com/festago/auth/presentation/AdminAuthController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,12 +30,31 @@ public class AdminAuthController {
     @Hidden
     public ResponseEntity<Void> login(@RequestBody @Valid AdminLoginRequest request) {
         String token = adminAuthService.login(request);
-        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, getCookie(token))
+        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, createLoginCookie(token))
             .build();
     }
 
-    private String getCookie(String token) {
+    private String createLoginCookie(String token) {
         return ResponseCookie.from("token", token)
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("None")
+            .path("/")
+            .build().toString();
+    }
+
+    /**
+     * 클라이언트 측에서 httpOnly 쿠키를 조작할 수 없기 때문에, 서버 측에서 쿠키를 관리해주어야 함
+     */
+    @GetMapping("/logout")
+    @Hidden
+    public ResponseEntity<Void> logout() {
+        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, createLogoutCookie())
+            .build();
+    }
+
+    private String createLogoutCookie() {
+        return ResponseCookie.from("token", "")
             .httpOnly(true)
             .secure(true)
             .sameSite("None")

--- a/backend/src/main/java/com/festago/auth/presentation/AdminAuthController.java
+++ b/backend/src/main/java/com/festago/auth/presentation/AdminAuthController.java
@@ -8,6 +8,7 @@ import com.festago.auth.dto.AdminSignupResponse;
 import com.festago.auth.dto.RootAdminInitializeRequest;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -59,6 +60,7 @@ public class AdminAuthController {
             .secure(true)
             .sameSite("None")
             .path("/")
+            .maxAge(Duration.ZERO)
             .build().toString();
     }
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #740

## ✨ PR 세부 내용

관리자 로그아웃 API를 추가했습니다.

로그아웃 API를 추가한 이유는 이슈에 남겨뒀으니 참고해주세요!

로그아웃 기능에는 변경이 없기에 모두가 접근할 수 있게 권한을 풀어도 되지만, 로그아웃을 하는 요청은 이미 권한을 얻은 뒤 요청을 하는 것이라 판단하여 따로 excludePathPatterns에 등록하지는 않았습니다. 

---

로그아웃 쿠키의 maxAge를 0으로 설정했는데, 지금 보니 로그인 쿠키에는 maxAge 설정이 되지 않아 세션으로 유지되네요!

이러면 보안에는 좋겠지만, 매번 브라우저를 재시작하면 로그인을 다시 해야할 것 같은데.. 관리자 기능인 만큼 보안이 중요하니 이대로 놔둬도 괜찮을 것 같은데 의견 있으시면 의견 남겨주세요!