### PR TITLE
[BE] refactor: Stage 엔티티 lineUp 필드 제거 (#752)

### DIFF
--- a/backend/src/main/java/com/festago/stage/application/StageService.java
+++ b/backend/src/main/java/com/festago/stage/application/StageService.java
@@ -27,7 +27,6 @@ public class StageService {
         Festival festival = festivalRepository.getOrThrow(request.festivalId());
         Stage newStage = stageRepository.save(new Stage(
             request.startTime(),
-            request.lineUp(),
             request.ticketOpenTime(),
             festival));
 
@@ -47,7 +46,6 @@ public class StageService {
     public void update(Long stageId, StageUpdateRequest request) {
         Stage stage = findStage(stageId);
         stage.changeTime(request.startTime(), request.ticketOpenTime());
-        stage.changeLineUp(request.lineUp());
     }
 
     public void delete(Long stageId) {

--- a/backend/src/main/java/com/festago/stage/domain/Stage.java
+++ b/backend/src/main/java/com/festago/stage/domain/Stage.java
@@ -14,7 +14,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,17 +24,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Stage extends BaseTimeEntity {
 
-    private static final int MAX_LINEUP_LENGTH = 255;
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull
     private LocalDateTime startTime;
-
-    @Size(max = MAX_LINEUP_LENGTH)
-    private String lineUp;
 
     @NotNull
     private LocalDateTime ticketOpenTime;
@@ -47,32 +41,22 @@ public class Stage extends BaseTimeEntity {
     @OneToMany(mappedBy = "stage", fetch = FetchType.LAZY)
     private List<Ticket> tickets = new ArrayList<>();
 
-    public Stage(LocalDateTime startTime, String lineUp, LocalDateTime ticketOpenTime, Festival festival) {
-        this(null, startTime, lineUp, ticketOpenTime, festival);
-    }
-
     public Stage(LocalDateTime startTime, LocalDateTime ticketOpenTime, Festival festival) {
-        this(null, startTime, null, ticketOpenTime, festival);
+        this(null, startTime, ticketOpenTime, festival);
     }
 
-    public Stage(Long id, LocalDateTime startTime, String lineUp, LocalDateTime ticketOpenTime,
+    public Stage(Long id, LocalDateTime startTime, LocalDateTime ticketOpenTime,
                  Festival festival) {
-        validate(startTime, lineUp, ticketOpenTime, festival);
+        validate(startTime, ticketOpenTime, festival);
         this.id = id;
         this.startTime = startTime;
-        this.lineUp = lineUp;
         this.ticketOpenTime = ticketOpenTime;
         this.festival = festival;
     }
 
-    private void validate(LocalDateTime startTime, String lineUp, LocalDateTime ticketOpenTime, Festival festival) {
-        validateLineUp(lineUp);
+    private void validate(LocalDateTime startTime, LocalDateTime ticketOpenTime, Festival festival) {
         validateFestival(festival);
         validateTime(startTime, ticketOpenTime, festival);
-    }
-
-    private void validateLineUp(String lineUp) {
-        Validator.maxLength(lineUp, MAX_LINEUP_LENGTH, "lineUp");
     }
 
     private void validateFestival(Festival festival) {
@@ -100,11 +84,6 @@ public class Stage extends BaseTimeEntity {
         this.ticketOpenTime = ticketOpenTime;
     }
 
-    public void changeLineUp(String lineUp) {
-        validateLineUp(lineUp);
-        this.lineUp = lineUp;
-    }
-
     public Long getId() {
         return id;
     }
@@ -113,8 +92,12 @@ public class Stage extends BaseTimeEntity {
         return startTime;
     }
 
+    /**
+     * API 일부에 사용되는 곳이 있기 때문에 빈 문자열을 반환하도록 처리
+     */
+    @Deprecated(forRemoval = true)
     public String getLineUp() {
-        return lineUp;
+        return "";
     }
 
     public LocalDateTime getTicketOpenTime() {

--- a/backend/src/main/resources/db/migration/V16__remove_stage_line_up.sql
+++ b/backend/src/main/resources/db/migration/V16__remove_stage_line_up.sql
@@ -1,0 +1,2 @@
+alter table stage
+    drop column line_up

--- a/backend/src/test/java/com/festago/support/StageFixture.java
+++ b/backend/src/test/java/com/festago/support/StageFixture.java
@@ -8,7 +8,6 @@ public class StageFixture {
 
     private Long id;
     private LocalDateTime startTime = LocalDateTime.now();
-    private String lineUp = "오리, 글렌, 푸우, 애쉬";
     private LocalDateTime ticketOpenTime = startTime.minusWeeks(1);
     private Festival festival = FestivalFixture.festival().build();
 
@@ -29,11 +28,6 @@ public class StageFixture {
         return this;
     }
 
-    public StageFixture lineUp(String lineUp) {
-        this.lineUp = lineUp;
-        return this;
-    }
-
     public StageFixture ticketOpenTime(LocalDateTime ticketOpenTime) {
         this.ticketOpenTime = ticketOpenTime;
         return this;
@@ -46,6 +40,6 @@ public class StageFixture {
     }
 
     public Stage build() {
-        return new Stage(id, startTime, lineUp, ticketOpenTime, festival);
+        return new Stage(id, startTime, ticketOpenTime, festival);
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #752
## ✨ PR 세부 내용

이슈 내용 그대로 `Stage` 엔티티의 `lineUp` 필드를 제거했습니다.

일부 조회 API의 하위 호환성을 위해 엔티티의 `getLineUp` 메서드는 빈 문자열을 반환하도록 남겨두었습니다.

이는 해당 사용처에서 빈 문자열을 사용하도록 하게 놔둘지 얘기가 필요할 것 같네요!
