### PR TITLE
[BE] 아티스트 별 축제 조회, 학교 별 축제 조회시 API 명세서와 같은 Response를 전달 (#743)

### DIFF
--- a/backend/src/main/java/com/festago/artist/presentation/v1/ArtistDetailV1Controller.java
+++ b/backend/src/main/java/com/festago/artist/presentation/v1/ArtistDetailV1Controller.java
@@ -4,6 +4,7 @@ import com.festago.artist.application.ArtistDetailV1QueryService;
 import com.festago.artist.dto.ArtistDetailV1Response;
 import com.festago.artist.dto.ArtistFestivalDetailV1Response;
 import com.festago.common.aop.ValidPageable;
+import com.festago.common.dto.SliceResponse;
 import com.festago.common.exception.ValidException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -36,7 +37,7 @@ public class ArtistDetailV1Controller {
     @GetMapping("/{artistId}/festivals")
     @Operation(description = "아티스트가 참석한 축제를 조회한다. isPast 값으로 종료 축제 와 진행, 예정 축제를 구분 가능하다", summary = "아티스트 축제 조회")
     @ValidPageable(maxSize = 20)
-    public ResponseEntity<Slice<ArtistFestivalDetailV1Response>> getArtistInfo(
+    public ResponseEntity<SliceResponse<ArtistFestivalDetailV1Response>> getArtistInfo(
         @PathVariable Long artistId,
         @RequestParam(required = false) Long lastFestivalId,
         @RequestParam(required = false) LocalDate lastStartDate,
@@ -44,8 +45,9 @@ public class ArtistDetailV1Controller {
         @PageableDefault(size = 10) Pageable pageable
     ) {
         validate(lastFestivalId, lastStartDate);
-        return ResponseEntity.ok(
-            artistDetailV1QueryService.findArtistFestivals(artistId, lastFestivalId, lastStartDate, isPast, pageable));
+        Slice<ArtistFestivalDetailV1Response> response = artistDetailV1QueryService.findArtistFestivals(artistId,
+            lastFestivalId, lastStartDate, isPast, pageable);
+        return ResponseEntity.ok(SliceResponse.from(response));
     }
 
     private void validate(Long lastFestivalId, LocalDate lastStartDate) {

--- a/backend/src/main/java/com/festago/common/dto/SliceResponse.java
+++ b/backend/src/main/java/com/festago/common/dto/SliceResponse.java
@@ -1,0 +1,14 @@
+package com.festago.common.dto;
+
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record SliceResponse<T>(
+    boolean last,
+    List<T> content
+) {
+
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return new SliceResponse(slice.isLast(), slice.getContent());
+    }
+}

--- a/backend/src/main/java/com/festago/school/presentation/v1/SchoolV1Controller.java
+++ b/backend/src/main/java/com/festago/school/presentation/v1/SchoolV1Controller.java
@@ -1,6 +1,7 @@
 package com.festago.school.presentation.v1;
 
 import com.festago.common.aop.ValidPageable;
+import com.festago.common.dto.SliceResponse;
 import com.festago.school.application.v1.SchoolV1QueryService;
 import com.festago.school.dto.v1.SchoolDetailV1Response;
 import com.festago.school.dto.v1.SchoolFestivalV1Response;
@@ -37,7 +38,7 @@ public class SchoolV1Controller {
     @GetMapping("/{schoolId}/festivals")
     @ValidPageable(maxSize = 20)
     @Operation(description = "해당 학교의 축제들을 페이징하여 조회한다.", summary = "학교 상세 조회")
-    public ResponseEntity<Slice<SchoolFestivalV1Response>> findFestivalsBySchoolId(
+    public ResponseEntity<SliceResponse<SchoolFestivalV1Response>> findFestivalsBySchoolId(
         @PathVariable Long schoolId,
         @RequestParam(required = false) Long lastFestivalId,
         @RequestParam(required = false) LocalDate lastStartDate,
@@ -51,6 +52,6 @@ public class SchoolV1Controller {
             today,
             searchCondition
         );
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(SliceResponse.from(response));
     }
 }

--- a/backend/src/test/java/com/festago/artist/presentation/v1/ArtistDetailV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/artist/presentation/v1/ArtistDetailV1ControllerTest.java
@@ -1,0 +1,131 @@
+package com.festago.artist.presentation.v1;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.artist.application.ArtistDetailV1QueryService;
+import com.festago.artist.dto.ArtistDetailV1Response;
+import com.festago.artist.dto.ArtistFestivalDetailV1Response;
+import com.festago.artist.dto.ArtistMediaV1Response;
+import com.festago.common.dto.SliceResponse;
+import com.festago.socialmedia.domain.SocialMediaType;
+import com.festago.support.CustomWebMvcTest;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTest
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ArtistDetailV1ControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ArtistDetailV1QueryService artistDetailV1QueryService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Nested
+    class 아티스트_상세_조회 {
+
+        final String uri = "/api/v1/artists/{artistId}";
+
+        @Nested
+        @DisplayName("GET " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            void 요청을_보내면_200_응답과_body가_반환된다() throws Exception {
+                // given
+                var expected = new ArtistDetailV1Response(
+                    1L, "경북대학교",
+                    "https://image.com/logo.png",
+                    "https://image.com/backgroundLogo.png",
+                    List.of(
+                        new ArtistMediaV1Response(SocialMediaType.YOUTUBE.name(), "유튜브",
+                            "https://image.com/youtube.png", "www.knu-youtube.com"),
+                        new ArtistMediaV1Response(SocialMediaType.INSTAGRAM.name(), "인스타그램",
+                            "https://image.com/youtube.png", "www.knu-instagram.com")
+                    )
+                );
+                given(artistDetailV1QueryService.findArtistDetail(expected.id()))
+                    .willReturn(expected);
+
+                // when & then
+                mockMvc.perform(get(uri, 1L)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(content().json(objectMapper.writeValueAsString(expected)));
+            }
+        }
+    }
+
+
+
+
+
+    @Nested
+    class 아티스트별_축제_조회 {
+
+        final String uri = "/api/v1/artists/{artistId}/festivals";
+
+        @Nested
+        @DisplayName("GET " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            void 요청을_보내면_200_응답과_body가_반환된다() throws Exception {
+                // given
+                var today = LocalDate.now();
+                var content = List.of(new ArtistFestivalDetailV1Response(
+                    1L, "경북대학교", today, today.plusDays(1), "www.image.com/image.png",
+                    "아티스트"
+                ));
+                Pageable pageable = Pageable.ofSize(10);
+                var slice = new SliceImpl(content, pageable, true);
+                var expected = SliceResponse.from(slice);
+
+                given(artistDetailV1QueryService.findArtistFestivals(1L, null, null, false, Pageable.ofSize(10)))
+                    .willReturn(slice);
+
+                // when & then
+                mockMvc.perform(get(uri, 1L)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(content().json(objectMapper.writeValueAsString(expected)));
+            }
+
+            @Test
+            void 요청시_페이지가_20을_넘어가면_예외() throws Exception {
+                // given
+                int maxPageSize = 20;
+
+                // when && then
+                mockMvc.perform(get(uri, 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("size", String.valueOf(maxPageSize + 1)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/school/presentation/v1/SchoolV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/school/presentation/v1/SchoolV1ControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.common.dto.SliceResponse;
 import com.festago.school.application.v1.SchoolV1QueryService;
 import com.festago.school.dto.v1.SchoolDetailV1Response;
 import com.festago.school.dto.v1.SchoolFestivalV1Response;
@@ -95,10 +96,11 @@ class SchoolV1ControllerTest {
                     1L, "경북대학교", today, today.plusDays(1), "www.image.com/image.png",
                     "아티스트"
                 ));
-                var expected = new SliceImpl(content, Pageable.ofSize(10), true);
+                var slice = new SliceImpl(content, Pageable.ofSize(10), true);
+                var expected = SliceResponse.from(slice);
 
                 given(schoolV1QueryService.findFestivalsBySchoolId(1L, today, searchCondition))
-                    .willReturn(expected);
+                    .willReturn(slice);
 
                 // when & then
                 mockMvc.perform(get(uri, 1L)


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #743 

## ✨ PR 세부 내용

```
{
     "last":false,
     "content":[
     {
          "id":1,
          "name":"경북대학교",
           "startDate":"2024-02-23",
           "endDate":"2024-02-24",
           "imageUrl":"www.image.com/image.png",
           //원래 artists가 json 배열인데 테스트코드에선 String 넣어서 이래요
           "artists":아티스트
     }
   ]
}
```

우선 API 명세서와 같게, 또 필요한 값만 던져줬습니다. 

다만 구현에 있어 여러분들의 의견이 필요합니다.

저는 Repository와 Service에서 그대로 Slice를 넘겨주고 Controller에서 이를 last 여부만 가지는 SliceResponse 클래스로 변환해서 return 했습니다.

이렇게 한 이유는, 컨트롤러단에서만 하는게 코드 변경이 제일 적기 때문입니다. 

여러분들의 생각을 적어주세요.

1. ㅇㅇ 굿

2. 내 생각엔 Service에서 last만 가지게 변환해서 Controller에서 넘겨주는게 맞음.

3. 난 더 깊게 Repository에서 last만 가지는 값 뱉어주는게 맞다고 생각함.

일단 최대한 변경이 적은 방향으로 구현을 했고, 의견을 듣고 추가 push를 할려고 합니다.
변경이 더 많아지더라도, 어차피 코드가 많진 않아서 시간은 별로 안듭니다.

