### PR TITLE
[BE] feat: Artist 생성, 수정에 누락된 필드를 추가한다.(#732)

### DIFF
--- a/backend/src/main/java/com/festago/admin/dto/ArtistCreateRequest.java
+++ b/backend/src/main/java/com/festago/admin/dto/ArtistCreateRequest.java
@@ -3,9 +3,9 @@ package com.festago.admin.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record ArtistCreateRequest(
-    @NotBlank(message = "아티스트 이름은 비어있을 수 없습니다.")
+    @NotBlank
     String name,
-    @NotBlank(message = "아티스트 이미지는 비어있을 수 없습니다.")
+    @NotBlank
     String profileImage,
     @NotBlank
     String backgroundImageUrl

--- a/backend/src/main/java/com/festago/admin/dto/ArtistCreateRequest.java
+++ b/backend/src/main/java/com/festago/admin/dto/ArtistCreateRequest.java
@@ -6,7 +6,9 @@ public record ArtistCreateRequest(
     @NotBlank(message = "아티스트 이름은 비어있을 수 없습니다.")
     String name,
     @NotBlank(message = "아티스트 이미지는 비어있을 수 없습니다.")
-    String profileImage
+    String profileImage,
+    @NotBlank
+    String backgroundImageUrl
 ) {
 
 }

--- a/backend/src/main/java/com/festago/admin/dto/ArtistUpdateRequest.java
+++ b/backend/src/main/java/com/festago/admin/dto/ArtistUpdateRequest.java
@@ -3,9 +3,9 @@ package com.festago.admin.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record ArtistUpdateRequest(
-    @NotBlank(message = "아티스트 이름은 비어있을 수 없습니다.")
+    @NotBlank
     String name,
-    @NotBlank(message = "아티스트 이미지는 비어있을 수 없습니다.")
+    @NotBlank
     String profileImage,
     @NotBlank
     String backgroundImageUrl

--- a/backend/src/main/java/com/festago/admin/dto/ArtistUpdateRequest.java
+++ b/backend/src/main/java/com/festago/admin/dto/ArtistUpdateRequest.java
@@ -6,7 +6,9 @@ public record ArtistUpdateRequest(
     @NotBlank(message = "아티스트 이름은 비어있을 수 없습니다.")
     String name,
     @NotBlank(message = "아티스트 이미지는 비어있을 수 없습니다.")
-    String profileImage
+    String profileImage,
+    @NotBlank
+    String backgroundImageUrl
 ) {
 
 }

--- a/backend/src/main/java/com/festago/artist/application/ArtistCommandService.java
+++ b/backend/src/main/java/com/festago/artist/application/ArtistCommandService.java
@@ -22,7 +22,7 @@ public class ArtistCommandService {
 
     public void update(ArtistUpdateRequest request, Long artistId) {
         Artist artist = artistRepository.getOrThrow(artistId);
-        artist.update(request.name(), request.profileImage());
+        artist.update(request.name(), request.profileImage(), request.backgroundImageUrl());
     }
 
     public void delete(Long artistId) {

--- a/backend/src/main/java/com/festago/artist/application/ArtistCommandService.java
+++ b/backend/src/main/java/com/festago/artist/application/ArtistCommandService.java
@@ -16,7 +16,8 @@ public class ArtistCommandService {
     private final ArtistRepository artistRepository;
 
     public Long save(ArtistCreateRequest request) {
-        Artist artist = artistRepository.save(new Artist(request.name(), request.profileImage()));
+        Artist artist = artistRepository.save(
+            new Artist(request.name(), request.profileImage(), request.backgroundImageUrl()));
         return artist.getId();
     }
 

--- a/backend/src/main/java/com/festago/artist/domain/Artist.java
+++ b/backend/src/main/java/com/festago/artist/domain/Artist.java
@@ -30,12 +30,16 @@ public class Artist {
         this.backgroundImageUrl = backgroundImageUrl;
     }
 
+    public Artist(Long id, String name, String profileImage) {
+        this(id, name, profileImage, DEFAULT_URL);
+    }
+
     public Artist(String name, String profileImage) {
         this(null, name, profileImage, DEFAULT_URL);
     }
 
-    public Artist(Long id, String name, String profileImage) {
-        this(id, name, profileImage, DEFAULT_URL);
+    public Artist(String name, String profileImage, String backgroundImageUrl) {
+        this(null, name, profileImage, backgroundImageUrl);
     }
 
     public void update(String name, String profileImage, String backgroundImageUrl) {

--- a/backend/src/main/java/com/festago/artist/domain/Artist.java
+++ b/backend/src/main/java/com/festago/artist/domain/Artist.java
@@ -38,9 +38,10 @@ public class Artist {
         this(id, name, profileImage, DEFAULT_URL);
     }
 
-    public void update(String name, String profileImage) {
+    public void update(String name, String profileImage, String backgroundImageUrl) {
         this.name = name;
         this.profileImage = profileImage;
+        this.backgroundImageUrl = backgroundImageUrl;
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/festago/artist/domain/Artist.java
+++ b/backend/src/main/java/com/festago/artist/domain/Artist.java
@@ -30,10 +30,6 @@ public class Artist {
         this.backgroundImageUrl = backgroundImageUrl;
     }
 
-    public Artist(Long id, String name, String profileImage) {
-        this(id, name, profileImage, DEFAULT_URL);
-    }
-
     public Artist(String name, String profileImage) {
         this(null, name, profileImage, DEFAULT_URL);
     }

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminArtistV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminArtistV1ControllerTest.java
@@ -38,7 +38,7 @@ import org.springframework.test.web.servlet.MockMvc;
 class AdminArtistV1ControllerTest {
 
     private static final Cookie TOKEN_COOKIE = new Cookie("token", "token");
-    private static final Cookie COOKIE = new Cookie("token", "token");
+
     @Autowired
     MockMvc mockMvc;
     @Autowired

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminArtistV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminArtistV1ControllerTest.java
@@ -38,20 +38,15 @@ import org.springframework.test.web.servlet.MockMvc;
 class AdminArtistV1ControllerTest {
 
     private static final Cookie TOKEN_COOKIE = new Cookie("token", "token");
-
+    private static final Cookie COOKIE = new Cookie("token", "token");
     @Autowired
     MockMvc mockMvc;
-
     @Autowired
     ObjectMapper objectMapper;
-
     @Autowired
     ArtistV1QueryService artistV1QueryService;
-
     @Autowired
     ArtistCommandService artistCommandService;
-
-    private static final Cookie COOKIE = new Cookie("token", "token");
 
     @Nested
     class 아티스트_생성 {
@@ -66,7 +61,8 @@ class AdminArtistV1ControllerTest {
             @WithMockAuth(role = Role.ADMIN)
             void 요청을_보내면_201_응답과_Location_헤더에_식별자가_반환된다() throws Exception {
                 // given
-                ArtistCreateRequest request = new ArtistCreateRequest("윤서연", "https://image.com/image.png");
+                ArtistCreateRequest request = new ArtistCreateRequest("윤서연", "https://image.com/image.png",
+                    "https://image.com/image.png");
                 given(artistCommandService.save(any(ArtistCreateRequest.class)))
                     .willReturn(1L);
 
@@ -111,7 +107,8 @@ class AdminArtistV1ControllerTest {
             @WithMockAuth(role = Role.ADMIN)
             void 요청을_보내면_200_응답이_반환된다() throws Exception {
                 // given
-                ArtistUpdateRequest request = new ArtistUpdateRequest("윤하", "https://image.com/image.png");
+                ArtistUpdateRequest request = new ArtistUpdateRequest("윤하", "https://image.com/image.png",
+                    "https://image.com/image.png");
 
                 // when & then
                 mockMvc.perform(put(uri, 1L)

--- a/backend/src/test/java/com/festago/artist/application/integration/ArtistCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/artist/application/integration/ArtistCommandServiceIntegrationTest.java
@@ -27,7 +27,8 @@ class ArtistCommandServiceIntegrationTest extends ApplicationIntegrationTest {
     @Test
     void 아티스트를_저장한다() {
         // given
-        ArtistCreateRequest request = new ArtistCreateRequest("윤서연", "https://image.com/image.png");
+        ArtistCreateRequest request = new ArtistCreateRequest("윤서연", "https://image.com/image.png",
+            "https://image.com/image.png");
 
         // when
         Long artistId = artistCommandService.save(request);
@@ -41,7 +42,8 @@ class ArtistCommandServiceIntegrationTest extends ApplicationIntegrationTest {
     void 아티스트_정보를_변경한다() {
         // given
         Long artistId = artistRepository.save(new Artist("고윤하", "https://image.com/image1.png")).getId();
-        ArtistUpdateRequest request = new ArtistUpdateRequest("윤하", "https://image.com/image2.png");
+        ArtistUpdateRequest request = new ArtistUpdateRequest("윤하", "https://image.com/image2.png",
+            "https://image.com/image2.png");
 
         // when
         artistCommandService.update(request, artistId);


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #732

## ✨ PR 세부 내용

Artist 생성, 수정에서 backgroundImgageUrl 을 함께 보내도록 수정 했습니다.
추가로 Artist 에서 사용하지 않는 생성자를 삭제했습니다.
글렌이 작업하신 예외 메시지 포맷을 따르기 위해서 @NotBlank의 메시지를 제거했습니다.
