### PR TITLE
[BE] School 생성, 수정에 누락된 필드 추가 (#731)

### DIFF
--- a/backend/src/main/java/com/festago/admin/presentation/v1/dto/SchoolV1CreateRequest.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/dto/SchoolV1CreateRequest.java
@@ -2,19 +2,32 @@ package com.festago.admin.presentation.v1.dto;
 
 import com.festago.school.domain.SchoolRegion;
 import com.festago.school.dto.SchoolCreateCommand;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
+@Builder
 public record SchoolV1CreateRequest(
-    @NotBlank(message = "name은 공백일 수 없습니다.")
+    @NotBlank
     String name,
-    @NotBlank(message = "domain은 공백일 수 없습니다.")
+    @NotBlank
     String domain,
-    @NotNull(message = "region은 null일 수 없습니다.")
-    SchoolRegion region
+    @NotNull
+    SchoolRegion region,
+    @Nullable
+    String logoUrl,
+    @Nullable
+    String backgroundImageUrl
 ) {
 
     public SchoolCreateCommand toCommand() {
-        return new SchoolCreateCommand(name, domain, region);
+        return SchoolCreateCommand.builder()
+            .name(name)
+            .domain(domain)
+            .region(region)
+            .logoUrl(logoUrl)
+            .backgroundImageUrl(backgroundImageUrl)
+            .build();
     }
 }

--- a/backend/src/main/java/com/festago/admin/presentation/v1/dto/SchoolV1UpdateRequest.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/dto/SchoolV1UpdateRequest.java
@@ -2,19 +2,32 @@ package com.festago.admin.presentation.v1.dto;
 
 import com.festago.school.domain.SchoolRegion;
 import com.festago.school.dto.SchoolUpdateCommand;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
+@Builder
 public record SchoolV1UpdateRequest(
-    @NotBlank(message = "name은 공백일 수 없습니다.")
+    @NotBlank
     String name,
-    @NotBlank(message = "domain은 공백일 수 없습니다.")
+    @NotBlank
     String domain,
-    @NotNull(message = "region은 null일 수 없습니다.")
-    SchoolRegion region
+    @NotNull
+    SchoolRegion region,
+    @Nullable
+    String logoUrl,
+    @Nullable
+    String backgroundImageUrl
 ) {
 
     public SchoolUpdateCommand toCommand() {
-        return new SchoolUpdateCommand(name, domain, region);
+        return SchoolUpdateCommand.builder()
+            .name(name)
+            .domain(domain)
+            .region(region)
+            .logoUrl(logoUrl)
+            .backgroundImageUrl(backgroundImageUrl)
+            .build();
     }
 }

--- a/backend/src/main/java/com/festago/school/application/SchoolCommandService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolCommandService.java
@@ -3,7 +3,6 @@ package com.festago.school.application;
 import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.ErrorCode;
 import com.festago.school.domain.School;
-import com.festago.school.domain.SchoolRegion;
 import com.festago.school.dto.SchoolCreateCommand;
 import com.festago.school.dto.SchoolUpdateCommand;
 import com.festago.school.repository.SchoolRepository;
@@ -20,15 +19,14 @@ public class SchoolCommandService {
     private final SchoolRepository schoolRepository;
 
     public Long createSchool(SchoolCreateCommand command) {
-        String domain = command.domain();
-        String name = command.name();
-        SchoolRegion region = command.region();
-        validateCreate(domain, name);
-        School school = schoolRepository.save(new School(domain, name, region));
+        validateCreate(command);
+        School school = schoolRepository.save(command.toDomain());
         return school.getId();
     }
 
-    private void validateCreate(String domain, String name) {
+    private void validateCreate(SchoolCreateCommand command) {
+        String domain = command.domain();
+        String name = command.name();
         if (schoolRepository.existsByDomain(domain)) {
             throw new BadRequestException(ErrorCode.DUPLICATE_SCHOOL_DOMAIN);
         }
@@ -42,13 +40,15 @@ public class SchoolCommandService {
      */
     public void updateSchool(Long schoolId, SchoolUpdateCommand command) {
         School school = schoolRepository.getOrThrow(schoolId);
-        validateUpdate(school, command.domain(), command.name());
+        validateUpdate(school, command);
         school.changeName(command.name());
         school.changeDomain(command.domain());
         school.changeRegion(command.region());
     }
 
-    private void validateUpdate(School school, String domain, String name) {
+    private void validateUpdate(School school, SchoolUpdateCommand command) {
+        String domain = command.domain();
+        String name = command.name();
         if (!Objects.equals(school.getDomain(), domain) && schoolRepository.existsByDomain(domain)) {
             throw new BadRequestException(ErrorCode.DUPLICATE_SCHOOL_DOMAIN);
         }

--- a/backend/src/main/java/com/festago/school/application/SchoolCommandService.java
+++ b/backend/src/main/java/com/festago/school/application/SchoolCommandService.java
@@ -44,6 +44,8 @@ public class SchoolCommandService {
         school.changeName(command.name());
         school.changeDomain(command.domain());
         school.changeRegion(command.region());
+        school.changeLogoUrl(command.logoUrl());
+        school.changeBackgroundImageUrl(command.backgroundImageUrl());
     }
 
     private void validateUpdate(School school, SchoolUpdateCommand command) {

--- a/backend/src/main/java/com/festago/school/domain/School.java
+++ b/backend/src/main/java/com/festago/school/domain/School.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,6 +22,7 @@ public class School extends BaseTimeEntity {
     private static final String DEFAULT_URL = "https://picsum.photos/536/354";
     private static final int MAX_DOMAIN_LENGTH = 50;
     private static final int MAX_NAME_LENGTH = 255;
+    private static final int MAX_IMAGE_URL_LENGTH = 255;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,28 +45,33 @@ public class School extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private SchoolRegion region;
 
-    public School(Long id, String domain, String name, String logoUrl, String backgroundUrl, SchoolRegion region) {
-        validate(domain, name, region);
+    public School(Long id, String domain, String name, String logoUrl, String backgroundImageUrl, SchoolRegion region) {
+        validate(domain, name, region, logoUrl, backgroundImageUrl);
         this.id = id;
         this.domain = domain;
         this.name = name;
-        this.logoUrl = logoUrl;
-        this.backgroundUrl = backgroundUrl;
+        this.logoUrl = getDefaultUrlIfBlank(logoUrl);
+        this.backgroundUrl = getDefaultUrlIfBlank(backgroundImageUrl);
         this.region = region;
+    }
+
+    private String getDefaultUrlIfBlank(String imageUrl) {
+        if (StringUtils.hasText(imageUrl)) {
+            return imageUrl;
+        }
+        return DEFAULT_URL;
     }
 
     public School(String domain, String name, SchoolRegion region) {
         this(null, domain, name, DEFAULT_URL, DEFAULT_URL, region);
     }
 
-    public School(Long id, String domain, String name, SchoolRegion region) {
-        this(id, domain, name, DEFAULT_URL, DEFAULT_URL, region);
-    }
-
-    private void validate(String domain, String name, SchoolRegion region) {
+    private void validate(String domain, String name, SchoolRegion region, String logoUrl, String backgroundImageUrl) {
         validateDomain(domain);
         validateName(name);
         validateRegion(region);
+        validateImageUrl(logoUrl, "logoUrl");
+        validateImageUrl(backgroundImageUrl, "backgroundImageUrl");
     }
 
     private void validateDomain(String domain) {
@@ -83,6 +90,10 @@ public class School extends BaseTimeEntity {
         Validator.notNull(region, "region");
     }
 
+    private void validateImageUrl(String logoUrl, String fieldName) {
+        Validator.maxLength(logoUrl, MAX_IMAGE_URL_LENGTH, fieldName);
+    }
+
     public void changeDomain(String domain) {
         validateDomain(domain);
         this.domain = domain;
@@ -96,6 +107,16 @@ public class School extends BaseTimeEntity {
     public void changeRegion(SchoolRegion region) {
         validateRegion(region);
         this.region = region;
+    }
+
+    public void changeLogoUrl(String logoUrl) {
+        validateImageUrl(logoUrl, "logoUrl");
+        this.logoUrl = getDefaultUrlIfBlank(logoUrl);
+    }
+
+    public void changeBackgroundImageUrl(String backgroundImageUrl) {
+        validateImageUrl(backgroundImageUrl, "backgroundImageUrl");
+        this.backgroundUrl = getDefaultUrlIfBlank(backgroundImageUrl);
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/festago/school/dto/SchoolCreateCommand.java
+++ b/backend/src/main/java/com/festago/school/dto/SchoolCreateCommand.java
@@ -1,17 +1,37 @@
 package com.festago.school.dto;
 
 import com.festago.common.util.Validator;
+import com.festago.school.domain.School;
 import com.festago.school.domain.SchoolRegion;
+import lombok.Builder;
 
+@Builder
 public record SchoolCreateCommand(
     String name,
     String domain,
-    SchoolRegion region
+    SchoolRegion region,
+    String logoUrl,
+    String backgroundImageUrl
 ) {
 
     public SchoolCreateCommand {
         Validator.notNull(name, "name");
         Validator.notNull(domain, "domain");
         Validator.notNull(region, "region");
+    }
+
+    /**
+     * TODO 도메인에도 빌더 패턴을 적용해야할까?
+     * 생성자에 같은 타입이 중복적으로 발생하여 버그 발생 가능성이 매우 높다.
+     */
+    public School toDomain() {
+        return new School(
+            null,
+            domain,
+            name,
+            logoUrl,
+            backgroundImageUrl,
+            region
+        );
     }
 }

--- a/backend/src/main/java/com/festago/school/dto/SchoolUpdateCommand.java
+++ b/backend/src/main/java/com/festago/school/dto/SchoolUpdateCommand.java
@@ -2,11 +2,15 @@ package com.festago.school.dto;
 
 import com.festago.common.util.Validator;
 import com.festago.school.domain.SchoolRegion;
+import lombok.Builder;
 
+@Builder
 public record SchoolUpdateCommand(
     String name,
     String domain,
-    SchoolRegion region
+    SchoolRegion region,
+    String logoUrl,
+    String backgroundImageUrl
 ) {
 
     public SchoolUpdateCommand {

--- a/backend/src/test/java/com/festago/acceptance/steps/AdminSchoolStepDefinitions.java
+++ b/backend/src/test/java/com/festago/acceptance/steps/AdminSchoolStepDefinitions.java
@@ -23,9 +23,14 @@ public class AdminSchoolStepDefinitions {
 
     @Given("지역이 {string}에 있고, 이름이 {string}이고, 도메인이 {string}인 학교를 생성한다.")
     public void 학교를_생성한다(String region, String name, String domain) {
+        var request = SchoolV1CreateRequest.builder()
+            .name(name)
+            .domain(domain)
+            .region(SchoolRegion.valueOf(region))
+            .build();
         RestAssured.given()
             .contentType(ContentType.JSON)
-            .body(new SchoolV1CreateRequest(name, domain, SchoolRegion.valueOf(region)))
+            .body(request)
             .cookie("token", cucumberClient.getToken())
             .post("/admin/api/v1/schools")
             .then()
@@ -38,9 +43,14 @@ public class AdminSchoolStepDefinitions {
     @When("이름이 {string}인 학교의 이름을 {string}로 변경한다.")
     public void 학교의_이름을_다른_이름으로_변경한다(String srcName, String dstName) {
         var response = getSchoolResponsesByName(srcName).get(0);
+        var request = SchoolV1UpdateRequest.builder()
+            .name(dstName)
+            .domain(response.domain())
+            .region(response.region())
+            .build();
         RestAssured.given()
             .contentType(ContentType.JSON)
-            .body(new SchoolV1UpdateRequest(dstName, response.domain(), response.region()))
+            .body(request)
             .cookie("token", cucumberClient.getToken())
             .pathParam("id", response.id())
             .patch("/admin/api/v1/schools/{id}")

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminSchoolV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminSchoolV1ControllerTest.java
@@ -74,7 +74,13 @@ class AdminSchoolV1ControllerTest {
             @WithMockAuth(role = Role.ADMIN)
             void 요청을_보내면_201_응답과_Location_헤더에_식별자가_반환된다() throws Exception {
                 // given
-                var request = new SchoolV1CreateRequest("테코대학교", "teco.ac.kr", SchoolRegion.서울);
+                var request = SchoolV1CreateRequest.builder()
+                    .name("테코대학교")
+                    .domain("teco.ac.kr")
+                    .region(SchoolRegion.서울)
+                    .logoUrl("https://image.com/logo.png")
+                    .backgroundImageUrl("https://image.com/backgroundImage.png")
+                    .build();
                 given(schoolCommandService.createSchool(any(SchoolCreateCommand.class)))
                     .willReturn(1L);
 
@@ -118,7 +124,13 @@ class AdminSchoolV1ControllerTest {
             @WithMockAuth(role = Role.ADMIN)
             void 요청을_보내면_200_응답이_반환된다() throws Exception {
                 // given
-                var request = new SchoolV1UpdateRequest("테코대학교", "teco.ac.kr", SchoolRegion.서울);
+                var request = SchoolV1UpdateRequest.builder()
+                    .name("테코대학교")
+                    .domain("teco.ac.kr")
+                    .region(SchoolRegion.서울)
+                    .logoUrl("https://image.com/logo.png")
+                    .backgroundImageUrl("https://image.com/backgroundImage.png")
+                    .build();
 
                 // when & then
                 mockMvc.perform(patch(uri, 1L)

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
@@ -81,11 +81,20 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
             .name("테코대학교")
             .domain("teco.ac.kr")
             .region(SchoolRegion.서울)
+            .logoUrl("https://image.com/newLogo.png")
+            .backgroundImageUrl("https://image.com/newBackgroundImage.png")
             .build();
 
         @BeforeEach
         void setUp() {
-            school = schoolRepository.save(new School("wote.ac.kr", "우테대학교", SchoolRegion.대구));
+            school = schoolRepository.save(SchoolFixture.school()
+                .name("우테대학교")
+                .domain("wote.ac.kr")
+                .region(SchoolRegion.대구)
+                .logoUrl("https://image.com/logo.png")
+                .backgroundImageUrl("https://image.com/backgroundImage.png")
+                .build()
+            );
         }
 
         @Test
@@ -173,6 +182,9 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
                 softly.assertThat(updatedSchool.getName()).isEqualTo("테코대학교");
                 softly.assertThat(updatedSchool.getDomain()).isEqualTo("teco.ac.kr");
                 softly.assertThat(updatedSchool.getRegion()).isEqualTo(SchoolRegion.서울);
+                softly.assertThat(updatedSchool.getLogoUrl()).isEqualTo("https://image.com/newLogo.png");
+                softly.assertThat(updatedSchool.getBackgroundUrl())
+                    .isEqualTo("https://image.com/newBackgroundImage.png");
             });
         }
     }

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
@@ -35,7 +35,11 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
     @Nested
     class createSchool {
 
-        SchoolCreateCommand command = new SchoolCreateCommand("테코대학교", "teco.ac.kr", SchoolRegion.서울);
+        SchoolCreateCommand command = SchoolCreateCommand.builder()
+            .name("테코대학교")
+            .domain("teco.ac.kr")
+            .region(SchoolRegion.서울)
+            .build();
 
         @Test
         void 같은_도메인의_학교가_저장되어_있으면_예외가_발생한다() {
@@ -72,8 +76,12 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
     @Nested
     class updateSchool {
 
-        SchoolUpdateCommand command = new SchoolUpdateCommand("테코대학교", "teco.ac.kr", SchoolRegion.서울);
         School school;
+        SchoolUpdateCommand command = SchoolUpdateCommand.builder()
+            .name("테코대학교")
+            .domain("teco.ac.kr")
+            .region(SchoolRegion.서울)
+            .build();
 
         @BeforeEach
         void setUp() {
@@ -119,7 +127,11 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
         void 수정할_이름이_수정할_학교의_이름과_같으면_이름은_수정되지_않는다() {
             // given
             Long schoolId = school.getId();
-            SchoolUpdateCommand command = new SchoolUpdateCommand(school.getName(), "teco.ac.kr", SchoolRegion.서울);
+            var command = SchoolUpdateCommand.builder()
+                .name(school.getName())
+                .domain("teco.ac.kr")
+                .region(SchoolRegion.서울)
+                .build();
 
             // when
             schoolCommandService.updateSchool(schoolId, command);
@@ -133,7 +145,11 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
         void 수정할_도메인이_수정할_학교의_도메인과_같으면_도메인은_수정되지_않는다() {
             // given
             Long schoolId = school.getId();
-            SchoolUpdateCommand command = new SchoolUpdateCommand("테코대학교", school.getDomain(), SchoolRegion.서울);
+            var command = SchoolUpdateCommand.builder()
+                .name("테코대학교")
+                .domain(school.getDomain())
+                .region(SchoolRegion.서울)
+                .build();
 
             // when
             schoolCommandService.updateSchool(schoolId, command);

--- a/backend/src/test/java/com/festago/school/domain/SchoolTest.java
+++ b/backend/src/test/java/com/festago/school/domain/SchoolTest.java
@@ -134,4 +134,164 @@ class SchoolTest {
         // then
         assertThat(school.getName()).isEqualTo(name);
     }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " ", "\t", "\n"})
+    void 학교의_logoUrl이_null_또는_공백이어도_성공(String logoUrl) {
+        // when
+        School school = new School(1L, "teco.ac.kr", "테코대학교", logoUrl, "https://image.com/backgroundImage.png",
+            SchoolRegion.서울);
+
+        // then
+        assertThat(school.getLogoUrl()).isNotBlank();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 255})
+    void 학교의_logoUrl이_255글자_이내_성공(int length) {
+        // given
+        String logoUrl = "1".repeat(length);
+
+        // when
+        School school = new School(1L, "teco.ac.kr", "테코대학교", logoUrl, "https://image.com/backgroundImage.png",
+            SchoolRegion.서울);
+
+        // then
+        assertThat(school.getLogoUrl()).isEqualTo(logoUrl);
+    }
+
+    @Test
+    void 학교의_logoUrl이_255자를_넘으면_예외() {
+        // given
+        String logoUrl = "1".repeat(256);
+
+        // when & then
+        assertThatThrownBy(() -> {
+            new School(1L, "teco.ac.kr", "테코대학교", logoUrl, "https://image.com/backgroundImage.png",
+                SchoolRegion.서울);
+        }).isInstanceOf(ValidException.class);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " ", "\t", "\n"})
+    void 학교의_logoUrl을_수정할때_null_또는_공백이어도_성공(String logoUrl) {
+        // given
+        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png",
+            "https://image.com/backgroundImage.png", SchoolRegion.서울);
+
+        // when
+        school.changeLogoUrl(logoUrl);
+
+        // then
+        assertThat(school.getLogoUrl()).isNotBlank();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 255})
+    void 학교의_logoUrl을_수정할때_255글자_이내_성공(int length) {
+        // given
+        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png",
+            "https://image.com/backgroundImage.png", SchoolRegion.서울);
+        String logoUrl = "1".repeat(length);
+
+        // when
+        school.changeLogoUrl(logoUrl);
+
+        // then
+        assertThat(school.getLogoUrl()).isEqualTo(logoUrl);
+    }
+
+    @Test
+    void 학교의_logoUrl을_수정할때_255자를_넘으면_예외() {
+        // given
+        String logoUrl = "1".repeat(256);
+        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png",
+            "https://image.com/backgroundImage.png", SchoolRegion.서울);
+
+        // when & then
+        assertThatThrownBy(() -> school.changeLogoUrl(logoUrl))
+            .isInstanceOf(ValidException.class);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " ", "\t", "\n"})
+    void 학교의_backgroundImageUrl이_null_또는_공백이어도_성공(String backgroundImageUrl) {
+        // when
+        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png", backgroundImageUrl,
+            SchoolRegion.서울);
+
+        // then
+        assertThat(school.getBackgroundUrl()).isNotBlank();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 255})
+    void 학교의_backgroundImageUrl이_255글자_이내_성공(int length) {
+        // given
+        String backgroundImageUrl = "1".repeat(length);
+
+        // when
+        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png", backgroundImageUrl,
+            SchoolRegion.서울);
+
+        // then
+        assertThat(school.getBackgroundUrl()).isEqualTo(backgroundImageUrl);
+    }
+
+    @Test
+    void 학교의_backgroundImageUrl이_255자를_넘으면_예외() {
+        // given
+        String backgroundImageUrl = "1".repeat(256);
+
+        // when & then
+        assertThatThrownBy(() -> {
+            new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png", backgroundImageUrl,
+                SchoolRegion.서울);
+        }).isInstanceOf(ValidException.class);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " ", "\t", "\n"})
+    void 학교의_backgroundImageUrl을_수정할때_null_또는_공백이어도_성공(String backgroundImageUrl) {
+        // given
+        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png",
+            "https://image.com/backgroundImage.png", SchoolRegion.서울);
+
+        // when
+        school.changeBackgroundImageUrl(backgroundImageUrl);
+
+        // then
+        assertThat(school.getBackgroundUrl()).isNotBlank();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 255})
+    void 학교의_backgroundImageUrl을_수정할때_255글자_이내_성공(int length) {
+        // given
+        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png",
+            "https://image.com/backgroundImage.png", SchoolRegion.서울);
+        String backgroundImageUrl = "1".repeat(length);
+
+        // when
+        school.changeBackgroundImageUrl(backgroundImageUrl);
+
+        // then
+        assertThat(school.getBackgroundUrl()).isEqualTo(backgroundImageUrl);
+    }
+
+    @Test
+    void 학교의_backgroundImageUrl을_수정할때_255자를_넘으면_예외() {
+        // given
+        String backgroundImageUrl = "1".repeat(256);
+        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png",
+            "https://image.com/backgroundImage.png", SchoolRegion.서울);
+
+        // when & then
+        assertThatThrownBy(() -> school.changeBackgroundImageUrl(backgroundImageUrl))
+            .isInstanceOf(ValidException.class);
+    }
 }

--- a/backend/src/test/java/com/festago/school/domain/SchoolTest.java
+++ b/backend/src/test/java/com/festago/school/domain/SchoolTest.java
@@ -2,10 +2,13 @@ package com.festago.school.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.festago.common.exception.ValidException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
@@ -15,283 +18,345 @@ import org.junit.jupiter.params.provider.ValueSource;
 @SuppressWarnings("NonAsciiCharacters")
 class SchoolTest {
 
-    @Test
-    void 학교의_도메인_길이가_50자를_넘으면_예외() {
-        // given
-        String domain = "1".repeat(51);
+    @Nested
+    class 생성 {
 
-        // when & then
-        assertThatThrownBy(() -> new School(domain, "테코대학교", SchoolRegion.서울))
-            .isInstanceOf(ValidException.class);
-    }
+        @Test
+        void 도메인이_50자를_넘으면_예외() {
+            // given
+            String domain = "1".repeat(51);
 
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(strings = {"", " ", "\t", "\n"})
-    void 학교의_도메인이_null_또는_공백이면_예외(String domain) {
-        // when & then
-        assertThatThrownBy(() -> new School(domain, "테코대학교", SchoolRegion.서울))
-            .isInstanceOf(ValidException.class);
-    }
+            // when & then
+            assertThatThrownBy(() -> new School(domain, "테코대학교", SchoolRegion.서울))
+                .isInstanceOf(ValidException.class);
+        }
 
-    @Test
-    void 학교의_이름이_255자를_넘으면_예외() {
-        // given
-        String name = "1".repeat(256);
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"", " ", "\t", "\n"})
+        void 도메인이_null_또는_공백이면_예외(String domain) {
+            // when & then
+            assertThatThrownBy(() -> new School(domain, "테코대학교", SchoolRegion.서울))
+                .isInstanceOf(ValidException.class);
+        }
 
-        // when & then
-        assertThatThrownBy(() -> new School("teco.ac.kr", name, SchoolRegion.서울))
-            .isInstanceOf(ValidException.class);
-    }
+        @ParameterizedTest
+        @ValueSource(ints = {1, 50})
+        void 도메인이_50자_이내이면_성공(int length) {
+            // given
+            String domain = "1".repeat(length);
 
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(strings = {"", " ", "\t", "\n"})
-    void 학교의_이름이_null_또는_공백이면_예외(String name) {
-        // when & then
-        assertThatThrownBy(() -> new School("teco.ac.kr", name, SchoolRegion.서울))
-            .isInstanceOf(ValidException.class);
-    }
+            // when
+            School school = new School(domain, "테코대학교", SchoolRegion.서울);
 
-    @Test
-    void 학교의_도메인을_수정할때_255자를_넘으면_예외() {
-        // given
-        School school = new School("teco.ac.kr", "테코대학교", SchoolRegion.서울);
+            // then
+            assertThat(school.getDomain()).isEqualTo(domain);
+        }
 
-        // when & then
-        String domain = "1".repeat(256);
-        assertThatThrownBy(() -> school.changeDomain(domain))
-            .isInstanceOf(ValidException.class);
-    }
+        @Test
+        void 이름이_255자를_넘으면_예외() {
+            // given
+            String name = "1".repeat(256);
 
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(strings = {"", " ", "\t", "\n"})
-    void 학교의_도메인을_수정할때_null_또는_공백이면_예외(String domain) {
-        // given
-        School school = new School("teco.ac.kr", "테코대학교", SchoolRegion.서울);
+            // when & then
+            assertThatThrownBy(() -> new School("teco.ac.kr", name, SchoolRegion.서울))
+                .isInstanceOf(ValidException.class);
+        }
 
-        // when & then
-        assertThatThrownBy(() -> school.changeDomain(domain))
-            .isInstanceOf(ValidException.class);
-    }
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"", " ", "\t", "\n"})
+        void 이름이_null_또는_공백이면_예외(String name) {
+            // when & then
+            assertThatThrownBy(() -> new School("teco.ac.kr", name, SchoolRegion.서울))
+                .isInstanceOf(ValidException.class);
+        }
 
-    @Test
-    void 학교의_이름을_수정할때_255자를_넘으면_예외() {
-        // given
-        School school = new School("teco.ac.kr", "테코대학교", SchoolRegion.서울);
+        @ParameterizedTest
+        @ValueSource(ints = {1, 255})
+        void 이름이_255자_이내이면_성공(int length) {
+            // given
+            String name = "1".repeat(length);
 
-        // when & then
-        String name = "1".repeat(256);
-        assertThatThrownBy(() -> school.changeName(name))
-            .isInstanceOf(ValidException.class);
-    }
+            // when
+            School school = new School("teco.ac.kr", name, SchoolRegion.서울);
 
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(strings = {"", " ", "\t", "\n"})
-    void 학교의_이름을_수정할때_null_또는_공백이면_예외(String name) {
-        // given
-        School school = new School("teco.ac.kr", "테코대학교", SchoolRegion.서울);
+            // then
+            assertThat(school.getName()).isEqualTo(name);
+        }
 
-        // when & then
-        assertThatThrownBy(() -> school.changeName(name))
-            .isInstanceOf(ValidException.class);
-    }
+        @Test
+        void 지역이_null이면_예외() {
+            // given
+            SchoolRegion region = null;
 
-    @Test
-    void 학교_생성_성공() {
-        // given
-        School school = new School("teco.ac.kr", "테코대학교", SchoolRegion.서울);
+            // when & then
+            assertThatThrownBy(() -> new School("teco.ac.kr", "테코대학교", region))
+                .isInstanceOf(ValidException.class);
+        }
 
-        // when & then
-        assertThat(school.getName()).isEqualTo("테코대학교");
-        assertThat(school.getDomain()).isEqualTo("teco.ac.kr");
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {1, 50})
-    void 학교를_생성할때_도메인이_50글자_이내_성공(int length) {
-        // given
-        String domain = "1".repeat(length);
-
-        // when
-        School school = new School(domain, "테코대학교", SchoolRegion.서울);
-
-        // then
-        assertThat(school.getDomain()).isEqualTo(domain);
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {1, 255})
-    void 학교를_생성할때_이름이_255글자_이내_성공(int length) {
-        // given
-        String name = "1".repeat(length);
-
-        // when
-        School school = new School("teco.ac.kr", name, SchoolRegion.서울);
-
-        // then
-        assertThat(school.getName()).isEqualTo(name);
-    }
-
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(strings = {"", " ", "\t", "\n"})
-    void 학교의_logoUrl이_null_또는_공백이어도_성공(String logoUrl) {
-        // when
-        School school = new School(1L, "teco.ac.kr", "테코대학교", logoUrl, "https://image.com/backgroundImage.png",
-            SchoolRegion.서울);
-
-        // then
-        assertThat(school.getLogoUrl()).isNotBlank();
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {1, 255})
-    void 학교의_logoUrl이_255글자_이내_성공(int length) {
-        // given
-        String logoUrl = "1".repeat(length);
-
-        // when
-        School school = new School(1L, "teco.ac.kr", "테코대학교", logoUrl, "https://image.com/backgroundImage.png",
-            SchoolRegion.서울);
-
-        // then
-        assertThat(school.getLogoUrl()).isEqualTo(logoUrl);
-    }
-
-    @Test
-    void 학교의_logoUrl이_255자를_넘으면_예외() {
-        // given
-        String logoUrl = "1".repeat(256);
-
-        // when & then
-        assertThatThrownBy(() -> {
-            new School(1L, "teco.ac.kr", "테코대학교", logoUrl, "https://image.com/backgroundImage.png",
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"", " ", "\t", "\n"})
+        void logoUrl이_null_또는_공백이어도_성공(String logoUrl) {
+            // when
+            School school = new School(1L, "teco.ac.kr", "테코대학교", logoUrl, "https://image.com/backgroundImage.png",
                 SchoolRegion.서울);
-        }).isInstanceOf(ValidException.class);
-    }
 
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(strings = {"", " ", "\t", "\n"})
-    void 학교의_logoUrl을_수정할때_null_또는_공백이어도_성공(String logoUrl) {
-        // given
-        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png",
-            "https://image.com/backgroundImage.png", SchoolRegion.서울);
+            // then
+            assertThat(school.getLogoUrl()).isNotBlank();
+        }
 
-        // when
-        school.changeLogoUrl(logoUrl);
+        @ParameterizedTest
+        @ValueSource(ints = {1, 255})
+        void logoUrl이_255자_이내이면_성공(int length) {
+            // given
+            String logoUrl = "1".repeat(length);
 
-        // then
-        assertThat(school.getLogoUrl()).isNotBlank();
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {1, 255})
-    void 학교의_logoUrl을_수정할때_255글자_이내_성공(int length) {
-        // given
-        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png",
-            "https://image.com/backgroundImage.png", SchoolRegion.서울);
-        String logoUrl = "1".repeat(length);
-
-        // when
-        school.changeLogoUrl(logoUrl);
-
-        // then
-        assertThat(school.getLogoUrl()).isEqualTo(logoUrl);
-    }
-
-    @Test
-    void 학교의_logoUrl을_수정할때_255자를_넘으면_예외() {
-        // given
-        String logoUrl = "1".repeat(256);
-        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png",
-            "https://image.com/backgroundImage.png", SchoolRegion.서울);
-
-        // when & then
-        assertThatThrownBy(() -> school.changeLogoUrl(logoUrl))
-            .isInstanceOf(ValidException.class);
-    }
-
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(strings = {"", " ", "\t", "\n"})
-    void 학교의_backgroundImageUrl이_null_또는_공백이어도_성공(String backgroundImageUrl) {
-        // when
-        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png", backgroundImageUrl,
-            SchoolRegion.서울);
-
-        // then
-        assertThat(school.getBackgroundUrl()).isNotBlank();
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {1, 255})
-    void 학교의_backgroundImageUrl이_255글자_이내_성공(int length) {
-        // given
-        String backgroundImageUrl = "1".repeat(length);
-
-        // when
-        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png", backgroundImageUrl,
-            SchoolRegion.서울);
-
-        // then
-        assertThat(school.getBackgroundUrl()).isEqualTo(backgroundImageUrl);
-    }
-
-    @Test
-    void 학교의_backgroundImageUrl이_255자를_넘으면_예외() {
-        // given
-        String backgroundImageUrl = "1".repeat(256);
-
-        // when & then
-        assertThatThrownBy(() -> {
-            new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png", backgroundImageUrl,
+            // when
+            School school = new School(1L, "teco.ac.kr", "테코대학교", logoUrl, "https://image.com/backgroundImage.png",
                 SchoolRegion.서울);
-        }).isInstanceOf(ValidException.class);
+
+            // then
+            assertThat(school.getLogoUrl()).isEqualTo(logoUrl);
+        }
+
+        @Test
+        void logoUrl이_255자를_넘으면_예외() {
+            // given
+            String logoUrl = "1".repeat(256);
+
+            // when & then
+            assertThatThrownBy(() -> {
+                new School(1L, "teco.ac.kr", "테코대학교", logoUrl, "https://image.com/backgroundImage.png",
+                    SchoolRegion.서울);
+            }).isInstanceOf(ValidException.class);
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"", " ", "\t", "\n"})
+        void backgroundImageUrl이_null_또는_공백이어도_성공(String backgroundImageUrl) {
+            // when
+            School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png", backgroundImageUrl,
+                SchoolRegion.서울);
+
+            // then
+            assertThat(school.getBackgroundUrl()).isNotBlank();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 255})
+        void backgroundImageUrl이_255자_이내이면_성공(int length) {
+            // given
+            String backgroundImageUrl = "1".repeat(length);
+
+            // when
+            School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png", backgroundImageUrl,
+                SchoolRegion.서울);
+
+            // then
+            assertThat(school.getBackgroundUrl()).isEqualTo(backgroundImageUrl);
+        }
+
+        @Test
+        void backgroundImageUrl이_255자를_넘으면_예외() {
+            // given
+            String backgroundImageUrl = "1".repeat(256);
+
+            // when & then
+            assertThatThrownBy(() -> {
+                new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png", backgroundImageUrl,
+                    SchoolRegion.서울);
+            }).isInstanceOf(ValidException.class);
+        }
+
+        // TODO 해당 테스트는 생성자 파라미터 순서가 올바른지 검사하는데 의의가 있음
+        // 다만 빌더 패턴을 적용하면 해당 테스트의 필요성이 있을까?
+        @Test
+        void 성공() {
+            // given
+            Long id = 1L;
+            String domain = "teco.ac.kr";
+            String name = "테코대학교";
+            String logoUrl = "https://image.com/logo.png";
+            String backgroundImageUrl = "https://image.com/backgroundImage.png";
+            SchoolRegion region = SchoolRegion.서울;
+
+            School school = new School(id, domain, name, logoUrl, backgroundImageUrl, region);
+
+            // when & then
+            assertSoftly(softly -> {
+                softly.assertThat(school.getId()).isEqualTo(1L);
+                softly.assertThat(school.getDomain()).isEqualTo(domain);
+                softly.assertThat(school.getName()).isEqualTo(name);
+                softly.assertThat(school.getLogoUrl()).isEqualTo(logoUrl);
+                softly.assertThat(school.getBackgroundUrl()).isEqualTo(backgroundImageUrl);
+                softly.assertThat(school.getRegion()).isEqualTo(region);
+            });
+        }
     }
 
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(strings = {"", " ", "\t", "\n"})
-    void 학교의_backgroundImageUrl을_수정할때_null_또는_공백이어도_성공(String backgroundImageUrl) {
-        // given
-        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png",
-            "https://image.com/backgroundImage.png", SchoolRegion.서울);
+    @Nested
+    class 수정 {
 
-        // when
-        school.changeBackgroundImageUrl(backgroundImageUrl);
+        School school;
 
-        // then
-        assertThat(school.getBackgroundUrl()).isNotBlank();
-    }
+        @BeforeEach
+        void setUp() {
+            school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png",
+                "https://image.com/backgroundImage.png", SchoolRegion.서울);
+        }
 
