### PR TITLE
[BE] feat: 관리자 축제 조회 기능 추가 (#745)

### DIFF
--- a/backend/src/main/java/com/festago/admin/application/AdminFestivalV1QueryService.java
+++ b/backend/src/main/java/com/festago/admin/application/AdminFestivalV1QueryService.java
@@ -1,0 +1,21 @@
+package com.festago.admin.application;
+
+import com.festago.admin.dto.AdminFestivalV1Response;
+import com.festago.admin.repository.AdminFestivalV1QueryDslRepository;
+import com.festago.common.querydsl.SearchCondition;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminFestivalV1QueryService {
+
+    private final AdminFestivalV1QueryDslRepository adminFestivalV1QueryDslRepository;
+
+    public Page<AdminFestivalV1Response> findAll(SearchCondition searchCondition) {
+        return adminFestivalV1QueryDslRepository.findAll(searchCondition);
+    }
+}

--- a/backend/src/main/java/com/festago/admin/dto/AdminFestivalV1Response.java
+++ b/backend/src/main/java/com/festago/admin/dto/AdminFestivalV1Response.java
@@ -1,0 +1,18 @@
+package com.festago.admin.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDate;
+
+public record AdminFestivalV1Response(
+    Long id,
+    String name,
+    String schoolName,
+    LocalDate startDate,
+    LocalDate endDate,
+    long stageCount
+) {
+
+    @QueryProjection
+    public AdminFestivalV1Response {
+    }
+}

--- a/backend/src/main/java/com/festago/admin/presentation/v1/AdminFestivalV1Controller.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/AdminFestivalV1Controller.java
@@ -1,19 +1,28 @@
 package com.festago.admin.presentation.v1;
 
+import com.festago.admin.application.AdminFestivalV1QueryService;
+import com.festago.admin.dto.AdminFestivalV1Response;
 import com.festago.admin.dto.FestivalV1CreateRequest;
 import com.festago.admin.dto.FestivalV1UpdateRequest;
+import com.festago.common.aop.ValidPageable;
+import com.festago.common.querydsl.SearchCondition;
 import com.festago.festival.application.command.FestivalCommandFacadeService;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,7 +31,19 @@ import org.springframework.web.bind.annotation.RestController;
 @Hidden
 public class AdminFestivalV1Controller {
 
+    private final AdminFestivalV1QueryService adminFestivalV1QueryService;
     private final FestivalCommandFacadeService festivalCommandFacadeService;
+
+    @ValidPageable(maxSize = 50)
+    @GetMapping
+    public ResponseEntity<Page<AdminFestivalV1Response>> findAll(
+        @RequestParam(defaultValue = "") String searchFilter,
+        @RequestParam(defaultValue = "") String searchKeyword,
+        @PageableDefault(size = 10) Pageable pageable
+    ) {
+        return ResponseEntity.ok()
+            .body(adminFestivalV1QueryService.findAll(new SearchCondition(searchFilter, searchKeyword, pageable)));
+    }
 
     @PostMapping
     public ResponseEntity<Void> createFestival(

--- a/backend/src/main/java/com/festago/admin/repository/AdminFestivalV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/admin/repository/AdminFestivalV1QueryDslRepository.java
@@ -1,0 +1,97 @@
+package com.festago.admin.repository;
+
+import static com.festago.festival.domain.QFestival.festival;
+import static com.festago.school.domain.QSchool.school;
+import static com.festago.stage.domain.QStage.stage;
+
+import com.festago.admin.dto.AdminFestivalV1Response;
+import com.festago.admin.dto.QAdminFestivalV1Response;
+import com.festago.common.querydsl.OrderSpecifierUtils;
+import com.festago.common.querydsl.QueryDslHelper;
+import com.festago.common.querydsl.SearchCondition;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminFestivalV1QueryDslRepository {
+
+    private final QueryDslHelper queryDslHelper;
+
+    public Page<AdminFestivalV1Response> findAll(SearchCondition searchCondition) {
+        Pageable pageable = searchCondition.pageable();
+        String searchFilter = searchCondition.searchFilter();
+        String searchKeyword = searchCondition.searchKeyword();
+        return queryDslHelper.applyPagination(pageable,
+            queryFactory -> queryFactory.select(
+                    new QAdminFestivalV1Response(
+                        festival.id,
+                        festival.name,
+                        school.name,
+                        festival.startDate,
+                        festival.endDate,
+                        stage.count()
+                    ))
+                .from(festival)
+                .innerJoin(school).on(school.id.eq(festival.school.id))
+                .leftJoin(stage).on(stage.festival.id.eq(festival.id))
+                .where(applySearchFilter(searchFilter, searchKeyword))
+                .groupBy(festival.id)
+                .orderBy(getOrderSpecifier(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize()),
+            queryFactory -> queryFactory.select(festival.count())
+                .from(festival)
+                .where(applySearchFilter(searchFilter, searchKeyword)));
+    }
+
+    private BooleanExpression applySearchFilter(String searchFilter, String searchKeyword) {
+        return switch (searchFilter) {
+            case "id" -> eqId(searchKeyword);
+            case "name" -> containsName(searchKeyword);
+            case "schoolName" -> containsSchoolName(searchKeyword);
+            default -> null;
+        };
+    }
+
+    private BooleanExpression eqId(String searchKeyword) {
+        if (StringUtils.hasText(searchKeyword)) {
+            return festival.id.stringValue().eq(searchKeyword);
+        }
+        return null;
+    }
+
+    private BooleanExpression containsName(String searchKeyword) {
+        if (StringUtils.hasText(searchKeyword)) {
+            return festival.name.contains(searchKeyword);
+        }
+        return null;
+    }
+
+    private BooleanExpression containsSchoolName(String searchKeyword) {
+        if (StringUtils.hasText(searchKeyword)) {
+            return school.name.contains(searchKeyword);
+        }
+        return null;
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(Sort sort) {
+        return sort.stream()
+            .findFirst()
+            .map(it -> switch (it.getProperty()) {
+                case "id" -> OrderSpecifierUtils.of(it.getDirection(), festival.id);
+                case "name" -> OrderSpecifierUtils.of(it.getDirection(), festival.name);
+                case "schoolName" -> OrderSpecifierUtils.of(it.getDirection(), school.name);
+                case "startDate" -> OrderSpecifierUtils.of(it.getDirection(), festival.startDate);
+                case "endDate" -> OrderSpecifierUtils.of(it.getDirection(), festival.endDate);
+                default -> OrderSpecifierUtils.NULL;
+            })
+            .orElse(OrderSpecifierUtils.NULL);
+    }
+}

--- a/backend/src/main/java/com/festago/common/querydsl/OrderSpecifierUtils.java
+++ b/backend/src/main/java/com/festago/common/querydsl/OrderSpecifierUtils.java
@@ -1,0 +1,20 @@
+package com.festago.common.querydsl;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.NullExpression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import org.springframework.data.domain.Sort;
+
+public class OrderSpecifierUtils {
+
+    public static final OrderSpecifier<?> NULL = new OrderSpecifier(Order.ASC, NullExpression.DEFAULT,
+        OrderSpecifier.NullHandling.Default);
+
+    private OrderSpecifierUtils() {
+    }
+
+    public static OrderSpecifier of(Sort.Direction direction, Expression<?> target) {
+        return new OrderSpecifier(direction.isAscending() ? Order.ASC : Order.DESC, target);
+    }
+}

--- a/backend/src/main/java/com/festago/common/querydsl/QueryDslHelper.java
+++ b/backend/src/main/java/com/festago/common/querydsl/QueryDslHelper.java
@@ -1,0 +1,39 @@
+package com.festago.common.querydsl;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QueryDslHelper {
+
+    private final JPAQueryFactory queryFactory;
+
+    public <T> JPAQuery<T> select(Expression<T> expr) {
+        return queryFactory.select(expr);
+    }
+
+    public <T> Optional<T> fetchOne(Function<JPAQueryFactory, JPAQuery<T>> queryFunction) {
+        JPAQuery<T> query = queryFunction.apply(queryFactory);
+        return Optional.ofNullable(query.fetchOne());
+    }
+
+    public <T> Page<T> applyPagination(
+        Pageable pageable,
+        Function<JPAQueryFactory, JPAQuery<T>> contentQueryFunction,
+        Function<JPAQueryFactory, JPAQuery<Long>> countQueryFunction
+    ) {
+        List<T> content = contentQueryFunction.apply(queryFactory).fetch();
+        JPAQuery<Long> countQuery = countQueryFunction.apply(queryFactory);
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+}

--- a/backend/src/test/java/com/festago/admin/application/integration/AdminFestivalV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/admin/application/integration/AdminFestivalV1QueryServiceIntegrationTest.java
@@ -1,0 +1,269 @@
+package com.festago.admin.application.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.festago.admin.application.AdminFestivalV1QueryService;
+import com.festago.admin.dto.AdminFestivalV1Response;
+import com.festago.common.querydsl.SearchCondition;
+import com.festago.festival.domain.Festival;
+import com.festago.festival.repository.FestivalRepository;
+import com.festago.school.domain.School;
+import com.festago.school.domain.SchoolRegion;
+import com.festago.school.repository.SchoolRepository;
+import com.festago.stage.domain.Stage;
+import com.festago.stage.repository.StageRepository;
+import com.festago.support.ApplicationIntegrationTest;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class AdminFestivalV1QueryServiceIntegrationTest extends ApplicationIntegrationTest {
+
+    @Autowired
+    AdminFestivalV1QueryService adminFestivalV1QueryService;
+
+    @Autowired
+    FestivalRepository festivalRepository;
+
+    @Autowired
+    SchoolRepository schoolRepository;
+
+    @Autowired
+    StageRepository stageRepository;
+
+    LocalDate now = LocalDate.parse("2077-06-30");
+    LocalDate tomorrow = now.plusDays(1);
+
+    Festival 테코대학교_축제;
+    Festival 테코대학교_공연_없는_축제;
+    Festival 우테대학교_축제;
+    Stage 테코대학교_공연;
+    Stage 우테대학교_첫째날_공연;
+    Stage 우테대학교_둘째날_공연;
+
+    @BeforeEach
+    void setUp() {
+        LocalDateTime ticketOpenTime = now.atStartOfDay().minusWeeks(1);
+        School 테코대학교 = schoolRepository.save(new School("teco.ac.kr", "테코대학교", SchoolRegion.서울));
+        School 우테대학교 = schoolRepository.save(new School("wote.ac.kr", "우테대학교", SchoolRegion.서울));
+        테코대학교_축제 = festivalRepository.save(new Festival("테코대학교 축제", now, now, 테코대학교));
+        테코대학교_공연_없는_축제 = festivalRepository.save(new Festival("테코대학교 공연 없는 축제", tomorrow, tomorrow, 테코대학교));
+        우테대학교_축제 = festivalRepository.save(new Festival("우테대학교 축제", now, tomorrow, 우테대학교));
+        테코대학교_공연 = stageRepository.save(new Stage(now.atTime(18, 0), ticketOpenTime, 테코대학교_축제));
+        우테대학교_첫째날_공연 = stageRepository.save(new Stage(now.atTime(18, 0), ticketOpenTime, 우테대학교_축제));
+        우테대학교_둘째날_공연 = stageRepository.save(new Stage(tomorrow.atTime(18, 0), ticketOpenTime, 우테대학교_축제));
+    }
+
+    @Nested
+    class findAll {
+
+        @Test
+        void 페이지네이션이_적용되어야_한다() {
+            // given
+            Pageable pageable = PageRequest.ofSize(2);
+            SearchCondition searchCondition = new SearchCondition("", "", pageable);
+
+            // when
+            var response = adminFestivalV1QueryService.findAll(searchCondition);
+
+            assertSoftly(softly -> {
+                softly.assertThat(response.getSize()).isEqualTo(2);
+                softly.assertThat(response.getTotalPages()).isEqualTo(2);
+                softly.assertThat(response.getTotalElements()).isEqualTo(3);
+            });
+        }
+
+        @Test
+        void 공연의_수가_정확하게_반환되어야_한다() {
+            // given
+            Pageable pageable = PageRequest.ofSize(10);
+            SearchCondition searchCondition = new SearchCondition("", "", pageable);
+
+            // when
+            var response = adminFestivalV1QueryService.findAll(searchCondition);
+
+            // then
+            assertThat(response.getContent())
+                .map(AdminFestivalV1Response::stageCount)
+                .containsExactly(1L, 0L, 2L);
+        }
+
+        @Nested
+        class 정렬 {
+
+            @Test
+            void 축제의_식별자로_정렬_되어야_한다() {
+                // given
+                Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "id"));
+                SearchCondition searchCondition = new SearchCondition("", "", pageable);
+
+                // when
+                var response = adminFestivalV1QueryService.findAll(searchCondition);
+
+                // then
+                assertThat(response.getContent())
+                    .map(AdminFestivalV1Response::id)
+                    .containsExactly(우테대학교_축제.getId(), 테코대학교_공연_없는_축제.getId(), 테코대학교_축제.getId());
+            }
+
+            @Test
+            void 축제의_이름으로_정렬이_되어야_한다() {
+                // given
+                Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "name"));
+                SearchCondition searchCondition = new SearchCondition("", "", pageable);
+
+                // when
+                var response = adminFestivalV1QueryService.findAll(searchCondition);
+
+                // then
+                assertThat(response.getContent())
+                    .map(AdminFestivalV1Response::name)
+                    .containsExactly(우테대학교_축제.getName(), 테코대학교_공연_없는_축제.getName(), 테코대학교_축제.getName());
+            }
+
+            @Test
+            void 학교의_이름으로_정렬이_되어야_한다() {
+                // given
+                Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "schoolName"));
+                SearchCondition searchCondition = new SearchCondition("", "", pageable);
+
+                // when
+                var response = adminFestivalV1QueryService.findAll(searchCondition);
+
+                // then
+                assertThat(response.getContent())
+                    .map(AdminFestivalV1Response::id)
+                    .containsExactly(우테대학교_축제.getId(), 테코대학교_축제.getId(), 테코대학교_공연_없는_축제.getId());
+            }
+
+            @Test
+            void 축제의_시작일으로_정렬이_되어야_한다() {
+                // given
+                Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "startDate"));
+                SearchCondition searchCondition = new SearchCondition("", "", pageable);
+
+                // when
+                var response = adminFestivalV1QueryService.findAll(searchCondition);
+
+                // then
+                assertThat(response.getContent())
+                    .map(AdminFestivalV1Response::id)
+                    .containsExactly(테코대학교_축제.getId(), 우테대학교_축제.getId(), 테코대학교_공연_없는_축제.getId());
+            }
+
+            @Test
+            void 축제의_종료일으로_정렬이_되어야_한다() {
+                // given
+                Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "endDate"));
+                SearchCondition searchCondition = new SearchCondition("", "", pageable);
+
+                // when
+                var response = adminFestivalV1QueryService.findAll(searchCondition);
+
+                // then
+                System.out.println(response.getContent());
+                assertThat(response.getContent())
+                    .map(AdminFestivalV1Response::id)
+                    .containsExactly(테코대학교_공연_없는_축제.getId(), 우테대학교_축제.getId(), 테코대학교_축제.getId());
+            }
+
+            @Test
+            void 정렬_조건에_없으면_식별자의_오름차순으로_정렬이_되어야_한다() {
+                // given
+                Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "foo"));
+                SearchCondition searchCondition = new SearchCondition("", "", pageable);
+
+                // when
+                var response = adminFestivalV1QueryService.findAll(searchCondition);
+
+                // then
+                assertThat(response.getContent())
+                    .map(AdminFestivalV1Response::id)
+                    .containsExactly(테코대학교_축제.getId(), 테코대학교_공연_없는_축제.getId(), 우테대학교_축제.getId());
+            }
+        }
+
+        @Nested
+        class 검색 {
+
+            @Test
+            void 축제의_식별자로_검색이_되어야_한다() {
+                // given
+                Pageable pageable = Pageable.ofSize(10);
+                SearchCondition searchCondition = new SearchCondition("id", 테코대학교_축제.getId().toString(), pageable);
+
+                // when
+                var response = adminFestivalV1QueryService.findAll(searchCondition);
+
+                assertThat(response.getContent())
+                    .map(AdminFestivalV1Response::id)
+                    .containsExactly(테코대학교_축제.getId());
+            }
+
+            @Test
+            void 축제의_이름이_포함된_검색이_되어야_한다() {
+                // given
+                Pageable pageable = Pageable.ofSize(10);
+                SearchCondition searchCondition = new SearchCondition("name", "테코대학교", pageable);
+
+                // when
+                var response = adminFestivalV1QueryService.findAll(searchCondition);
+
+                assertThat(response.getContent())
+                    .map(AdminFestivalV1Response::id)
+                    .containsExactly(테코대학교_축제.getId(), 테코대학교_공연_없는_축제.getId());
+            }
+
+            @Test
+            void 학교의_이름이_포함된_검색이_되어야_한다() {
+                // given
+                Pageable pageable = Pageable.ofSize(10);
+                SearchCondition searchCondition = new SearchCondition("schoolName", "우테대학교", pageable);
+
+                // when
+                var response = adminFestivalV1QueryService.findAll(searchCondition);
+
+                assertThat(response.getContent())
+                    .map(AdminFestivalV1Response::id)
+                    .containsExactly(우테대학교_축제.getId());
+            }
+
+            @Test
+            void 검색_필터가_비어있으면_필터링이_적용되지_않는다() {
+                // given
+                Pageable pageable = Pageable.ofSize(10);
+                SearchCondition searchCondition = new SearchCondition("", "글렌", pageable);
+
+                // when
+                var response = adminFestivalV1QueryService.findAll(searchCondition);
+
+                assertThat(response.getContent())
+                    .hasSize(3);
+            }
+
+            @Test
+            void 검색어가_비어있으면_필터링이_적용되지_않는다() {
+                // given
+                Pageable pageable = Pageable.ofSize(10);
+                SearchCondition searchCondition = new SearchCondition("id", "", pageable);
+
+                // when
+                var response = adminFestivalV1QueryService.findAll(searchCondition);
+
+                assertThat(response.getContent())
+                    .hasSize(3);
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminFestivalV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminFestivalV1ControllerTest.java
@@ -3,14 +3,19 @@ package com.festago.admin.presentation.v1;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.admin.application.AdminFestivalV1QueryService;
+import com.festago.admin.dto.AdminFestivalV1Response;
 import com.festago.admin.dto.FestivalV1UpdateRequest;
 import com.festago.auth.domain.Role;
+import com.festago.common.querydsl.SearchCondition;
 import com.festago.festival.application.command.FestivalCommandFacadeService;
 import com.festago.festival.dto.FestivalCreateRequest;
 import com.festago.festival.dto.command.FestivalCreateCommand;
@@ -18,12 +23,14 @@ import com.festago.support.CustomWebMvcTest;
 import com.festago.support.WithMockAuth;
 import jakarta.servlet.http.Cookie;
 import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -43,6 +50,9 @@ class AdminFestivalV1ControllerTest {
 
     @Autowired
     FestivalCommandFacadeService festivalCommandFacadeService;
+
+    @Autowired
+    AdminFestivalV1QueryService adminFestivalV1QueryService;
 
     @Nested
     class 축제_생성 {
@@ -167,6 +177,51 @@ class AdminFestivalV1ControllerTest {
             void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
                 // when & then
                 mockMvc.perform(delete(uri, 1L)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
+
+    @Nested
+    class 모든_축제_정보_조회 {
+
+        final String uri = "/admin/api/v1/festivals";
+
+        @Nested
+        @DisplayName("GET " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_하면_200_응답과_학교_정보_목록이_반환된다() throws Exception {
+                // given
+                var expected = List.of(
+                    new AdminFestivalV1Response(1L, "테코대학교 축제", "테코대학교", LocalDate.now(), LocalDate.now(), 0)
+                );
+                given(adminFestivalV1QueryService.findAll(any(SearchCondition.class)))
+                    .willReturn(new PageImpl<>(expected));
+
+                // when & then
+                mockMvc.perform(get(uri)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content.size()").value(1));
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri)
                         .cookie(TOKEN_COOKIE))
                     .andExpect(status().isNotFound());
             }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #745

## ✨ PR 세부 내용

관리자 페이지에서 축제 조회를 위한 기능을 추가했습니다.

~~#695 PR에서 `AdminFestivalV1Controller` API를 먼저 구현하고 있기 때문에 해당 PR이 머지되면 API를 추가해야 할 것 같습니다.~~
해당 작업 완료 했습니다.

중요하게 봐야할 사항은 `AdminFestivalV1QueryDslRepository`가 의존하고 있는 `QueryDslHelper` 클래스인데, 해당 클래스는 기존 상속으로 사용하던 `QueryDslRepositorySupport` 추상 클래스의 Bean 버전입니다.

왜 기존에 잘 만들어둔 `QueryDslRepositorySupport`을 상속하지 않고 `QueryDslHelper`를 의존해서 사용했냐면, 여러 이유가 있는데 그 중 가장 큰 이유는 정렬을 할 때 발생하는 문제 때문입니다.

`applyPagination` 메서드를 사용하면 `orderBy`를 해주지 않아도 정렬이 되는데 이유는 `querydsl.applyPagination()` 메서드를 호출할 때 Pageable 객체만 넘기면 정렬이 자동으로 되기 때문입니다.

자동으로 정렬이 되게 하는 마법같은 일은 `QueryDslRepositorySupport`의 생성자로 받는 도메인 클래스를 분석해서 해당 도메인 클래스가 가진 필드를 기준으로 프로퍼티를 설정함으로 이뤄집니다.

```java
protected QueryDslRepositorySupport(Class<?> domainClass) {
        this.domainClass = domainClass;
    }

@Autowired
protected void setQueryFactory(EntityManager entityManager) {
    Assert.notNull(entityManager, "EntityManager must not be null!");
    JpaEntityInformation<?, ?> entityInformation =
        JpaEntityInformationSupport.getEntityInformation(domainClass, entityManager);
    SimpleEntityPathResolver resolver = SimpleEntityPathResolver.INSTANCE;
    EntityPath<?> path = resolver.createPath(entityInformation.getJavaType());
    this.querydsl = new Querydsl(entityManager, new PathBuilder<>(path.getType(), path.getMetadata()));
    this.queryFactory = new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
}
```

그런데 이 편리한 자동 정렬이 왜 문제가 되냐면, 생성자로 받은 도메인 클래스의 필드에 대해서만 정렬이 됩니다.

즉 축제 목록을 조회할 때, 학교 이름으로 정렬을 하고 싶다면 정렬이 불가능합니다.

또한 잘못된 프로퍼티(name -> naem)를 입력하면 BadRequest가 아닌 InternalServerError가 발생하기 때문에 여러 애로사항이 생깁니다.  (PropertyReferenceException 예외가 발생하는데, 해당 예외를 BadRequest로 처리하는게 과연 맞나 싶네요.)

따라서 결국 수동으로 정렬을 해야하는 상황이 생겼고, `QueryDslRepositorySupport`를 상속하는 방법에서 `QueryDslHelper`를 의존하는 방법을 택하였습니다.

`QueryDslHelper`를 의존하면서 생기는 이점은 아무래도 어떠한 메서드를 사용할 수 있는지 객체를 통해 확인할 수 있다는 점과 생성자로 도메인 클래스를 넣어주지 않아도 된다는 점이 있겠네요.

물론 기존에 제공해주던 자동 정렬 기능은 사용하지 못하게 되므로, 정렬이 필요하다면 정렬 메서드를 직접 구현해야 합니다.

> Spring의 Sort 객체와 QueryDSL의 Sort 객체가 달라 변환용 유틸 클래스를 만들어서 사용했습니다.