-    @ParameterizedTest
-    @ValueSource(ints = {1, 255})
-    void 학교의_backgroundImageUrl을_수정할때_255글자_이내_성공(int length) {
-        // given
-        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png",
-            "https://image.com/backgroundImage.png", SchoolRegion.서울);
-        String backgroundImageUrl = "1".repeat(length);
+        @Test
+        void 도메인이_51자를_넘으면_예외() {
+            // given
+            String domain = "1".repeat(51);
 
-        // when
-        school.changeBackgroundImageUrl(backgroundImageUrl);
+            // when & then
+            assertThatThrownBy(() -> school.changeDomain(domain))
+                .isInstanceOf(ValidException.class);
+        }
 
-        // then
-        assertThat(school.getBackgroundUrl()).isEqualTo(backgroundImageUrl);
-    }
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"", " ", "\t", "\n"})
+        void 도메인이_null_또는_공백이면_예외(String domain) {
+            // when & then
+            assertThatThrownBy(() -> school.changeDomain(domain))
+                .isInstanceOf(ValidException.class);
+        }
 
-    @Test
-    void 학교의_backgroundImageUrl을_수정할때_255자를_넘으면_예외() {
-        // given
-        String backgroundImageUrl = "1".repeat(256);
-        School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png",
-            "https://image.com/backgroundImage.png", SchoolRegion.서울);
+        @ParameterizedTest
+        @ValueSource(ints = {1, 50})
+        void 도메인이_50자_이내이면_성공(int length) {
+            // given
+            String domain = "1".repeat(length);
 
-        // when & then
-        assertThatThrownBy(() -> school.changeBackgroundImageUrl(backgroundImageUrl))
-            .isInstanceOf(ValidException.class);
+            // when
+            school.changeDomain(domain);
+
+            // then
+            assertThat(school.getDomain()).isEqualTo(domain);
+        }
+
+        @Test
+        void 이름이_255자를_넘으면_예외() {
+            // when & then
+            String name = "1".repeat(256);
+            assertThatThrownBy(() -> school.changeName(name))
+                .isInstanceOf(ValidException.class);
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"", " ", "\t", "\n"})
+        void 이름이_null_또는_공백이면_예외(String name) {
+            // when & then
+            assertThatThrownBy(() -> school.changeName(name))
+                .isInstanceOf(ValidException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 255})
+        void 이름이_255자_이내이면_성공(int length) {
+            // given
+            String name = "1".repeat(length);
+
+            // when
+            school.changeName(name);
+
+            // then
+            assertThat(school.getName()).isEqualTo(name);
+        }
+
+        @Test
+        void 지역이_null이면_예외() {
+            // given
+            SchoolRegion region = null;
+
+            // when & then
+            assertThatThrownBy(() -> school.changeRegion(region))
+                .isInstanceOf(ValidException.class);
+        }
+
+        @Test
+        void 지역이_null이_아니면_성공() {
+            // given
+            SchoolRegion region = SchoolRegion.대구;
+
+            // when
+            school.changeRegion(region);
+
+            // then
+            assertThat(school.getRegion()).isEqualTo(region);
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"", " ", "\t", "\n"})
+        void logoUrl이_null_또는_공백이어도_성공(String logoUrl) {
+            // when
+            school.changeLogoUrl(logoUrl);
+
+            // then
+            assertThat(school.getLogoUrl()).isNotBlank();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 255})
+        void logoUrl이_255글자_이내이면_성공(int length) {
+            String logoUrl = "1".repeat(length);
+
+            // when
+            school.changeLogoUrl(logoUrl);
+
+            // then
+            assertThat(school.getLogoUrl()).isEqualTo(logoUrl);
+        }
+
+        @Test
+        void logoUrl이_255자를_넘으면_예외() {
+            // given
+            String logoUrl = "1".repeat(256);
+
+            // when & then
+            assertThatThrownBy(() -> school.changeLogoUrl(logoUrl))
+                .isInstanceOf(ValidException.class);
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"", " ", "\t", "\n"})
+        void backgroundImageUrl이_null_또는_공백이어도_성공(String backgroundImageUrl) {
+            // when
+            school.changeBackgroundImageUrl(backgroundImageUrl);
+
+            // then
+            assertThat(school.getBackgroundUrl()).isNotBlank();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 255})
+        void backgroundImageUrl이_255글자_이내이면_성공(int length) {
+            // given
+            String backgroundImageUrl = "1".repeat(length);
+
+            // when
+            school.changeBackgroundImageUrl(backgroundImageUrl);
+
+            // then
+            assertThat(school.getBackgroundUrl()).isEqualTo(backgroundImageUrl);
+        }
+
+        @Test
+        void backgroundImageUrl이_255자를_넘으면_예외() {
+            // given
+            String backgroundImageUrl = "1".repeat(256);
+
+            // when & then
+            assertThatThrownBy(() -> school.changeBackgroundImageUrl(backgroundImageUrl))
+                .isInstanceOf(ValidException.class);
+        }
     }
 }

--- a/backend/src/test/java/com/festago/support/SchoolFixture.java
+++ b/backend/src/test/java/com/festago/support/SchoolFixture.java
@@ -39,6 +39,11 @@ public class SchoolFixture {
         return this;
     }
 
+    public SchoolFixture region(SchoolRegion region) {
+        this.region = region;
+        return this;
+    }
+
     public SchoolFixture logoUrl(String logoUrl) {
         this.logoUrl = logoUrl;
         return this;

--- a/backend/src/test/java/com/festago/support/SchoolFixture.java
+++ b/backend/src/test/java/com/festago/support/SchoolFixture.java
@@ -13,6 +13,10 @@ public class SchoolFixture {
 
     private SchoolRegion region = SchoolRegion.서울;
 
+    private String logoUrl = "https://image.com/logo.png";
+
+    private String backgroundImageUrl = "https://image.com/backgroundImage.png";
+
     private SchoolFixture() {
     }
 
@@ -35,7 +39,17 @@ public class SchoolFixture {
         return this;
     }
 
+    public SchoolFixture logoUrl(String logoUrl) {
+        this.logoUrl = logoUrl;
+        return this;
+    }
+
+    public SchoolFixture backgroundImageUrl(String backgroundImageUrl) {
+        this.backgroundImageUrl = backgroundImageUrl;
+        return this;
+    }
+
     public School build() {
-        return new School(id, domain, name, region);
+        return new School(id, domain, name, logoUrl, backgroundImageUrl, region);
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #731

## ✨ PR 세부 내용

School 생성, 수정 시 누락된 `logoUrl`, `backgroundImageUrl`에 대한 필드를 추가했습니다.

적용 사항은 Request와 Command에 빌더 패턴을 적용했습니다.

이유는 School 생성 시 생성자의 인자에 String이 연속되기 때문에 실수로 인한 버그가 발생할 수 있기 때문입니다.
게다가 Request와 Command는 record이기 때문에 필드의 순서에 따라 생성자의 인자가 변합니다. (Request는 상관 없지만 테스트의 편의성과 가독성을 위해 적용했습니다.) 

TODO에도 남겨놨듯이 도메인에는 적용하지 않았지만, 도메인에도 적용하면 어떨까 하네요.

그리고 도메인이 가지고 있는 `logoUrl`, `backgroundImageUrl` 필드는 값 타입을 사용해도 좋을 것 같습니다.
이유는 해당 필드들이 공통점이 많기 때문이고, `Festival`, `Artist`에도 해당 개념이 사용되고 있습니다.
또한 기본 이미지 URL로 사용되는 경우에도 정적 변수로 할당하여 사용할 수 있을 것 같습니다. (ex: DEFAULT_POSTER_IMAGE_URL)

--- 

추가로 private 변수들만 `backgroundImageUrl`으로 변수명을 사용했습니다!