### PR TITLE
[AN/USER] feat: 축제 상세 페이지 구현(#750)

### DIFF
--- a/android/festago/data/src/main/java/com/festago/festago/data/dto/festival/FestivalDetailResponse.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/dto/festival/FestivalDetailResponse.kt
@@ -1,0 +1,31 @@
+package com.festago.festago.data.dto.festival
+
+import com.festago.festago.data.dto.school.SchoolResponse
+import com.festago.festago.data.dto.school.SocialMediaResponse
+import com.festago.festago.data.dto.stage.StageResponse
+import com.festago.festago.domain.model.festival.FestivalDetail
+import kotlinx.serialization.Serializable
+import java.time.LocalDate
+
+@Serializable
+data class FestivalDetailResponse(
+    val id: Long,
+    val name: String,
+    val startDate: String,
+    val endDate: String,
+    val posterImageUrl: String,
+    val school: SchoolResponse,
+    val socialMedias: List<SocialMediaResponse>,
+    val stages: List<StageResponse>,
+) {
+    fun toDomain() = FestivalDetail(
+        id,
+        name,
+        LocalDate.parse(startDate),
+        LocalDate.parse(endDate),
+        posterImageUrl,
+        school.toDomain(),
+        socialMedias.map { it.toDomain() },
+        stages.map { it.toDomain() },
+    )
+}

--- a/android/festago/data/src/main/java/com/festago/festago/data/dto/stage/StageResponse.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/dto/stage/StageResponse.kt
@@ -1,0 +1,19 @@
+package com.festago.festago.data.dto.stage
+
+import com.festago.festago.data.dto.artist.ArtistResponse
+import com.festago.festago.domain.model.stage.Stage
+import kotlinx.serialization.Serializable
+import java.time.LocalDateTime
+
+@Serializable
+data class StageResponse(
+    val id: Long,
+    val startDateTime: String,
+    val artists: List<ArtistResponse>,
+) {
+    fun toDomain() = Stage(
+        id = id,
+        startDateTime = LocalDateTime.parse(startDateTime),
+        artists = artists.map { it.toDomain() },
+    )
+}

--- a/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeArtistRepository.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeArtistRepository.kt
@@ -3,8 +3,8 @@ package com.festago.festago.data.repository
 import com.festago.festago.domain.model.artist.Artist
 import com.festago.festago.domain.model.artist.ArtistDetail
 import com.festago.festago.domain.model.artist.ArtistMedia
-import com.festago.festago.domain.model.artist.Stages
 import com.festago.festago.domain.model.festival.Festival
+import com.festago.festago.domain.model.festival.FestivalsPage
 import com.festago.festago.domain.model.school.School
 import com.festago.festago.domain.repository.ArtistRepository
 import java.time.LocalDate

--- a/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeArtistRepository.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeArtistRepository.kt
@@ -37,11 +37,11 @@ class FakeArtistRepository @Inject constructor() : ArtistRepository {
             ),
         )
 
-    override suspend fun loadArtistStages(id: Long, size: Int): Result<Stages> =
+    override suspend fun loadArtistFestivals(id: Long, size: Int): Result<FestivalsPage> =
         Result.success(
-            Stages(
-                false,
-                (0..10).flatMap {
+            FestivalsPage(
+                isLastPage = false,
+                festivals = (0..10).flatMap {
                     listOf(
                         Festival(
                             1,

--- a/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeFestivalRepository.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeFestivalRepository.kt
@@ -2,13 +2,17 @@ package com.festago.festago.data.repository
 
 import com.festago.festago.domain.model.artist.Artist
 import com.festago.festago.domain.model.festival.Festival
+import com.festago.festago.domain.model.festival.FestivalDetail
 import com.festago.festago.domain.model.festival.FestivalFilter
 import com.festago.festago.domain.model.festival.FestivalsPage
 import com.festago.festago.domain.model.festival.PopularFestivals
 import com.festago.festago.domain.model.festival.SchoolRegion
 import com.festago.festago.domain.model.school.School
+import com.festago.festago.domain.model.social.SocialMedia
+import com.festago.festago.domain.model.stage.Stage
 import com.festago.festago.domain.repository.FestivalRepository
 import java.time.LocalDate
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 class FakeFestivalRepository @Inject constructor() : FestivalRepository {
@@ -61,6 +65,64 @@ class FakeFestivalRepository @Inject constructor() : FestivalRepository {
                 ),
             )
         }
+    }
+
+    override suspend fun loadFestivalDetail(id: Long): Result<FestivalDetail> {
+        return Result.success(
+            FestivalDetail(
+                id = 1L,
+                name = "대동제",
+                startDate = LocalDate.now().minusDays(1L),
+                endDate = LocalDate.now().plusDays(1L),
+                posterImageUrl = "https://scontent-lax3-1.xx.fbcdn.net/v/t39.30808-6/279157499_2243399062505940_3971514424591662251_n.jpg?stp=dst-jpg_p526x296&_nc_cat=109&ccb=1-7&_nc_sid=dd5e9f&_nc_ohc=47PXoJjSATcAX8RDKYA&_nc_ht=scontent-lax3-1.xx&oh=00_AfClc8Z5CvQf1P8eZrt1H0Zp0QLqB-1lMhWJJPVP6SYUxg&oe=65E188C8",
+                school = School(id = 2L, name = "부경대학교", imageUrl = ""),
+                socialMedias = listOf(
+                    SocialMedia(
+                        type = "INSTAGRAM",
+                        name = "부경대학교 인스타",
+                        logoUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Instagram_logo_2016.svg/2048px-Instagram_logo_2016.svg.png",
+                        url = "https://www.instagram.com/25th_solution/",
+                    ),
+                    SocialMedia(
+                        type = "FACEBOOK",
+                        name = "부경대학교 페이스북",
+                        logoUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/5/51/Facebook_f_logo_%282019%29.svg/1200px-Facebook_f_logo_%282019%29.svg.png",
+                        url = "https://www.facebook.com/23rdemotion/",
+                    ),
+                ),
+                stages = listOf(
+                    Stage(
+                        id = 1L,
+                        startDateTime = LocalDateTime.now(),
+                        artists = listOf(
+                            Artist(id = 1L, "BTS", ""),
+                            Artist(id = 2L, "싸이", ""),
+                            Artist(id = 10L, "마마무", ""),
+                            Artist(id = 11L, "블랙핑크", ""),
+                        ),
+                    ),
+                    Stage(
+                        id = 1L,
+                        startDateTime = LocalDateTime.now(),
+                        artists = listOf(
+                            Artist(id = 3L, "아이유", ""),
+                            Artist(id = 4L, "AKMU", ""),
+                            Artist(id = 5L, "뉴진스", ""),
+                            Artist(id = 6L, "비비", ""),
+                        ),
+                    ),
+                    Stage(
+                        id = 1L,
+                        startDateTime = LocalDateTime.now(),
+                        artists = listOf(
+                            Artist(id = 7L, "TWS", ""),
+                            Artist(id = 8L, "소녀시대", ""),
+                            Artist(id = 9L, "르세라핌", ""),
+                        ),
+                    ),
+                ),
+            ),
+        )
     }
 
     companion object {

--- a/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeFestivalRepository.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeFestivalRepository.kt
@@ -62,6 +62,26 @@ class FakeFestivalRepository @Inject constructor() : FestivalRepository {
                         name = "뉴진스",
                         imageUrl = "https://cdn.mediatoday.co.kr/news/photo/202311/313885_438531_4716.jpg",
                     ),
+                    Artist(
+                        id = 1L,
+                        name = "BTS",
+                        imageUrl = "https://i.namu.wiki/i/gpgJvt_C2vKJS4VA4K_Vm57Y5WoS83ofshxhJlQaT4P9Tu0N96vZ2OcdeAN7ZtRAM26UyyQs3sualkKk6i_SrRMvwVKrU015XJqzJ7wKRbOub_oUAxPSFre_8D5De3oy-fCxL0uZ-HGvsWxIX57yrw.webp",
+                    ),
+                    Artist(
+                        id = 2L,
+                        name = "싸이",
+                        imageUrl = "https://i.namu.wiki/i/VH58lI8f-y8QSoxFH9IAjjCobySN0lflZ4rMy6Un7qawUwAyi9UfeseZWCzxH-lQeZk7q_eUyTHGlZBAPqSLWliIKWYDLaAgomVtOyAQg60aCpF3oNTBOgUe_hig3rbHW-YAgoj95Fww3MCToyM6MA.webp",
+                    ),
+                    Artist(
+                        id = 10L,
+                        name = "마마무",
+                        imageUrl = "https://i.namu.wiki/i/Mre8tXnE40mB9_UwXIwASMEAUSVhHvyjJxXq-lQo40C3bLWYfxXBeai8t6TugyomPjFgxL3VfDA2zn65HlzqPXgTKlvdRl1gJ6PGZLxYYk8Uhk8L6va7zm_etSK5UzVLE56fUATqUCq-6tRQXigmYQ.webp",
+                    ),
+                    Artist(
+                        id = 11L,
+                        name = "블랙핑크",
+                        imageUrl = "https://i.namu.wiki/i/VZxRYO8_CXa2QbOSZgttDq5ue5QEu_Fbk1Lwo3qpasLAfS802YExcnmVmDhCq3ONF0ExzhACz_YkZbxOGmIfjuPDZnFo7i0pWaT05NluHRHGfp9NqsAT6WBNb0k5KecOyDvakXk0VH2fUo4ojSwC6g.webp",
+                    ),
                 ),
             )
         }
@@ -72,20 +92,20 @@ class FakeFestivalRepository @Inject constructor() : FestivalRepository {
             FestivalDetail(
                 id = 1L,
                 name = "대동제",
-                startDate = LocalDate.now().minusDays(1L),
-                endDate = LocalDate.now().plusDays(1L),
-                posterImageUrl = "https://scontent-lax3-1.xx.fbcdn.net/v/t39.30808-6/279157499_2243399062505940_3971514424591662251_n.jpg?stp=dst-jpg_p526x296&_nc_cat=109&ccb=1-7&_nc_sid=dd5e9f&_nc_ohc=47PXoJjSATcAX8RDKYA&_nc_ht=scontent-lax3-1.xx&oh=00_AfClc8Z5CvQf1P8eZrt1H0Zp0QLqB-1lMhWJJPVP6SYUxg&oe=65E188C8",
+                startDate = LocalDate.now(),
+                endDate = LocalDate.now().plusDays(5L),
+                posterImageUrl = "https://mblogthumb-phinf.pstatic.net/MjAyMzA1MjNfMTMx/MDAxNjg0ODIwNzY5NzQ5.MuYItN1HCOQUcADB6B7ua0SO9Au_QNNk01-6yZkcTH0g.wxSjluY-Glq20JIojs7OuScLQWh6c_sQsoW5xXqiM7Ag.JPEG.chummilmil99/SE-126908ba-0f82-4903-91c5-695db78a98e9.jpg?type=w800",
                 school = School(id = 2L, name = "부경대학교", imageUrl = ""),
                 socialMedias = listOf(
                     SocialMedia(
                         type = "INSTAGRAM",
-                        name = "부경대학교 인스타",
+                        name = "총학생회 인스타그램",
                         logoUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Instagram_logo_2016.svg/2048px-Instagram_logo_2016.svg.png",
                         url = "https://www.instagram.com/25th_solution/",
                     ),
                     SocialMedia(
                         type = "FACEBOOK",
-                        name = "부경대학교 페이스북",
+                        name = "총학생회 페이스북",
                         logoUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/5/51/Facebook_f_logo_%282019%29.svg/1200px-Facebook_f_logo_%282019%29.svg.png",
                         url = "https://www.facebook.com/23rdemotion/",
                     ),
@@ -93,31 +113,117 @@ class FakeFestivalRepository @Inject constructor() : FestivalRepository {
                 stages = listOf(
                     Stage(
                         id = 1L,
-                        startDateTime = LocalDateTime.now(),
+                        startDateTime = LocalDateTime.now().plusDays(0L),
                         artists = listOf(
-                            Artist(id = 1L, "BTS", ""),
-                            Artist(id = 2L, "싸이", ""),
-                            Artist(id = 10L, "마마무", ""),
-                            Artist(id = 11L, "블랙핑크", ""),
+                            Artist(
+                                id = 1L,
+                                name = "BTS",
+                                imageUrl = "https://i.namu.wiki/i/gpgJvt_C2vKJS4VA4K_Vm57Y5WoS83ofshxhJlQaT4P9Tu0N96vZ2OcdeAN7ZtRAM26UyyQs3sualkKk6i_SrRMvwVKrU015XJqzJ7wKRbOub_oUAxPSFre_8D5De3oy-fCxL0uZ-HGvsWxIX57yrw.webp",
+                            ),
+                            Artist(
+                                id = 2L,
+                                name = "싸이",
+                                imageUrl = "https://i.namu.wiki/i/VH58lI8f-y8QSoxFH9IAjjCobySN0lflZ4rMy6Un7qawUwAyi9UfeseZWCzxH-lQeZk7q_eUyTHGlZBAPqSLWliIKWYDLaAgomVtOyAQg60aCpF3oNTBOgUe_hig3rbHW-YAgoj95Fww3MCToyM6MA.webp",
+                            ),
+                            Artist(
+                                id = 10L,
+                                name = "마마무",
+                                imageUrl = "https://i.namu.wiki/i/Mre8tXnE40mB9_UwXIwASMEAUSVhHvyjJxXq-lQo40C3bLWYfxXBeai8t6TugyomPjFgxL3VfDA2zn65HlzqPXgTKlvdRl1gJ6PGZLxYYk8Uhk8L6va7zm_etSK5UzVLE56fUATqUCq-6tRQXigmYQ.webp",
+                            ),
+                            Artist(
+                                id = 11L,
+                                name = "블랙핑크",
+                                imageUrl = "https://i.namu.wiki/i/VZxRYO8_CXa2QbOSZgttDq5ue5QEu_Fbk1Lwo3qpasLAfS802YExcnmVmDhCq3ONF0ExzhACz_YkZbxOGmIfjuPDZnFo7i0pWaT05NluHRHGfp9NqsAT6WBNb0k5KecOyDvakXk0VH2fUo4ojSwC6g.webp",
+                            ),
+                            Artist(
+                                id = 4L,
+                                name = "AKMU",
+                                imageUrl = "https://i.namu.wiki/i/7yRF8Yrk9kdQxzETNO8TQp9jJpQENVUGbj-4YwB-xdVmJWoTAY7MgVA6G72Z-xmunPG0Zd3WTN_EsTwsx7oNFIO-yl0nHmaIU-ZRCpyhzVE5L9y8Sb9gkAKVt_jZBtgvVrOjw1UQq32gQsYaoS1jsg.webp",
+                            ),
                         ),
                     ),
                     Stage(
-                        id = 1L,
-                        startDateTime = LocalDateTime.now(),
+                        id = 2L,
+                        startDateTime = LocalDateTime.now().plusDays(1L),
                         artists = listOf(
-                            Artist(id = 3L, "아이유", ""),
-                            Artist(id = 4L, "AKMU", ""),
-                            Artist(id = 5L, "뉴진스", ""),
-                            Artist(id = 6L, "비비", ""),
+                            Artist(
+                                id = 3L,
+                                name = "아이유",
+                                imageUrl = "https://i.namu.wiki/i/-GuxB5nI9Q-a5W_nAJEapwdUzCLyFShWJfmUfZk04cW_fFC485TRD6UlzGQCBnFpJegXBaa4WO-PThNom_7wlosOiXgb-k3-wgUr3PkyX89PU3RCschmgQ0FmS1ClOK3ph4ztAd55YWWlhk7Gm114w.webp",
+                            ),
+                            Artist(
+                                id = 5L,
+                                name = "뉴진스",
+                                imageUrl = "https://i.namu.wiki/i/GdMUzQlsrAXyF5zlgqRR0lYvAGnFghBbLxqTZK_mzLvV0LYPNQdaak1ezYtKqSNBA7UaINkrMNqncRkxThI8j2IEk2qcXJ3bLqIllRexenai641g-uvxCxFcDa9doCy0kTnMLEp5gad8Ze2fLDDBvg.webp",
+                            ),
+                            Artist(
+                                id = 6L,
+                                name = "비비",
+                                imageUrl = "https://i.namu.wiki/i/JlXBTAah7fOILgmvAQf5bW4yWbS082qw6XtV36g4a-2g5TrwTRaUf95r1YnEYi6dt_rf3o9YuRN2qVl0pdgIW5d6-DeYg67KwaSrqu3_MkUwQItlsrSLqDjm1G0jW-Z5mzQ2aOTU4ZvyE1hpSokIOA.webp",
+                            ),
                         ),
                     ),
                     Stage(
-                        id = 1L,
-                        startDateTime = LocalDateTime.now(),
+                        id = 3L,
+                        startDateTime = LocalDateTime.now().plusDays(2L),
                         artists = listOf(
-                            Artist(id = 7L, "TWS", ""),
-                            Artist(id = 8L, "소녀시대", ""),
-                            Artist(id = 9L, "르세라핌", ""),
+                            Artist(
+                                id = 7L,
+                                name = "TWS",
+                                imageUrl = "https://i.namu.wiki/i/rVwKhMepUc-b-hRa2Nc6mIJRO0eTfgxyAEwVS5XfADNRhQhYJdSg8ke3o6VZd3rLyNasMlGjuXJWqHDoD_Z24o3dBzkaf7gqhCc89XoCKOiII4P-eilx46XHOOTfd2eaonCVNQevsAVl0l5WIWaI5Q.webp",
+                            ),
+                            Artist(
+                                id = 8L,
+                                name = "소녀시대",
+                                imageUrl = "https://i.namu.wiki/i/snftu-N6Op26hU4HITlraWW6Q_WiSXqhRX2NOhQadzI81RPC7054_mi-evsqRTdRe9nKcBEF-Ugji4vtWunmtiEY1v319tHhIVestCkcSJ0MZF6KbKOScoDjOypW7WPa58goYA-vX5D8baIa2UYFZg.webp",
+                            ),
+                            Artist(
+                                id = 9L,
+                                name = "르세라핌",
+                                imageUrl = "https://i.namu.wiki/i/Zbm1DseL0fjSd9H2uLrfL9SpBLPYQe7j4S9BPI2wdTw9G_Gykifyw-Nil8yVZglxxW-CRQt15b-tMdrvfuUiSW9mm2ZEBf8sQQQgp9wZmZhe8neg_5A6ehJ6hYLATAqvnOw157aODDq4qU1J-kv-bA.webp",
+                            ),
+                        ),
+                    ),
+                    Stage(
+                        id = 4L,
+                        startDateTime = LocalDateTime.now().plusDays(3L),
+                        artists = listOf(
+                            Artist(
+                                id = 7L,
+                                name = "TWS",
+                                imageUrl = "https://i.namu.wiki/i/rVwKhMepUc-b-hRa2Nc6mIJRO0eTfgxyAEwVS5XfADNRhQhYJdSg8ke3o6VZd3rLyNasMlGjuXJWqHDoD_Z24o3dBzkaf7gqhCc89XoCKOiII4P-eilx46XHOOTfd2eaonCVNQevsAVl0l5WIWaI5Q.webp",
+                            ),
+                            Artist(
+                                id = 8L,
+                                name = "소녀시대",
+                                imageUrl = "https://i.namu.wiki/i/snftu-N6Op26hU4HITlraWW6Q_WiSXqhRX2NOhQadzI81RPC7054_mi-evsqRTdRe9nKcBEF-Ugji4vtWunmtiEY1v319tHhIVestCkcSJ0MZF6KbKOScoDjOypW7WPa58goYA-vX5D8baIa2UYFZg.webp",
+                            ),
+                            Artist(
+                                id = 9L,
+                                name = "르세라핌",
+                                imageUrl = "https://i.namu.wiki/i/Zbm1DseL0fjSd9H2uLrfL9SpBLPYQe7j4S9BPI2wdTw9G_Gykifyw-Nil8yVZglxxW-CRQt15b-tMdrvfuUiSW9mm2ZEBf8sQQQgp9wZmZhe8neg_5A6ehJ6hYLATAqvnOw157aODDq4qU1J-kv-bA.webp",
+                            ),
+                        ),
+                    ),
+                    Stage(
+                        id = 5L,
+                        startDateTime = LocalDateTime.now().plusDays(4L),
+                        artists = listOf(
+                            Artist(
+                                id = 7L,
+                                name = "TWS",
+                                imageUrl = "https://i.namu.wiki/i/rVwKhMepUc-b-hRa2Nc6mIJRO0eTfgxyAEwVS5XfADNRhQhYJdSg8ke3o6VZd3rLyNasMlGjuXJWqHDoD_Z24o3dBzkaf7gqhCc89XoCKOiII4P-eilx46XHOOTfd2eaonCVNQevsAVl0l5WIWaI5Q.webp",
+                            ),
+                            Artist(
+                                id = 8L,
+                                name = "소녀시대",
+                                imageUrl = "https://i.namu.wiki/i/snftu-N6Op26hU4HITlraWW6Q_WiSXqhRX2NOhQadzI81RPC7054_mi-evsqRTdRe9nKcBEF-Ugji4vtWunmtiEY1v319tHhIVestCkcSJ0MZF6KbKOScoDjOypW7WPa58goYA-vX5D8baIa2UYFZg.webp",
+                            ),
+                            Artist(
+                                id = 9L,
+                                name = "르세라핌",
+                                imageUrl = "https://i.namu.wiki/i/Zbm1DseL0fjSd9H2uLrfL9SpBLPYQe7j4S9BPI2wdTw9G_Gykifyw-Nil8yVZglxxW-CRQt15b-tMdrvfuUiSW9mm2ZEBf8sQQQgp9wZmZhe8neg_5A6ehJ6hYLATAqvnOw157aODDq4qU1J-kv-bA.webp",
+                            ),
                         ),
                     ),
                 ),

--- a/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeFestivalRepository.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeFestivalRepository.kt
@@ -8,11 +8,8 @@ import com.festago.festago.domain.model.festival.FestivalsPage
 import com.festago.festago.domain.model.festival.PopularFestivals
 import com.festago.festago.domain.model.festival.SchoolRegion
 import com.festago.festago.domain.model.school.School
-import com.festago.festago.domain.model.social.SocialMedia
-import com.festago.festago.domain.model.stage.Stage
 import com.festago.festago.domain.repository.FestivalRepository
 import java.time.LocalDate
-import java.time.LocalDateTime
 import javax.inject.Inject
 
 class FakeFestivalRepository @Inject constructor() : FestivalRepository {
@@ -88,147 +85,7 @@ class FakeFestivalRepository @Inject constructor() : FestivalRepository {
     }
 
     override suspend fun loadFestivalDetail(id: Long): Result<FestivalDetail> {
-        return Result.success(
-            FestivalDetail(
-                id = 1L,
-                name = "대동제",
-                startDate = LocalDate.now(),
-                endDate = LocalDate.now().plusDays(5L),
-                posterImageUrl = "https://mblogthumb-phinf.pstatic.net/MjAyMzA1MjNfMTMx/MDAxNjg0ODIwNzY5NzQ5.MuYItN1HCOQUcADB6B7ua0SO9Au_QNNk01-6yZkcTH0g.wxSjluY-Glq20JIojs7OuScLQWh6c_sQsoW5xXqiM7Ag.JPEG.chummilmil99/SE-126908ba-0f82-4903-91c5-695db78a98e9.jpg?type=w800",
-                school = School(id = 2L, name = "부경대학교", imageUrl = ""),
-                socialMedias = listOf(
-                    SocialMedia(
-                        type = "INSTAGRAM",
-                        name = "총학생회 인스타그램",
-                        logoUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Instagram_logo_2016.svg/2048px-Instagram_logo_2016.svg.png",
-                        url = "https://www.instagram.com/25th_solution/",
-                    ),
-                    SocialMedia(
-                        type = "FACEBOOK",
-                        name = "총학생회 페이스북",
-                        logoUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/5/51/Facebook_f_logo_%282019%29.svg/1200px-Facebook_f_logo_%282019%29.svg.png",
-                        url = "https://www.facebook.com/23rdemotion/",
-                    ),
-                ),
-                stages = listOf(
-                    Stage(
-                        id = 1L,
-                        startDateTime = LocalDateTime.now().plusDays(0L),
-                        artists = listOf(
-                            Artist(
-                                id = 1L,
-                                name = "BTS",
-                                imageUrl = "https://i.namu.wiki/i/gpgJvt_C2vKJS4VA4K_Vm57Y5WoS83ofshxhJlQaT4P9Tu0N96vZ2OcdeAN7ZtRAM26UyyQs3sualkKk6i_SrRMvwVKrU015XJqzJ7wKRbOub_oUAxPSFre_8D5De3oy-fCxL0uZ-HGvsWxIX57yrw.webp",
-                            ),
-                            Artist(
-                                id = 2L,
-                                name = "싸이",
-                                imageUrl = "https://i.namu.wiki/i/VH58lI8f-y8QSoxFH9IAjjCobySN0lflZ4rMy6Un7qawUwAyi9UfeseZWCzxH-lQeZk7q_eUyTHGlZBAPqSLWliIKWYDLaAgomVtOyAQg60aCpF3oNTBOgUe_hig3rbHW-YAgoj95Fww3MCToyM6MA.webp",
-                            ),
-                            Artist(
-                                id = 10L,
-                                name = "마마무",
-                                imageUrl = "https://i.namu.wiki/i/Mre8tXnE40mB9_UwXIwASMEAUSVhHvyjJxXq-lQo40C3bLWYfxXBeai8t6TugyomPjFgxL3VfDA2zn65HlzqPXgTKlvdRl1gJ6PGZLxYYk8Uhk8L6va7zm_etSK5UzVLE56fUATqUCq-6tRQXigmYQ.webp",
-                            ),
-                            Artist(
-                                id = 11L,
-                                name = "블랙핑크",
-                                imageUrl = "https://i.namu.wiki/i/VZxRYO8_CXa2QbOSZgttDq5ue5QEu_Fbk1Lwo3qpasLAfS802YExcnmVmDhCq3ONF0ExzhACz_YkZbxOGmIfjuPDZnFo7i0pWaT05NluHRHGfp9NqsAT6WBNb0k5KecOyDvakXk0VH2fUo4ojSwC6g.webp",
-                            ),
-                            Artist(
-                                id = 4L,
-                                name = "AKMU",
-                                imageUrl = "https://i.namu.wiki/i/7yRF8Yrk9kdQxzETNO8TQp9jJpQENVUGbj-4YwB-xdVmJWoTAY7MgVA6G72Z-xmunPG0Zd3WTN_EsTwsx7oNFIO-yl0nHmaIU-ZRCpyhzVE5L9y8Sb9gkAKVt_jZBtgvVrOjw1UQq32gQsYaoS1jsg.webp",
-                            ),
-                        ),
-                    ),
-                    Stage(
-                        id = 2L,
-                        startDateTime = LocalDateTime.now().plusDays(1L),
-                        artists = listOf(
-                            Artist(
-                                id = 3L,
-                                name = "아이유",
-                                imageUrl = "https://i.namu.wiki/i/-GuxB5nI9Q-a5W_nAJEapwdUzCLyFShWJfmUfZk04cW_fFC485TRD6UlzGQCBnFpJegXBaa4WO-PThNom_7wlosOiXgb-k3-wgUr3PkyX89PU3RCschmgQ0FmS1ClOK3ph4ztAd55YWWlhk7Gm114w.webp",
-                            ),
-                            Artist(
-                                id = 5L,
-                                name = "뉴진스",
-                                imageUrl = "https://i.namu.wiki/i/GdMUzQlsrAXyF5zlgqRR0lYvAGnFghBbLxqTZK_mzLvV0LYPNQdaak1ezYtKqSNBA7UaINkrMNqncRkxThI8j2IEk2qcXJ3bLqIllRexenai641g-uvxCxFcDa9doCy0kTnMLEp5gad8Ze2fLDDBvg.webp",
-                            ),
-                            Artist(
-                                id = 6L,
-                                name = "비비",
-                                imageUrl = "https://i.namu.wiki/i/JlXBTAah7fOILgmvAQf5bW4yWbS082qw6XtV36g4a-2g5TrwTRaUf95r1YnEYi6dt_rf3o9YuRN2qVl0pdgIW5d6-DeYg67KwaSrqu3_MkUwQItlsrSLqDjm1G0jW-Z5mzQ2aOTU4ZvyE1hpSokIOA.webp",
-                            ),
-                        ),
-                    ),
-                    Stage(
-                        id = 3L,
-                        startDateTime = LocalDateTime.now().plusDays(2L),
-                        artists = listOf(
-                            Artist(
-                                id = 7L,
-                                name = "TWS",
-                                imageUrl = "https://i.namu.wiki/i/rVwKhMepUc-b-hRa2Nc6mIJRO0eTfgxyAEwVS5XfADNRhQhYJdSg8ke3o6VZd3rLyNasMlGjuXJWqHDoD_Z24o3dBzkaf7gqhCc89XoCKOiII4P-eilx46XHOOTfd2eaonCVNQevsAVl0l5WIWaI5Q.webp",
-                            ),
-                            Artist(
-                                id = 8L,
-                                name = "소녀시대",
-                                imageUrl = "https://i.namu.wiki/i/snftu-N6Op26hU4HITlraWW6Q_WiSXqhRX2NOhQadzI81RPC7054_mi-evsqRTdRe9nKcBEF-Ugji4vtWunmtiEY1v319tHhIVestCkcSJ0MZF6KbKOScoDjOypW7WPa58goYA-vX5D8baIa2UYFZg.webp",
-                            ),
-                            Artist(
-                                id = 9L,
-                                name = "르세라핌",
-                                imageUrl = "https://i.namu.wiki/i/Zbm1DseL0fjSd9H2uLrfL9SpBLPYQe7j4S9BPI2wdTw9G_Gykifyw-Nil8yVZglxxW-CRQt15b-tMdrvfuUiSW9mm2ZEBf8sQQQgp9wZmZhe8neg_5A6ehJ6hYLATAqvnOw157aODDq4qU1J-kv-bA.webp",
-                            ),
-                        ),
-                    ),
-                    Stage(
-                        id = 4L,
-                        startDateTime = LocalDateTime.now().plusDays(3L),
-                        artists = listOf(
-                            Artist(
-                                id = 7L,
-                                name = "TWS",
-                                imageUrl = "https://i.namu.wiki/i/rVwKhMepUc-b-hRa2Nc6mIJRO0eTfgxyAEwVS5XfADNRhQhYJdSg8ke3o6VZd3rLyNasMlGjuXJWqHDoD_Z24o3dBzkaf7gqhCc89XoCKOiII4P-eilx46XHOOTfd2eaonCVNQevsAVl0l5WIWaI5Q.webp",
-                            ),
-                            Artist(
-                                id = 8L,
-                                name = "소녀시대",
-                                imageUrl = "https://i.namu.wiki/i/snftu-N6Op26hU4HITlraWW6Q_WiSXqhRX2NOhQadzI81RPC7054_mi-evsqRTdRe9nKcBEF-Ugji4vtWunmtiEY1v319tHhIVestCkcSJ0MZF6KbKOScoDjOypW7WPa58goYA-vX5D8baIa2UYFZg.webp",
-                            ),
-                            Artist(
-                                id = 9L,
-                                name = "르세라핌",
-                                imageUrl = "https://i.namu.wiki/i/Zbm1DseL0fjSd9H2uLrfL9SpBLPYQe7j4S9BPI2wdTw9G_Gykifyw-Nil8yVZglxxW-CRQt15b-tMdrvfuUiSW9mm2ZEBf8sQQQgp9wZmZhe8neg_5A6ehJ6hYLATAqvnOw157aODDq4qU1J-kv-bA.webp",
-                            ),
-                        ),
-                    ),
-                    Stage(
-                        id = 5L,
-                        startDateTime = LocalDateTime.now().plusDays(4L),
-                        artists = listOf(
-                            Artist(
-                                id = 7L,
-                                name = "TWS",
-                                imageUrl = "https://i.namu.wiki/i/rVwKhMepUc-b-hRa2Nc6mIJRO0eTfgxyAEwVS5XfADNRhQhYJdSg8ke3o6VZd3rLyNasMlGjuXJWqHDoD_Z24o3dBzkaf7gqhCc89XoCKOiII4P-eilx46XHOOTfd2eaonCVNQevsAVl0l5WIWaI5Q.webp",
-                            ),
-                            Artist(
-                                id = 8L,
-                                name = "소녀시대",
-                                imageUrl = "https://i.namu.wiki/i/snftu-N6Op26hU4HITlraWW6Q_WiSXqhRX2NOhQadzI81RPC7054_mi-evsqRTdRe9nKcBEF-Ugji4vtWunmtiEY1v319tHhIVestCkcSJ0MZF6KbKOScoDjOypW7WPa58goYA-vX5D8baIa2UYFZg.webp",
-                            ),
-                            Artist(
-                                id = 9L,
-                                name = "르세라핌",
-                                imageUrl = "https://i.namu.wiki/i/Zbm1DseL0fjSd9H2uLrfL9SpBLPYQe7j4S9BPI2wdTw9G_Gykifyw-Nil8yVZglxxW-CRQt15b-tMdrvfuUiSW9mm2ZEBf8sQQQgp9wZmZhe8neg_5A6ehJ6hYLATAqvnOw157aODDq4qU1J-kv-bA.webp",
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-        )
+        return Result.success(FakeFestivals.festivalDetail)
     }
 
     companion object {

--- a/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeFestivals.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeFestivals.kt
@@ -2,10 +2,154 @@ package com.festago.festago.data.repository
 
 import com.festago.festago.domain.model.artist.Artist
 import com.festago.festago.domain.model.festival.Festival
+import com.festago.festago.domain.model.festival.FestivalDetail
 import com.festago.festago.domain.model.school.School
+import com.festago.festago.domain.model.social.SocialMedia
+import com.festago.festago.domain.model.stage.Stage
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 object FakeFestivals {
+
+    val festivalDetail = FestivalDetail(
+        id = 1L,
+        name = "대동제",
+        startDate = LocalDate.now(),
+        endDate = LocalDate.now().plusDays(5L),
+        posterImageUrl = "https://mblogthumb-phinf.pstatic.net/MjAyMzA1MjNfMTMx/MDAxNjg0ODIwNzY5NzQ5.MuYItN1HCOQUcADB6B7ua0SO9Au_QNNk01-6yZkcTH0g.wxSjluY-Glq20JIojs7OuScLQWh6c_sQsoW5xXqiM7Ag.JPEG.chummilmil99/SE-126908ba-0f82-4903-91c5-695db78a98e9.jpg?type=w800",
+        school = School(id = 2L, name = "부경대학교", imageUrl = ""),
+        socialMedias = listOf(
+            SocialMedia(
+                type = "INSTAGRAM",
+                name = "총학생회 인스타그램",
+                logoUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Instagram_logo_2016.svg/2048px-Instagram_logo_2016.svg.png",
+                url = "https://www.instagram.com/25th_solution/",
+            ),
+            SocialMedia(
+                type = "FACEBOOK",
+                name = "총학생회 페이스북",
+                logoUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/5/51/Facebook_f_logo_%282019%29.svg/1200px-Facebook_f_logo_%282019%29.svg.png",
+                url = "https://www.facebook.com/23rdemotion/",
+            ),
+        ),
+        stages = listOf(
+            Stage(
+                id = 1L,
+                startDateTime = LocalDateTime.now().plusDays(0L),
+                artists = listOf(
+                    Artist(
+                        id = 1L,
+                        name = "BTS",
+                        imageUrl = "https://i.namu.wiki/i/gpgJvt_C2vKJS4VA4K_Vm57Y5WoS83ofshxhJlQaT4P9Tu0N96vZ2OcdeAN7ZtRAM26UyyQs3sualkKk6i_SrRMvwVKrU015XJqzJ7wKRbOub_oUAxPSFre_8D5De3oy-fCxL0uZ-HGvsWxIX57yrw.webp",
+                    ),
+                    Artist(
+                        id = 2L,
+                        name = "싸이",
+                        imageUrl = "https://i.namu.wiki/i/VH58lI8f-y8QSoxFH9IAjjCobySN0lflZ4rMy6Un7qawUwAyi9UfeseZWCzxH-lQeZk7q_eUyTHGlZBAPqSLWliIKWYDLaAgomVtOyAQg60aCpF3oNTBOgUe_hig3rbHW-YAgoj95Fww3MCToyM6MA.webp",
+                    ),
+                    Artist(
+                        id = 10L,
+                        name = "마마무",
+                        imageUrl = "https://i.namu.wiki/i/Mre8tXnE40mB9_UwXIwASMEAUSVhHvyjJxXq-lQo40C3bLWYfxXBeai8t6TugyomPjFgxL3VfDA2zn65HlzqPXgTKlvdRl1gJ6PGZLxYYk8Uhk8L6va7zm_etSK5UzVLE56fUATqUCq-6tRQXigmYQ.webp",
+                    ),
+                    Artist(
+                        id = 11L,
+                        name = "블랙핑크",
+                        imageUrl = "https://i.namu.wiki/i/VZxRYO8_CXa2QbOSZgttDq5ue5QEu_Fbk1Lwo3qpasLAfS802YExcnmVmDhCq3ONF0ExzhACz_YkZbxOGmIfjuPDZnFo7i0pWaT05NluHRHGfp9NqsAT6WBNb0k5KecOyDvakXk0VH2fUo4ojSwC6g.webp",
+                    ),
+                    Artist(
+                        id = 4L,
+                        name = "AKMU",
+                        imageUrl = "https://i.namu.wiki/i/7yRF8Yrk9kdQxzETNO8TQp9jJpQENVUGbj-4YwB-xdVmJWoTAY7MgVA6G72Z-xmunPG0Zd3WTN_EsTwsx7oNFIO-yl0nHmaIU-ZRCpyhzVE5L9y8Sb9gkAKVt_jZBtgvVrOjw1UQq32gQsYaoS1jsg.webp",
+                    ),
+                ),
+            ),
+            Stage(
+                id = 2L,
+                startDateTime = LocalDateTime.now().plusDays(1L),
+                artists = listOf(
+                    Artist(
+                        id = 3L,
+                        name = "아이유",
+                        imageUrl = "https://i.namu.wiki/i/-GuxB5nI9Q-a5W_nAJEapwdUzCLyFShWJfmUfZk04cW_fFC485TRD6UlzGQCBnFpJegXBaa4WO-PThNom_7wlosOiXgb-k3-wgUr3PkyX89PU3RCschmgQ0FmS1ClOK3ph4ztAd55YWWlhk7Gm114w.webp",
+                    ),
+                    Artist(
+                        id = 5L,
+                        name = "뉴진스",
+                        imageUrl = "https://i.namu.wiki/i/GdMUzQlsrAXyF5zlgqRR0lYvAGnFghBbLxqTZK_mzLvV0LYPNQdaak1ezYtKqSNBA7UaINkrMNqncRkxThI8j2IEk2qcXJ3bLqIllRexenai641g-uvxCxFcDa9doCy0kTnMLEp5gad8Ze2fLDDBvg.webp",
+                    ),
+                    Artist(
+                        id = 6L,
+                        name = "비비",
+                        imageUrl = "https://i.namu.wiki/i/JlXBTAah7fOILgmvAQf5bW4yWbS082qw6XtV36g4a-2g5TrwTRaUf95r1YnEYi6dt_rf3o9YuRN2qVl0pdgIW5d6-DeYg67KwaSrqu3_MkUwQItlsrSLqDjm1G0jW-Z5mzQ2aOTU4ZvyE1hpSokIOA.webp",
+                    ),
+                ),
+            ),
+            Stage(
+                id = 3L,
+                startDateTime = LocalDateTime.now().plusDays(2L),
+                artists = listOf(
+                    Artist(
+                        id = 7L,
+                        name = "TWS",
+                        imageUrl = "https://i.namu.wiki/i/rVwKhMepUc-b-hRa2Nc6mIJRO0eTfgxyAEwVS5XfADNRhQhYJdSg8ke3o6VZd3rLyNasMlGjuXJWqHDoD_Z24o3dBzkaf7gqhCc89XoCKOiII4P-eilx46XHOOTfd2eaonCVNQevsAVl0l5WIWaI5Q.webp",
+                    ),
+                    Artist(
+                        id = 8L,
+                        name = "소녀시대",
+                        imageUrl = "https://i.namu.wiki/i/snftu-N6Op26hU4HITlraWW6Q_WiSXqhRX2NOhQadzI81RPC7054_mi-evsqRTdRe9nKcBEF-Ugji4vtWunmtiEY1v319tHhIVestCkcSJ0MZF6KbKOScoDjOypW7WPa58goYA-vX5D8baIa2UYFZg.webp",
+                    ),
+                    Artist(
+                        id = 9L,
+                        name = "르세라핌",
+                        imageUrl = "https://i.namu.wiki/i/Zbm1DseL0fjSd9H2uLrfL9SpBLPYQe7j4S9BPI2wdTw9G_Gykifyw-Nil8yVZglxxW-CRQt15b-tMdrvfuUiSW9mm2ZEBf8sQQQgp9wZmZhe8neg_5A6ehJ6hYLATAqvnOw157aODDq4qU1J-kv-bA.webp",
+                    ),
+                ),
+            ),
+            Stage(
+                id = 4L,
+                startDateTime = LocalDateTime.now().plusDays(3L),
+                artists = listOf(
+                    Artist(
+                        id = 7L,
+                        name = "TWS",
+                        imageUrl = "https://i.namu.wiki/i/rVwKhMepUc-b-hRa2Nc6mIJRO0eTfgxyAEwVS5XfADNRhQhYJdSg8ke3o6VZd3rLyNasMlGjuXJWqHDoD_Z24o3dBzkaf7gqhCc89XoCKOiII4P-eilx46XHOOTfd2eaonCVNQevsAVl0l5WIWaI5Q.webp",
+                    ),
+                    Artist(
+                        id = 8L,
+                        name = "소녀시대",
+                        imageUrl = "https://i.namu.wiki/i/snftu-N6Op26hU4HITlraWW6Q_WiSXqhRX2NOhQadzI81RPC7054_mi-evsqRTdRe9nKcBEF-Ugji4vtWunmtiEY1v319tHhIVestCkcSJ0MZF6KbKOScoDjOypW7WPa58goYA-vX5D8baIa2UYFZg.webp",
+                    ),
+                    Artist(
+                        id = 9L,
+                        name = "르세라핌",
+                        imageUrl = "https://i.namu.wiki/i/Zbm1DseL0fjSd9H2uLrfL9SpBLPYQe7j4S9BPI2wdTw9G_Gykifyw-Nil8yVZglxxW-CRQt15b-tMdrvfuUiSW9mm2ZEBf8sQQQgp9wZmZhe8neg_5A6ehJ6hYLATAqvnOw157aODDq4qU1J-kv-bA.webp",
+                    ),
+                ),
+            ),
+            Stage(
+                id = 5L,
+                startDateTime = LocalDateTime.now().plusDays(4L),
+                artists = listOf(
+                    Artist(
+                        id = 7L,
+                        name = "TWS",
+                        imageUrl = "https://i.namu.wiki/i/rVwKhMepUc-b-hRa2Nc6mIJRO0eTfgxyAEwVS5XfADNRhQhYJdSg8ke3o6VZd3rLyNasMlGjuXJWqHDoD_Z24o3dBzkaf7gqhCc89XoCKOiII4P-eilx46XHOOTfd2eaonCVNQevsAVl0l5WIWaI5Q.webp",
+                    ),
+                    Artist(
+                        id = 8L,
+                        name = "소녀시대",
+                        imageUrl = "https://i.namu.wiki/i/snftu-N6Op26hU4HITlraWW6Q_WiSXqhRX2NOhQadzI81RPC7054_mi-evsqRTdRe9nKcBEF-Ugji4vtWunmtiEY1v319tHhIVestCkcSJ0MZF6KbKOScoDjOypW7WPa58goYA-vX5D8baIa2UYFZg.webp",
+                    ),
+                    Artist(
+                        id = 9L,
+                        name = "르세라핌",
+                        imageUrl = "https://i.namu.wiki/i/Zbm1DseL0fjSd9H2uLrfL9SpBLPYQe7j4S9BPI2wdTw9G_Gykifyw-Nil8yVZglxxW-CRQt15b-tMdrvfuUiSW9mm2ZEBf8sQQQgp9wZmZhe8neg_5A6ehJ6hYLATAqvnOw157aODDq4qU1J-kv-bA.webp",
+                    ),
+                ),
+            ),
+        ),
+    )
 
     val progressFestivals = listOf(
         Festival(

--- a/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeFestivals.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeFestivals.kt
@@ -13,7 +13,7 @@ object FakeFestivals {
 
     val festivalDetail = FestivalDetail(
         id = 1L,
-        name = "대동제",
+        name = "부경대 대동제",
         startDate = LocalDate.now(),
         endDate = LocalDate.now().plusDays(5L),
         posterImageUrl = "https://mblogthumb-phinf.pstatic.net/MjAyMzA1MjNfMTMx/MDAxNjg0ODIwNzY5NzQ5.MuYItN1HCOQUcADB6B7ua0SO9Au_QNNk01-6yZkcTH0g.wxSjluY-Glq20JIojs7OuScLQWh6c_sQsoW5xXqiM7Ag.JPEG.chummilmil99/SE-126908ba-0f82-4903-91c5-695db78a98e9.jpg?type=w800",

--- a/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeFestivals.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeFestivals.kt
@@ -14,8 +14,8 @@ object FakeFestivals {
     val festivalDetail = FestivalDetail(
         id = 1L,
         name = "부경대 대동제",
-        startDate = LocalDate.now(),
-        endDate = LocalDate.now().plusDays(5L),
+        startDate = LocalDate.now().plusDays(7L),
+        endDate = LocalDate.now().plusDays(10L),
         posterImageUrl = "https://mblogthumb-phinf.pstatic.net/MjAyMzA1MjNfMTMx/MDAxNjg0ODIwNzY5NzQ5.MuYItN1HCOQUcADB6B7ua0SO9Au_QNNk01-6yZkcTH0g.wxSjluY-Glq20JIojs7OuScLQWh6c_sQsoW5xXqiM7Ag.JPEG.chummilmil99/SE-126908ba-0f82-4903-91c5-695db78a98e9.jpg?type=w800",
         school = School(id = 2L, name = "부경대학교", imageUrl = ""),
         socialMedias = listOf(

--- a/android/festago/data/src/main/java/com/festago/festago/data/repository/FestivalDefaultRepository.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/repository/FestivalDefaultRepository.kt
@@ -3,6 +3,7 @@ package com.festago.festago.data.repository
 import com.festago.festago.data.service.FestivalRetrofitService
 import com.festago.festago.data.util.onSuccessOrCatch
 import com.festago.festago.data.util.runCatchingResponse
+import com.festago.festago.domain.model.festival.FestivalDetail
 import com.festago.festago.domain.model.festival.FestivalFilter
 import com.festago.festago.domain.model.festival.FestivalsPage
 import com.festago.festago.domain.model.festival.PopularFestivals
@@ -36,6 +37,12 @@ class FestivalDefaultRepository @Inject constructor(
                 lastStartDate = lastStartDate,
                 size = size,
             )
+        }.onSuccessOrCatch { it.toDomain() }
+    }
+
+    override suspend fun loadFestivalDetail(id: Long): Result<FestivalDetail> {
+        return runCatchingResponse {
+            festivalRetrofitService.getFestivalDetail(id)
         }.onSuccessOrCatch { it.toDomain() }
     }
 }

--- a/android/festago/data/src/main/java/com/festago/festago/data/service/FestivalRetrofitService.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/service/FestivalRetrofitService.kt
@@ -1,5 +1,6 @@
 package com.festago.festago.data.service
 
+import com.festago.festago.data.dto.festival.FestivalDetailResponse
 import com.festago.festago.data.dto.festival.FestivalsResponse
 import com.festago.festago.data.dto.festival.PopularFestivalsResponse
 import retrofit2.Response
@@ -19,4 +20,7 @@ interface FestivalRetrofitService {
         @Query("lastStartDate") lastStartDate: LocalDate?,
         @Query("size") size: Int?,
     ): Response<FestivalsResponse>
+
+    @GET("api/v1/popular/festivals/")
+    suspend fun getFestivalDetail(id: Long): Response<FestivalDetailResponse>
 }

--- a/android/festago/data/src/main/java/com/festago/festago/data/service/FestivalRetrofitService.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/service/FestivalRetrofitService.kt
@@ -5,6 +5,7 @@ import com.festago.festago.data.dto.festival.FestivalsResponse
 import com.festago.festago.data.dto.festival.PopularFestivalsResponse
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.Query
 import java.time.LocalDate
 
@@ -21,6 +22,8 @@ interface FestivalRetrofitService {
         @Query("size") size: Int?,
     ): Response<FestivalsResponse>
 
-    @GET("api/v1/popular/festivals/")
-    suspend fun getFestivalDetail(id: Long): Response<FestivalDetailResponse>
+    @GET("api/v1/festivals/{festivalId}")
+    suspend fun getFestivalDetail(
+        @Path("festivalId") festivalId: Long,
+    ): Response<FestivalDetailResponse>
 }

--- a/android/festago/domain/src/main/java/com/festago/festago/domain/model/artist/Stages.kt
+++ b/android/festago/domain/src/main/java/com/festago/festago/domain/model/artist/Stages.kt
@@ -1,8 +1,0 @@
-package com.festago.festago.domain.model.artist
-
-import com.festago.festago.domain.model.festival.Festival
-
-data class Stages(
-    val last: Boolean,
-    val stage: List<Festival>,
-)

--- a/android/festago/domain/src/main/java/com/festago/festago/domain/model/festival/FestivalDetail.kt
+++ b/android/festago/domain/src/main/java/com/festago/festago/domain/model/festival/FestivalDetail.kt
@@ -1,0 +1,17 @@
+package com.festago.festago.domain.model.festival
+
+import com.festago.festago.domain.model.school.School
+import com.festago.festago.domain.model.social.SocialMedia
+import com.festago.festago.domain.model.stage.Stage
+import java.time.LocalDate
+
+data class FestivalDetail(
+    val id: Long,
+    val name: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val posterImageUrl: String,
+    val school: School,
+    val socialMedias: List<SocialMedia>,
+    val stages: List<Stage>,
+)

--- a/android/festago/domain/src/main/java/com/festago/festago/domain/model/stage/Stage.kt
+++ b/android/festago/domain/src/main/java/com/festago/festago/domain/model/stage/Stage.kt
@@ -1,0 +1,10 @@
+package com.festago.festago.domain.model.stage
+
+import com.festago.festago.domain.model.artist.Artist
+import java.time.LocalDateTime
+
+class Stage(
+    val id: Long,
+    val startDateTime: LocalDateTime,
+    val artists: List<Artist>,
+)

--- a/android/festago/domain/src/main/java/com/festago/festago/domain/repository/ArtistRepository.kt
+++ b/android/festago/domain/src/main/java/com/festago/festago/domain/repository/ArtistRepository.kt
@@ -1,10 +1,10 @@
 package com.festago.festago.domain.repository
 
 import com.festago.festago.domain.model.artist.ArtistDetail
-import com.festago.festago.domain.model.artist.Stages
+import com.festago.festago.domain.model.festival.FestivalsPage
 
 interface ArtistRepository {
     suspend fun loadArtistDetail(id: Long): Result<ArtistDetail>
 
-    suspend fun loadArtistStages(id: Long, size: Int): Result<Stages>
+    suspend fun loadArtistFestivals(id: Long, size: Int): Result<FestivalsPage>
 }

--- a/android/festago/domain/src/main/java/com/festago/festago/domain/repository/FestivalRepository.kt
+++ b/android/festago/domain/src/main/java/com/festago/festago/domain/repository/FestivalRepository.kt
@@ -1,5 +1,6 @@
 package com.festago.festago.domain.repository
 
+import com.festago.festago.domain.model.festival.FestivalDetail
 import com.festago.festago.domain.model.festival.FestivalFilter
 import com.festago.festago.domain.model.festival.FestivalsPage
 import com.festago.festago.domain.model.festival.PopularFestivals
@@ -15,4 +16,6 @@ interface FestivalRepository {
         lastStartDate: LocalDate? = null,
         size: Int? = null,
     ): Result<FestivalsPage>
+
+    suspend fun loadFestivalDetail(id: Long): Result<FestivalDetail>
 }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailFragment.kt
@@ -89,8 +89,9 @@ class ArtistDetailFragment : Fragment() {
         uiState.artist.artistMedia.map { media ->
             with(ItemMediaBinding.inflate(layoutInflater, binding.llcArtistMedia, false)) {
                 imageUrl = media.logoUrl
-                ivImage.setOnClickListener { startBrowser(media.url) }
-                binding.llcArtistMedia.addView(ivImage)
+                name = media.name
+                clMedia.setOnClickListener { startBrowser(media.url) }
+                binding.llcArtistMedia.addView(clMedia)
             }
         }
     }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailFragment.kt
@@ -89,9 +89,8 @@ class ArtistDetailFragment : Fragment() {
         uiState.artist.artistMedia.map { media ->
             with(ItemMediaBinding.inflate(layoutInflater, binding.llcArtistMedia, false)) {
                 imageUrl = media.logoUrl
-                name = media.name
-                clMedia.setOnClickListener { startBrowser(media.url) }
-                binding.llcArtistMedia.addView(clMedia)
+                ivImage.setOnClickListener { startBrowser(media.url) }
+                binding.llcArtistMedia.addView(ivImage)
             }
         }
     }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
@@ -6,7 +6,7 @@ import com.festago.festago.domain.model.artist.Stages
 import com.festago.festago.domain.repository.ArtistRepository
 import com.festago.festago.presentation.ui.artistdetail.uistate.ArtistDetailUiState
 import com.festago.festago.presentation.ui.artistdetail.uistate.ArtistUiState
-import com.festago.festago.presentation.ui.artistdetail.uistate.StageUiState
+import com.festago.festago.presentation.ui.artistdetail.uistate.FestivalItemUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -36,7 +36,7 @@ class ArtistDetailViewModel @Inject constructor(
     }
 
     private fun Stages.toUiState() = this.stage.map {
-        StageUiState(
+        FestivalItemUiState(
             id = it.id,
             name = it.name,
             imageUrl = it.imageUrl,

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
@@ -2,7 +2,7 @@ package com.festago.festago.presentation.ui.artistdetail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.festago.festago.domain.model.artist.Stages
+import com.festago.festago.domain.model.festival.FestivalsPage
 import com.festago.festago.domain.repository.ArtistRepository
 import com.festago.festago.presentation.ui.artistdetail.uistate.ArtistDetailUiState
 import com.festago.festago.presentation.ui.artistdetail.uistate.ArtistUiState
@@ -35,7 +35,7 @@ class ArtistDetailViewModel @Inject constructor(
         }
     }
 
-    private fun Stages.toUiState() = this.stage.map {
+    private fun FestivalsPage.toUiState() = festivals.map {
         FestivalItemUiState(
             id = it.id,
             name = it.name,

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
@@ -27,7 +27,7 @@ class ArtistDetailViewModel @Inject constructor(
             runCatching {
                 _uiState.value = ArtistDetailUiState.Success(
                     artistRepository.loadArtistDetail(id).getOrThrow(),
-                    artistRepository.loadArtistStages(id, 20).getOrThrow().toUiState(),
+                    artistRepository.loadArtistFestivals(id, 20).getOrThrow().toUiState(),
                 )
             }.onFailure {
                 _uiState.value = ArtistDetailUiState.Error

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/adapter/festival/ArtistDetailAdapter.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/adapter/festival/ArtistDetailAdapter.kt
@@ -3,11 +3,11 @@ package com.festago.festago.presentation.ui.artistdetail.adapter.festival
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
-import com.festago.festago.presentation.ui.artistdetail.uistate.StageUiState
+import com.festago.festago.presentation.ui.artistdetail.uistate.FestivalItemUiState
 
 class ArtistDetailAdapter(
     private val onArtistClick: (Long) -> Unit,
-) : ListAdapter<StageUiState, ArtistDetailFestivalViewHolder>(diffUtil) {
+) : ListAdapter<FestivalItemUiState, ArtistDetailFestivalViewHolder>(diffUtil) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ArtistDetailFestivalViewHolder {
         return ArtistDetailFestivalViewHolder.of(parent, onArtistClick)
     }
@@ -18,12 +18,12 @@ class ArtistDetailAdapter(
     }
 
     companion object {
-        private val diffUtil = object : DiffUtil.ItemCallback<StageUiState>() {
-            override fun areItemsTheSame(oldItem: StageUiState, newItem: StageUiState): Boolean {
+        private val diffUtil = object : DiffUtil.ItemCallback<FestivalItemUiState>() {
+            override fun areItemsTheSame(oldItem: FestivalItemUiState, newItem: FestivalItemUiState): Boolean {
                 return oldItem.id == newItem.id
             }
 
-            override fun areContentsTheSame(oldItem: StageUiState, newItem: StageUiState): Boolean {
+            override fun areContentsTheSame(oldItem: FestivalItemUiState, newItem: FestivalItemUiState): Boolean {
                 return oldItem == newItem
             }
         }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/adapter/festival/ArtistDetailFestivalViewHolder.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/adapter/festival/ArtistDetailFestivalViewHolder.kt
@@ -12,7 +12,7 @@ import androidx.recyclerview.widget.RecyclerView.ItemDecoration
 import com.festago.festago.presentation.R
 import com.festago.festago.presentation.databinding.ItemArtistDetailFestivalBinding
 import com.festago.festago.presentation.ui.artistdetail.adapter.artistlist.ArtistAdapter
-import com.festago.festago.presentation.ui.artistdetail.uistate.StageUiState
+import com.festago.festago.presentation.ui.artistdetail.uistate.FestivalItemUiState
 import java.time.LocalDate
 
 class ArtistDetailFestivalViewHolder(
@@ -26,13 +26,13 @@ class ArtistDetailFestivalViewHolder(
         binding.rvFestivalArtists.addItemDecoration(ArtistItemDecoration())
     }
 
-    fun bind(item: StageUiState) {
+    fun bind(item: FestivalItemUiState) {
         binding.item = item
         artistAdapter.submitList(item.artists)
         bindDDayView(item)
     }
 
-    private fun bindDDayView(item: StageUiState) {
+    private fun bindDDayView(item: FestivalItemUiState) {
         val context = binding.root.context
 
         val dDayView = binding.tvFestivalDDay

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/uistate/ArtistDetailUiState.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/uistate/ArtistDetailUiState.kt
@@ -9,6 +9,6 @@ sealed interface ArtistDetailUiState {
 
     data class Success(
         val artist: ArtistDetail,
-        val stages: List<StageUiState>,
+        val stages: List<FestivalItemUiState>,
     ) : ArtistDetailUiState
 }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/uistate/FestivalItemUiState.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/uistate/FestivalItemUiState.kt
@@ -2,7 +2,7 @@ package com.festago.festago.presentation.ui.artistdetail.uistate
 
 import java.time.LocalDate
 
-data class StageUiState(
+data class FestivalItemUiState(
     val id: Long,
     val name: String,
     val startDate: LocalDate,

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailEvent.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailEvent.kt
@@ -1,0 +1,5 @@
+package com.festago.festago.presentation.ui.festivaldetail
+
+sealed interface FestivalDetailEvent {
+    class ShowArtistDetail(val artistId: Long) : FestivalDetailEvent
+}

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentTransaction
 import androidx.fragment.app.commit
@@ -102,17 +103,33 @@ class FestivalDetailFragment : Fragment() {
     private fun TextView.setFestivalDDay(startDate: LocalDate, endDate: LocalDate) {
         when {
             LocalDate.now() in startDate..endDate -> {
-                text = context.getString(R.string.festival_detail_tv_dday)
-            }
-
-            LocalDate.now() < startDate -> {
-                text = context.getString(
-                    R.string.festival_detail_tv_dday_format,
-                    (LocalDate.now().toEpochDay() - startDate.toEpochDay()).toString(),
+                text = context.getString(R.string.festival_detail_tv_dday_in_progress)
+                setTextColor(context.getColor(R.color.secondary_pink_01))
+                background = AppCompatResources.getDrawable(
+                    context,
+                    R.drawable.bg_festival_list_dday_in_progress,
                 )
             }
 
+            LocalDate.now() < startDate -> {
+                val dDay = LocalDate.now().toEpochDay() - startDate.toEpochDay()
+                val backgroundColor = if (dDay >= -7L) {
+                    context.getColor(R.color.secondary_pink_01)
+                } else {
+                    context.getColor(R.color.contents_gray_07)
+                }
+                setBackgroundColor(backgroundColor)
+                setTextColor(context.getColor(R.color.background_gray_01))
+                text = context.getString(R.string.festival_detail_tv_dday_format, dDay.toString())
+            }
+
             else -> {
+                setBackgroundColor(Color.TRANSPARENT)
+                setTextColor(context.getColor(R.color.background_gray_01))
+                background = AppCompatResources.getDrawable(
+                    context,
+                    R.drawable.bg_festival_detail_dday_end,
+                )
                 text = context.getString(R.string.festival_detail_tv_dday_end)
             }
         }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
@@ -8,9 +8,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentTransaction
+import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
+import com.festago.festago.presentation.R
 import com.festago.festago.presentation.databinding.FragmentFestivalDetailBinding
 import com.festago.festago.presentation.databinding.ItemMediaBinding
+import com.festago.festago.presentation.ui.artistdetail.ArtistDetailFragment
 import com.festago.festago.presentation.ui.festivaldetail.adapter.stage.StageListAdapter
 import com.festago.festago.presentation.ui.festivaldetail.uiState.FestivalDetailUiState
 import com.festago.festago.presentation.util.repeatOnStarted
@@ -61,6 +65,11 @@ class FestivalDetailFragment : Fragment() {
                 updateUi(it)
             }
         }
+        repeatOnStarted(viewLifecycleOwner) {
+            vm.event.collect {
+                handleEvent(it)
+            }
+        }
     }
 
     private fun updateUi(uiState: FestivalDetailUiState) {
@@ -91,6 +100,18 @@ class FestivalDetailFragment : Fragment() {
         val intent = Intent(Intent.ACTION_VIEW)
         intent.data = Uri.parse(url)
         startActivity(intent)
+    }
+
+    private fun handleEvent(event: FestivalDetailEvent) {
+        when (event) {
+            is FestivalDetailEvent.ShowArtistDetail -> {
+                requireActivity().supportFragmentManager.commit {
+                    add(R.id.fcvHomeContainer, ArtistDetailFragment.newInstance(event.artistId))
+                    setTransition(FragmentTransaction.TRANSIT_FRAGMENT_MATCH_ACTIVITY_OPEN)
+                    addToBackStack(null)
+                }
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
@@ -1,6 +1,7 @@
 package com.festago.festago.presentation.ui.festivaldetail
 
 import android.content.Intent
+import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -74,6 +75,7 @@ class FestivalDetailFragment : Fragment() {
 
     private fun handleSuccess(uiState: FestivalDetailUiState.Success) {
         binding.successUiState = uiState
+        binding.ivFestivalBackground.setColorFilter(Color.parseColor("#66000000"))
         adapter.submitList(uiState.stages)
         binding.llcFestivalSocialMedia.removeAllViews()
         uiState.festival.socialMedias.forEach { media ->

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
@@ -81,9 +81,8 @@ class FestivalDetailFragment : Fragment() {
         uiState.festival.socialMedias.forEach { media ->
             with(ItemMediaBinding.inflate(layoutInflater, binding.llcFestivalSocialMedia, false)) {
                 imageUrl = media.logoUrl
-                name = media.name
-                clMedia.setOnClickListener { startBrowser(media.url) }
-                binding.llcFestivalSocialMedia.addView(clMedia)
+                ivImage.setOnClickListener { startBrowser(media.url) }
+                binding.llcFestivalSocialMedia.addView(ivImage)
             }
         }
     }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentTransaction
 import androidx.fragment.app.commit
@@ -19,6 +20,7 @@ import com.festago.festago.presentation.ui.festivaldetail.adapter.stage.StageLis
 import com.festago.festago.presentation.ui.festivaldetail.uiState.FestivalDetailUiState
 import com.festago.festago.presentation.util.repeatOnStarted
 import dagger.hilt.android.AndroidEntryPoint
+import java.time.LocalDate
 
 @AndroidEntryPoint
 class FestivalDetailFragment : Fragment() {
@@ -84,6 +86,7 @@ class FestivalDetailFragment : Fragment() {
 
     private fun handleSuccess(uiState: FestivalDetailUiState.Success) {
         binding.successUiState = uiState
+        binding.tvFestivalDDay.setFestivalDDay(uiState.festival.startDate, uiState.festival.endDate)
         binding.ivFestivalBackground.setColorFilter(Color.parseColor("#66000000"))
         adapter.submitList(uiState.stages)
         binding.llcFestivalSocialMedia.removeAllViews()
@@ -92,6 +95,25 @@ class FestivalDetailFragment : Fragment() {
                 imageUrl = media.logoUrl
                 ivImage.setOnClickListener { startBrowser(media.url) }
                 binding.llcFestivalSocialMedia.addView(ivImage)
+            }
+        }
+    }
+
+    private fun TextView.setFestivalDDay(startDate: LocalDate, endDate: LocalDate) {
+        when {
+            LocalDate.now() in startDate..endDate -> {
+                text = context.getString(R.string.festival_detail_tv_dday)
+            }
+
+            LocalDate.now() < startDate -> {
+                text = context.getString(
+                    R.string.festival_detail_tv_dday_format,
+                    (LocalDate.now().toEpochDay() - startDate.toEpochDay()).toString(),
+                )
+            }
+
+            else -> {
+                text = context.getString(R.string.festival_detail_tv_dday_end)
             }
         }
     }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
@@ -1,0 +1,48 @@
+package com.festago.festago.presentation.ui.festivaldetail
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.festago.festago.presentation.databinding.FragmentFestivalDetailBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class FestivalDetailFragment : Fragment() {
+
+    private var _binding: FragmentFestivalDetailBinding? = null
+    private val binding get() = _binding!!
+
+    private val vm: FestivalDetailViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentFestivalDetailBinding.inflate(inflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val id = requireArguments().getLong(KEY_ID)
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+
+    companion object {
+        private const val KEY_ID = "ID"
+
+        fun newInstance(id: Long) = FestivalDetailFragment().apply {
+            arguments = Bundle().apply {
+                putLong(KEY_ID, id)
+            }
+        }
+    }
+}

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailFragment.kt
@@ -79,8 +79,9 @@ class FestivalDetailFragment : Fragment() {
         uiState.festival.socialMedias.forEach { media ->
             with(ItemMediaBinding.inflate(layoutInflater, binding.llcFestivalSocialMedia, false)) {
                 imageUrl = media.logoUrl
-                ivImage.setOnClickListener { startBrowser(media.url) }
-                binding.llcFestivalSocialMedia.addView(ivImage)
+                name = media.name
+                clMedia.setOnClickListener { startBrowser(media.url) }
+                binding.llcFestivalSocialMedia.addView(clMedia)
             }
         }
     }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailViewModel.kt
@@ -13,8 +13,11 @@ import com.festago.festago.presentation.ui.festivaldetail.uiState.FestivalDetail
 import com.festago.festago.presentation.ui.festivaldetail.uiState.FestivalUiState
 import com.festago.festago.presentation.ui.festivaldetail.uiState.StageItemUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -24,8 +27,12 @@ class FestivalDetailViewModel @Inject constructor(
     private val festivalRepository: FestivalRepository,
     private val analyticsHelper: AnalyticsHelper,
 ) : ViewModel() {
+
     private val _uiState = MutableStateFlow<FestivalDetailUiState>(FestivalDetailUiState.Loading)
     val uiState: StateFlow<FestivalDetailUiState> = _uiState.asStateFlow()
+
+    private val _event = MutableSharedFlow<FestivalDetailEvent>()
+    val event: SharedFlow<FestivalDetailEvent> = _event.asSharedFlow()
 
     fun loadFestivalDetail(festivalId: Long) {
         viewModelScope.launch {
@@ -65,7 +72,14 @@ class FestivalDetailViewModel @Inject constructor(
         id = id,
         name = name,
         imageUrl = imageUrl,
+        onArtistDetail = ::showArtistDetail,
     )
+
+    private fun showArtistDetail(artistId: Long) {
+        viewModelScope.launch {
+            _event.emit(FestivalDetailEvent.ShowArtistDetail(artistId))
+        }
+    }
 
     companion object {
         private const val KEY_LOAD_FESTIVAL_DETAIL = "KEY_LOAD_FESTIVAL_DETAIL"

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailViewModel.kt
@@ -1,5 +1,65 @@
 package com.festago.festago.presentation.ui.festivaldetail
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.festago.festago.common.analytics.AnalyticsHelper
+import com.festago.festago.common.analytics.logNetworkFailure
+import com.festago.festago.domain.model.festival.FestivalDetail
+import com.festago.festago.domain.model.stage.Stage
+import com.festago.festago.domain.repository.FestivalRepository
+import com.festago.festago.presentation.ui.festivaldetail.uiState.FestivalDetailUiState
+import com.festago.festago.presentation.ui.festivaldetail.uiState.FestivalUiState
+import com.festago.festago.presentation.ui.festivaldetail.uiState.StageItemUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class FestivalDetailViewModel : ViewModel()
+@HiltViewModel
+class FestivalDetailViewModel @Inject constructor(
+    private val festivalRepository: FestivalRepository,
+    private val analyticsHelper: AnalyticsHelper,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow<FestivalDetailUiState>(FestivalDetailUiState.Loading)
+    val uiState: StateFlow<FestivalDetailUiState> = _uiState.asStateFlow()
+
+    fun loadFestivalDetail(festivalId: Long) {
+        viewModelScope.launch {
+            festivalRepository.loadFestivalDetail(festivalId).onSuccess { festivalDetail ->
+                _uiState.value = festivalDetail.toSuccessUiState()
+            }.onFailure {
+                _uiState.value = FestivalDetailUiState.Error
+                analyticsHelper.logNetworkFailure(
+                    key = KEY_LOAD_FESTIVAL_DETAIL,
+                    value = it.message.toString(),
+                )
+            }
+        }
+    }
+
+    private fun FestivalDetail.toSuccessUiState() =
+        FestivalDetailUiState.Success(
+            FestivalUiState(
+                id = id,
+                name = name,
+                startDate = startDate,
+                endDate = endDate,
+                posterImageUrl = posterImageUrl,
+                school = school,
+                socialMedias = socialMedias,
+            ),
+            stages = stages.map { it.toUiState() },
+        )
+
+    private fun Stage.toUiState() = StageItemUiState(
+        id = id,
+        startDateTime = startDateTime,
+        artists = artists,
+    )
+
+    companion object {
+        private const val KEY_LOAD_FESTIVAL_DETAIL = "KEY_LOAD_FESTIVAL_DETAIL"
+    }
+}

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailViewModel.kt
@@ -4,9 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.festago.festago.common.analytics.AnalyticsHelper
 import com.festago.festago.common.analytics.logNetworkFailure
+import com.festago.festago.domain.model.artist.Artist
 import com.festago.festago.domain.model.festival.FestivalDetail
 import com.festago.festago.domain.model.stage.Stage
 import com.festago.festago.domain.repository.FestivalRepository
+import com.festago.festago.presentation.ui.festivaldetail.uiState.ArtistItemUiState
 import com.festago.festago.presentation.ui.festivaldetail.uiState.FestivalDetailUiState
 import com.festago.festago.presentation.ui.festivaldetail.uiState.FestivalUiState
 import com.festago.festago.presentation.ui.festivaldetail.uiState.StageItemUiState
@@ -56,7 +58,13 @@ class FestivalDetailViewModel @Inject constructor(
     private fun Stage.toUiState() = StageItemUiState(
         id = id,
         startDateTime = startDateTime,
-        artists = artists,
+        artists = artists.map { it.toUiState() },
+    )
+
+    private fun Artist.toUiState() = ArtistItemUiState(
+        id = id,
+        name = name,
+        imageUrl = imageUrl,
     )
 
     companion object {

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailViewModel.kt
@@ -1,0 +1,5 @@
+package com.festago.festago.presentation.ui.festivaldetail
+
+import androidx.lifecycle.ViewModel
+
+class FestivalDetailViewModel : ViewModel()

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/adapter/artist/ArtistAdapter.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/adapter/artist/ArtistAdapter.kt
@@ -1,0 +1,35 @@
+package com.festago.festago.presentation.ui.festivaldetail.adapter.artist
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.festago.festago.presentation.ui.festivaldetail.uiState.ArtistItemUiState
+
+class ArtistAdapter : ListAdapter<ArtistItemUiState, ArtistViewHolder>(diffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ArtistViewHolder {
+        return ArtistViewHolder.of(parent)
+    }
+
+    override fun onBindViewHolder(holder: ArtistViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    companion object {
+        private val diffUtil = object : DiffUtil.ItemCallback<ArtistItemUiState>() {
+            override fun areItemsTheSame(
+                oldItem: ArtistItemUiState,
+                newItem: ArtistItemUiState,
+            ): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(
+                oldItem: ArtistItemUiState,
+                newItem: ArtistItemUiState,
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/adapter/artist/ArtistViewHolder.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/adapter/artist/ArtistViewHolder.kt
@@ -1,0 +1,27 @@
+package com.festago.festago.presentation.ui.festivaldetail.adapter.artist
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.festago.festago.presentation.databinding.ItemFestivalDetailStageArtistBinding
+import com.festago.festago.presentation.ui.festivaldetail.uiState.ArtistItemUiState
+
+class ArtistViewHolder(
+    private val binding: ItemFestivalDetailStageArtistBinding,
+) : RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(item: ArtistItemUiState) {
+        binding.artist = item
+    }
+
+    companion object {
+        fun of(parent: ViewGroup): ArtistViewHolder {
+            val binding = ItemFestivalDetailStageArtistBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false,
+            )
+            return ArtistViewHolder(binding)
+        }
+    }
+}

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/adapter/artist/ArtistViewHolder.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/adapter/artist/ArtistViewHolder.kt
@@ -11,7 +11,7 @@ class ArtistViewHolder(
 ) : RecyclerView.ViewHolder(binding.root) {
 
     fun bind(item: ArtistItemUiState) {
-        binding.artist = item
+        binding.item = item
     }
 
     companion object {

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/adapter/stage/StageListAdapter.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/adapter/stage/StageListAdapter.kt
@@ -1,0 +1,35 @@
+package com.festago.festago.presentation.ui.festivaldetail.adapter.stage
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.festago.festago.presentation.ui.festivaldetail.uiState.StageItemUiState
+
+class StageListAdapter : ListAdapter<StageItemUiState, StageViewHolder>(diffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StageViewHolder {
+        return StageViewHolder.of(parent)
+    }
+
+    override fun onBindViewHolder(holder: StageViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<StageItemUiState>() {
+            override fun areItemsTheSame(
+                oldItem: StageItemUiState,
+                newItem: StageItemUiState,
+            ): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(
+                oldItem: StageItemUiState,
+                newItem: StageItemUiState,
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/adapter/stage/StageViewHolder.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/adapter/stage/StageViewHolder.kt
@@ -1,0 +1,35 @@
+package com.festago.festago.presentation.ui.festivaldetail.adapter.stage
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.festago.festago.presentation.databinding.ItemFestivalDetailStageBinding
+import com.festago.festago.presentation.ui.festivaldetail.adapter.artist.ArtistAdapter
+import com.festago.festago.presentation.ui.festivaldetail.uiState.StageItemUiState
+
+class StageViewHolder(
+    private val binding: ItemFestivalDetailStageBinding,
+) : RecyclerView.ViewHolder(binding.root) {
+
+    private val artistAdapter = ArtistAdapter()
+
+    init {
+        binding.rvStageArtists.adapter = artistAdapter
+    }
+
+    fun bind(item: StageItemUiState) {
+        binding.item = item
+        artistAdapter.submitList(item.artists)
+    }
+
+    companion object {
+        fun of(parent: ViewGroup): StageViewHolder {
+            val binding = ItemFestivalDetailStageBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false,
+            )
+            return StageViewHolder(binding)
+        }
+    }
+}

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/uiState/ArtistItemUiState.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/uiState/ArtistItemUiState.kt
@@ -4,4 +4,5 @@ data class ArtistItemUiState(
     val id: Long,
     val name: String,
     val imageUrl: String,
+    val onArtistDetail: (artistId: Long) -> Unit,
 )

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/uiState/ArtistItemUiState.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/uiState/ArtistItemUiState.kt
@@ -1,0 +1,7 @@
+package com.festago.festago.presentation.ui.festivaldetail.uiState
+
+data class ArtistItemUiState(
+    val id: Long,
+    val name: String,
+    val imageUrl: String,
+)

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/uiState/FestivalDetailUiState.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/uiState/FestivalDetailUiState.kt
@@ -1,0 +1,16 @@
+package com.festago.festago.presentation.ui.festivaldetail.uiState
+
+interface FestivalDetailUiState {
+    object Loading : FestivalDetailUiState
+
+    data class Success(
+        val festival: FestivalUiState,
+        val stages: List<StageItemUiState>,
+    ) : FestivalDetailUiState
+
+    object Error : FestivalDetailUiState
+
+    val shouldShowSuccess get() = this is Success
+    val shouldShowLoading get() = this is Loading
+    val shouldShowError get() = this is Error
+}

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/uiState/FestivalUiState.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/uiState/FestivalUiState.kt
@@ -1,0 +1,15 @@
+package com.festago.festago.presentation.ui.festivaldetail.uiState
+
+import com.festago.festago.domain.model.school.School
+import com.festago.festago.domain.model.social.SocialMedia
+import java.time.LocalDate
+
+data class FestivalUiState(
+    val id: Long,
+    val name: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val posterImageUrl: String,
+    val school: School,
+    val socialMedias: List<SocialMedia>,
+)

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/uiState/StageItemUiState.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/uiState/StageItemUiState.kt
@@ -1,10 +1,9 @@
 package com.festago.festago.presentation.ui.festivaldetail.uiState
 
-import com.festago.festago.domain.model.artist.Artist
 import java.time.LocalDateTime
 
 data class StageItemUiState(
     val id: Long,
     val startDateTime: LocalDateTime,
-    val artists: List<Artist>,
+    val artists: List<ArtistItemUiState>,
 )

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/uiState/StageItemUiState.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/uiState/StageItemUiState.kt
@@ -1,0 +1,10 @@
+package com.festago.festago.presentation.ui.festivaldetail.uiState
+
+import com.festago.festago.domain.model.artist.Artist
+import java.time.LocalDateTime
+
+data class StageItemUiState(
+    val id: Long,
+    val startDateTime: LocalDateTime,
+    val artists: List<Artist>,
+)

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/HomeActivity.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/HomeActivity.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.Fragment
 import com.festago.festago.presentation.R
 import com.festago.festago.presentation.databinding.ActivityHomeBinding
 import com.festago.festago.presentation.ui.artistdetail.ArtistDetailFragment
+import com.festago.festago.presentation.ui.festivaldetail.FestivalDetailFragment
 import com.festago.festago.presentation.ui.home.bookmarklist.BookmarkListFragment
 import com.festago.festago.presentation.ui.home.festivallist.FestivalListFragment
 import com.festago.festago.presentation.ui.home.mypage.MyPageFragment
@@ -63,12 +64,14 @@ class HomeActivity : AppCompatActivity() {
 
     private fun initBackStackListener() {
         supportFragmentManager.addOnBackStackChangedListener {
-            val fragment = supportFragmentManager.findFragmentById(R.id.fcvHomeContainer)
-            if (fragment is ArtistDetailFragment) {
-                setStatusBarMode(isLight = false, backgroundColor = Color.TRANSPARENT)
-            } else {
-                setStatusBarMode(isLight = true, backgroundColor = Color.TRANSPARENT)
+            val isLight = when (supportFragmentManager.findFragmentById(R.id.fcvHomeContainer)) {
+                is ArtistDetailFragment,
+                is FestivalDetailFragment,
+                -> true
+
+                else -> false
             }
+            setStatusBarMode(isLight = isLight, backgroundColor = Color.TRANSPARENT)
         }
     }
 
@@ -109,7 +112,8 @@ class HomeActivity : AppCompatActivity() {
         var targetFragment = supportFragmentManager.findFragmentByTag(tag)
 
         if (targetFragment == null) {
-            targetFragment = supportFragmentManager.fragmentFactory.instantiate(classLoader, tag)
+            targetFragment =
+                supportFragmentManager.fragmentFactory.instantiate(classLoader, tag)
             fragmentTransaction.add(R.id.fcvHomeContainer, targetFragment, tag)
         } else {
             fragmentTransaction.show(targetFragment)

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/HomeActivity.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/HomeActivity.kt
@@ -19,6 +19,7 @@ import com.festago.festago.presentation.ui.home.bookmarklist.BookmarkListFragmen
 import com.festago.festago.presentation.ui.home.festivallist.FestivalListFragment
 import com.festago.festago.presentation.ui.home.mypage.MyPageFragment
 import com.festago.festago.presentation.ui.home.ticketlist.TicketListFragment
+import com.festago.festago.presentation.ui.schooldetail.SchoolDetailFragment
 import com.festago.festago.presentation.util.setOnApplyWindowInsetsCompatListener
 import com.festago.festago.presentation.util.setStatusBarMode
 import dagger.hilt.android.AndroidEntryPoint
@@ -67,6 +68,7 @@ class HomeActivity : AppCompatActivity() {
             val isLight = when (supportFragmentManager.findFragmentById(R.id.fcvHomeContainer)) {
                 is ArtistDetailFragment,
                 is FestivalDetailFragment,
+                is SchoolDetailFragment,
                 -> false
 
                 else -> true

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/HomeActivity.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/HomeActivity.kt
@@ -67,9 +67,9 @@ class HomeActivity : AppCompatActivity() {
             val isLight = when (supportFragmentManager.findFragmentById(R.id.fcvHomeContainer)) {
                 is ArtistDetailFragment,
                 is FestivalDetailFragment,
-                -> true
+                -> false
 
-                else -> false
+                else -> true
             }
             setStatusBarMode(isLight = isLight, backgroundColor = Color.TRANSPARENT)
         }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListEvent.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListEvent.kt
@@ -1,0 +1,5 @@
+package com.festago.festago.presentation.ui.home.festivallist
+
+sealed interface FestivalListEvent {
+    class ShowFestivalDetail(val festivalId: Long) : FestivalListEvent
+}

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
@@ -165,7 +165,7 @@ class FestivalListFragment : Fragment() {
 
     private fun showSchoolDetail() {
         activity?.supportFragmentManager!!.beginTransaction()
-            .replace(R.id.fcvHomeContainer, SchoolDetailFragment.newInstance(0))
+            .add(R.id.fcvHomeContainer, SchoolDetailFragment.newInstance(0))
             .addToBackStack(null)
             .commit()
     }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.festago.festago.presentation.R
 import com.festago.festago.presentation.databinding.FragmentFestivalListBinding
 import com.festago.festago.presentation.ui.artistdetail.ArtistDetailFragment
+import com.festago.festago.presentation.ui.festivaldetail.FestivalDetailFragment
 import com.festago.festago.presentation.ui.home.festivallist.festival.FestivalListAdapter
 import com.festago.festago.presentation.ui.home.festivallist.uistate.FestivalFilterUiState
 import com.festago.festago.presentation.ui.home.festivallist.uistate.FestivalListUiState
@@ -61,6 +62,11 @@ class FestivalListFragment : Fragment() {
             vm.uiState.collect {
                 binding.uiState = it
                 updateUi(it)
+            }
+        }
+        repeatOnStarted(viewLifecycleOwner) {
+            vm.event.collect {
+                handleEvent(it)
             }
         }
     }
@@ -126,6 +132,18 @@ class FestivalListFragment : Fragment() {
             -> Unit
 
             is FestivalListUiState.Success -> handleSuccess(uiState)
+        }
+    }
+
+    private fun handleEvent(event: FestivalListEvent) {
+        when (event) {
+            is FestivalListEvent.ShowFestivalDetail -> {
+                requireActivity().supportFragmentManager.commit {
+                    add(R.id.fcvHomeContainer, FestivalDetailFragment.newInstance(event.festivalId))
+                    setTransition(FragmentTransaction.TRANSIT_FRAGMENT_MATCH_ACTIVITY_OPEN)
+                    addToBackStack(null)
+                }
+            }
         }
     }
 

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListViewModel.kt
@@ -15,8 +15,11 @@ import com.festago.festago.presentation.ui.home.festivallist.uistate.PopularFest
 import com.festago.festago.presentation.ui.home.festivallist.uistate.SchoolUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -29,6 +32,9 @@ class FestivalListViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow<FestivalListUiState>(FestivalListUiState.Loading)
     val uiState: StateFlow<FestivalListUiState> = _uiState.asStateFlow()
+
+    private val _event = MutableSharedFlow<FestivalListEvent>()
+    val event: SharedFlow<FestivalListEvent> = _event.asSharedFlow()
 
     private var festivalFilter: FestivalFilter = FestivalFilter.PROGRESS
 
@@ -82,7 +88,14 @@ class FestivalListViewModel @Inject constructor(
         artists = artists.map { artist ->
             ArtistUiState(artist.id, artist.name, artist.imageUrl)
         },
+        ::showFestivalDetail,
     )
+
+    private fun showFestivalDetail(festivalId: Long) {
+        viewModelScope.launch {
+            _event.emit(FestivalListEvent.ShowFestivalDetail(festivalId))
+        }
+    }
 
     companion object {
         private const val KEY_LOAD_FESTIVAL = "KEY_LOAD_FESTIVAL"

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/uistate/FestivalItemUiState.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/uistate/FestivalItemUiState.kt
@@ -10,4 +10,5 @@ data class FestivalItemUiState(
     val imageUrl: String,
     val schoolUiState: SchoolUiState,
     val artists: List<ArtistUiState>,
+    val onFestivalDetail: (festivalId: Long) -> Unit,
 )

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailFragment.kt
@@ -80,8 +80,9 @@ class SchoolDetailFragment : Fragment() {
         uiState.schoolInfo.socialMedia.forEach { media ->
             with(ItemMediaBinding.inflate(layoutInflater, binding.llcSchoolSocialMedia, false)) {
                 imageUrl = media.logoUrl
-                ivImage.setOnClickListener { startBrowser(media.url) }
-                binding.llcSchoolSocialMedia.addView(ivImage)
+                name = media.name
+                clMedia.setOnClickListener { startBrowser(media.url) }
+                binding.llcSchoolSocialMedia.addView(clMedia)
             }
         }
     }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailFragment.kt
@@ -28,7 +28,7 @@ class SchoolDetailFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentSchoolDetailBinding.inflate(inflater)
         return binding.root
@@ -80,9 +80,8 @@ class SchoolDetailFragment : Fragment() {
         uiState.schoolInfo.socialMedia.forEach { media ->
             with(ItemMediaBinding.inflate(layoutInflater, binding.llcSchoolSocialMedia, false)) {
                 imageUrl = media.logoUrl
-                name = media.name
-                clMedia.setOnClickListener { startBrowser(media.url) }
-                binding.llcSchoolSocialMedia.addView(clMedia)
+                ivImage.setOnClickListener { startBrowser(media.url) }
+                binding.llcSchoolSocialMedia.addView(ivImage)
             }
         }
     }

--- a/android/festago/presentation/src/main/res/drawable/bg_festival_detail_dday_end.xml
+++ b/android/festago/presentation/src/main/res/drawable/bg_festival_detail_dday_end.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" >
+    <stroke
+        android:color="@color/background_gray_01"
+        android:width="1dp" />
+    <solid
+        android:color="@color/transparent" />
+</shape>

--- a/android/festago/presentation/src/main/res/layout/fragment_artist_detail.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_artist_detail.xml
@@ -15,6 +15,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/background_gray_01"
+        android:clickable="true"
         android:orientation="vertical"
         app:layout_collapseMode="parallax"
         app:layout_collapseParallaxMultiplier="0.0">
@@ -72,9 +73,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:adjustViewBounds="true"
+                android:contentDescription="@null"
                 android:scaleType="centerCrop"
-                android:src="@drawable/ic_launcher_foreground"
-                android:contentDescription="@null" />
+                android:src="@drawable/ic_launcher_foreground" />
         </androidx.cardview.widget.CardView>
 
         <androidx.cardview.widget.CardView

--- a/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.festivaldetail.FestivalDetailFragment">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="Hello" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
@@ -1,20 +1,174 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
+        <import type="java.time.LocalDate" />
+
+        <import type="java.time.format.DateTimeFormatter" />
+
+        <variable
+            name="uiState"
+            type="com.festago.festago.presentation.ui.festivaldetail.uiState.FestivalDetailUiState" />
+
+        <variable
+            name="successUiState"
+            type="com.festago.festago.presentation.ui.festivaldetail.uiState.FestivalDetailUiState.Success" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/background_gray_01"
         tools:context=".ui.festivaldetail.FestivalDetailFragment">
 
-        <TextView
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/clFestivalInfo"
+            visibility="@{uiState.shouldShowSuccess}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@color/background_gray_01"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/ivFestivalBackground"
+                imageUrl="@{successUiState.festival.posterImageUrl}"
+                android:layout_width="match_parent"
+                android:layout_height="136dp"
+                android:scaleType="centerCrop"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:src="@drawable/ic_launcher_background" />
+
+            <ImageView
+                android:id="@+id/ivBack"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="16dp"
+                android:src="@drawable/ic_back"
+                app:layout_constraintBottom_toBottomOf="@id/ivFestivalBackground"
+                app:layout_constraintStart_toStartOf="@id/ivFestivalBackground"
+                app:layout_constraintTop_toTopOf="@id/ivFestivalBackground" />
+
+            <ImageView
+                android:id="@+id/ivFestivalPoster"
+                imageUrl="@{successUiState.festival.posterImageUrl}"
+                android:layout_width="80dp"
+                android:layout_height="80dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="-40dp"
+                android:scaleType="centerCrop"
+                app:layout_constraintDimensionRatio="1:1"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/ivFestivalBackground"
+                tools:src="@drawable/ic_launcher_foreground" />
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/cvBookmark"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                app:cardBackgroundColor="@color/background_gray_02"
+                app:cardCornerRadius="1000dp"
+                app:layout_constraintBottom_toBottomOf="@id/ivFestivalPoster"
+                app:layout_constraintEnd_toEndOf="@id/ivFestivalPoster"
+                app:layout_constraintStart_toEndOf="@id/ivFestivalPoster">
+
+                <ImageView
+                    android:id="@+id/ivBookmark"
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_gravity="center"
+                    android:adjustViewBounds="true"
+                    android:contentDescription="@null"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/ic_bookmark"
+                    app:tint="@color/tint_bookmark" />
+            </androidx.cardview.widget.CardView>
+
+            <TextView
+                android:id="@+id/tvFestivalName"
+                style="@style/H1Bold20Lh20"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="30dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:gravity="start"
+                android:maxLines="2"
+                android:text="@{successUiState.festival.school.name + successUiState.festival.name}"
+                android:textColor="@color/contents_gray_07"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/ivFestivalPoster"
+                app:layout_constraintTop_toBottomOf="@id/ivFestivalBackground"
+                tools:text="홍익대학교 와우페스티벌 2023" />
+
+            <TextView
+                android:id="@+id/tvFestivalSchedule"
+                style="@style/B1Medium16Lh20"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@{@string/festival_list_tv_date_range_format(successUiState.festival.startDate.format(DateTimeFormatter.ofPattern(@string/festival_list_tv_date_format)),successUiState.festival.endDate.format(DateTimeFormatter.ofPattern(@string/festival_list_tv_date_format)))}"
+                android:textColor="@color/contents_gray_07"
+                app:layout_constraintStart_toStartOf="@+id/tvFestivalName"
+                app:layout_constraintTop_toBottomOf="@+id/tvFestivalName"
+                tools:text="21.10.10 ~ 21.10.12" />
+
+            <HorizontalScrollView
+                android:id="@+id/hsvFestivalSocialMedia"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="16dp"
+                android:scrollbars="none"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/mdDivider"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@id/tvFestivalSchedule"
+                app:layout_constraintTop_toBottomOf="@id/tvFestivalSchedule"
+                app:singleLine="true">
+
+                <androidx.appcompat.widget.LinearLayoutCompat
+                    android:id="@+id/llcFestivalSocialMedia"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal" />
+            </HorizontalScrollView>
+
+            <com.google.android.material.divider.MaterialDivider
+                android:id="@+id/mdDivider"
+                android:layout_width="match_parent"
+                android:layout_height="0.2dp"
+                app:dividerColor="@color/background_gray_03"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvStageList"
+            visibility="@{uiState.shouldShowSuccess}"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:text="Hello" />
+            android:layout_height="0dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:orientation="vertical"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/clFestivalInfo"
+            tools:listitem="@layout/item_festival_list_festival" />
+
+        <ProgressBar
+            android:id="@+id/pbLoading"
+            visibility="@{uiState.shouldShowLoading}"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
@@ -70,28 +70,20 @@
                 app:layout_constraintTop_toBottomOf="@id/ivFestivalBackground"
                 tools:src="@drawable/ic_launcher_foreground" />
 
-            <androidx.cardview.widget.CardView
-                android:id="@+id/cvFestivalDDay"
-                android:layout_width="68dp"
+            <TextView
+                android:id="@+id/tvFestivalDDay"
+                style="@style/H5Bold14Lh16"
+                android:layout_width="56dp"
                 android:layout_height="24dp"
+                android:layout_gravity="center"
                 android:layout_marginStart="30dp"
                 android:layout_marginBottom="8dp"
-                app:cardBackgroundColor="@color/secondary_pink_01"
-                app:cardCornerRadius="1000dp"
+                android:background="@color/secondary_pink_01"
+                android:gravity="center"
+                android:textColor="@color/background_gray_01"
                 app:layout_constraintBottom_toBottomOf="@+id/ivFestivalBackground"
-                app:layout_constraintStart_toEndOf="@+id/ivFestivalPoster">
-
-                <TextView
-                    android:id="@+id/tvFestivalDDay"
-                    style="@style/H5Bold14Lh16"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:textColor="@color/background_gray_01"
-                    tools:text="D-DAY" />
-
-            </androidx.cardview.widget.CardView>
-
+                app:layout_constraintStart_toEndOf="@+id/ivFestivalPoster"
+                tools:text="D-DAY" />
 
             <androidx.cardview.widget.CardView
                 android:id="@+id/cvBookmark"
@@ -124,6 +116,7 @@
                 android:layout_marginTop="8dp"
                 android:layout_marginEnd="16dp"
                 android:gravity="start"
+                android:includeFontPadding="false"
                 android:maxLines="2"
                 android:text="@{successUiState.festival.name}"
                 android:textColor="@color/contents_gray_07"

--- a/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
@@ -179,7 +179,6 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginHorizontal="16dp"
-            android:layout_marginTop="8dp"
             android:layout_marginBottom="8dp"
             android:orientation="vertical"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"

--- a/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
@@ -39,6 +39,7 @@
                 imageUrl="@{successUiState.festival.posterImageUrl}"
                 android:layout_width="match_parent"
                 android:layout_height="136dp"
+                android:importantForAccessibility="no"
                 android:scaleType="centerCrop"
                 app:layout_constraintTop_toTopOf="parent"
                 tools:src="@drawable/ic_launcher_background" />
@@ -48,6 +49,7 @@
                 android:layout_width="24dp"
                 android:layout_height="24dp"
                 android:layout_marginStart="16dp"
+                android:importantForAccessibility="no"
                 android:src="@drawable/ic_back"
                 app:layout_constraintBottom_toBottomOf="@id/ivFestivalBackground"
                 app:layout_constraintStart_toStartOf="@id/ivFestivalBackground"
@@ -60,6 +62,7 @@
                 android:layout_height="80dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="-40dp"
+                android:importantForAccessibility="no"
                 android:scaleType="centerCrop"
                 app:layout_constraintDimensionRatio="1:1"
                 app:layout_constraintStart_toStartOf="parent"
@@ -152,13 +155,14 @@
             visibility="@{uiState.shouldShowSuccess}"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:layout_marginHorizontal="16dp"
             android:layout_marginTop="8dp"
             android:layout_marginBottom="8dp"
             android:orientation="vertical"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/clFestivalInfo"
-            tools:listitem="@layout/item_festival_list_festival" />
+            tools:listitem="@layout/item_festival_detail_stage" />
 
         <ProgressBar
             android:id="@+id/pbLoading"

--- a/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
@@ -22,6 +22,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/background_gray_01"
+        android:clickable="true"
         tools:context=".ui.festivaldetail.FestivalDetailFragment">
 
         <androidx.constraintlayout.widget.ConstraintLayout

--- a/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
@@ -93,7 +93,7 @@
 
             <TextView
                 android:id="@+id/tvFestivalName"
-                style="@style/H1Bold20Lh20"
+                style="@style/H2Bold20Lh24"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="30dp"

--- a/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
@@ -101,7 +101,7 @@
                 android:layout_marginEnd="16dp"
                 android:gravity="start"
                 android:maxLines="2"
-                android:text="@{successUiState.festival.school.name + successUiState.festival.name}"
+                android:text="@{successUiState.festival.name}"
                 android:textColor="@color/contents_gray_07"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/ivFestivalPoster"

--- a/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_festival_detail.xml
@@ -70,6 +70,29 @@
                 tools:src="@drawable/ic_launcher_foreground" />
 
             <androidx.cardview.widget.CardView
+                android:id="@+id/cvFestivalDDay"
+                android:layout_width="68dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="30dp"
+                android:layout_marginBottom="8dp"
+                app:cardBackgroundColor="@color/secondary_pink_01"
+                app:cardCornerRadius="1000dp"
+                app:layout_constraintBottom_toBottomOf="@+id/ivFestivalBackground"
+                app:layout_constraintStart_toEndOf="@+id/ivFestivalPoster">
+
+                <TextView
+                    android:id="@+id/tvFestivalDDay"
+                    style="@style/H5Bold14Lh16"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:textColor="@color/background_gray_01"
+                    tools:text="D-DAY" />
+
+            </androidx.cardview.widget.CardView>
+
+
+            <androidx.cardview.widget.CardView
                 android:id="@+id/cvBookmark"
                 android:layout_width="28dp"
                 android:layout_height="28dp"

--- a/android/festago/presentation/src/main/res/layout/fragment_festival_list.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_festival_list.xml
@@ -13,6 +13,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clickable="true"
         tools:context=".ui.home.festivallist.FestivalListFragment">
 
         <androidx.constraintlayout.widget.ConstraintLayout

--- a/android/festago/presentation/src/main/res/layout/fragment_school_detail.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_school_detail.xml
@@ -18,6 +18,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/background_gray_01"
+        android:clickable="true"
         tools:context=".ui.home.festivallist.FestivalListFragment">
 
         <androidx.recyclerview.widget.RecyclerView

--- a/android/festago/presentation/src/main/res/layout/item_artist_detail_festival.xml
+++ b/android/festago/presentation/src/main/res/layout/item_artist_detail_festival.xml
@@ -45,9 +45,9 @@
             android:layout_width="56dp"
             android:layout_height="24dp"
             android:background="#FFFA1273"
-            android:visibility="@{LocalDate.now().compareTo(item.endDate) &lt;= 0 ? View.VISIBLE : View.GONE}"
             android:gravity="center"
             android:textColor="@color/background_gray_01"
+            android:visibility="@{LocalDate.now().compareTo(item.endDate) &lt;= 0 ? View.VISIBLE : View.GONE}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="D-1" />
@@ -70,14 +70,17 @@
         <TextView
             android:id="@+id/tvFestivalName"
             style="@style/H4Bold16Lh20"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
+            android:layout_marginHorizontal="12dp"
             android:layout_marginTop="10dp"
+            android:ellipsize="end"
+            android:maxLines="1"
             android:text="@{item.name}"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/ivFestivalImage"
             app:layout_constraintTop_toTopOf="@+id/ivFestivalImage"
-            tools:text="중앙대학교 청진난만" />
+            tools:text="중앙대학교 청진난만 중앙대학교 천진난만" />
 
         <TextView
             android:id="@+id/tvFestivalSchedule"

--- a/android/festago/presentation/src/main/res/layout/item_artist_detail_festival.xml
+++ b/android/festago/presentation/src/main/res/layout/item_artist_detail_festival.xml
@@ -13,7 +13,7 @@
 
         <variable
             name="item"
-            type="com.festago.festago.presentation.ui.artistdetail.uistate.StageUiState" />
+            type="com.festago.festago.presentation.ui.artistdetail.uistate.FestivalItemUiState" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/android/festago/presentation/src/main/res/layout/item_festival_detail_stage.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_detail_stage.xml
@@ -5,6 +5,10 @@
 
     <data>
 
+        <import type="java.time.LocalDate" />
+
+        <import type="java.time.format.DateTimeFormatter" />
+
         <variable
             name="item"
             type="com.festago.festago.presentation.ui.festivaldetail.uiState.StageItemUiState" />
@@ -21,6 +25,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
+            android:text="@{item.startDateTime.format(DateTimeFormatter.ofPattern(@string/festival_list_tv_date_format))}"
             android:textColor="@color/contents_gray_07"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
@@ -42,7 +47,6 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
-                android:layout_marginBottom="8dp"
                 android:orientation="horizontal"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/android/festago/presentation/src/main/res/layout/item_festival_detail_stage.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_detail_stage.xml
@@ -24,7 +24,7 @@
             style="@style/H3Bold18Lh20"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="16dp"
             android:text="@{item.startDateTime.format(DateTimeFormatter.ofPattern(@string/festival_list_tv_date_format))}"
             android:textColor="@color/contents_gray_07"
             app:layout_constraintStart_toStartOf="parent"

--- a/android/festago/presentation/src/main/res/layout/item_festival_detail_stage.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_detail_stage.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="item"
+            type="com.festago.festago.presentation.ui.festivaldetail.uiState.StageItemUiState" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_gray_01">
+
+        <TextView
+            android:id="@+id/tvStageDate"
+            style="@style/H3Bold18Lh20"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textColor="@color/contents_gray_07"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="24.05.15" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/clStageArtists"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:background="@color/background_gray_02"
+            android:paddingVertical="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tvStageDate">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvStageArtists"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginBottom="8dp"
+                android:orientation="horizontal"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:listitem="@layout/item_festival_detail_stage_artist" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/festago/presentation/src/main/res/layout/item_festival_detail_stage_artist.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_detail_stage_artist.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="artist"
+            type="com.festago.festago.presentation.ui.festivaldetail.uiState.ArtistItemUiState" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cvFestivalImage"
+            android:layout_width="66dp"
+            android:layout_height="66dp"
+            android:layout_marginHorizontal="8dp"
+            app:cardCornerRadius="1000dp"
+            app:cardElevation="0dp"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/ivFestivalImage"
+                imageUrl="@{artist.imageUrl}"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:importantForAccessibility="no"
+                android:scaleType="centerCrop"
+                tools:src="@drawable/ic_launcher_background" />
+
+        </androidx.cardview.widget.CardView>
+
+        <TextView
+            android:id="@+id/tvFestivalName"
+            style="@style/B3Medium14Lh14"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@{artist.name}"
+            android:textColor="@color/contents_gray_07"
+            app:layout_constraintEnd_toEndOf="@id/cvFestivalImage"
+            app:layout_constraintStart_toStartOf="@id/cvFestivalImage"
+            app:layout_constraintTop_toBottomOf="@id/cvFestivalImage"
+            tools:text="윤하" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/festago/presentation/src/main/res/layout/item_festival_detail_stage_artist.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_detail_stage_artist.xml
@@ -40,15 +40,19 @@
         <TextView
             android:id="@+id/tvFestivalName"
             style="@style/B3Medium14Lh14"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
+            android:ellipsize="end"
+            android:gravity="top|center"
+            android:maxLines="2"
+            android:minLines="2"
             android:text="@{artist.name}"
             android:textColor="@color/contents_gray_07"
-            app:layout_constraintEnd_toEndOf="@id/cvFestivalImage"
-            app:layout_constraintStart_toStartOf="@id/cvFestivalImage"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cvFestivalImage"
-            tools:text="윤하" />
+            tools:text="스트레이 키즈 스트레이 키즈 스트" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/festago/presentation/src/main/res/layout/item_festival_detail_stage_artist.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_detail_stage_artist.xml
@@ -6,7 +6,7 @@
     <data>
 
         <variable
-            name="artist"
+            name="item"
             type="com.festago.festago.presentation.ui.festivaldetail.uiState.ArtistItemUiState" />
     </data>
 
@@ -16,6 +16,7 @@
 
         <androidx.cardview.widget.CardView
             android:id="@+id/cvFestivalImage"
+            onSingleClick="@{()-> item.onArtistDetail.invoke(item.id) }"
             android:layout_width="66dp"
             android:layout_height="66dp"
             android:layout_marginHorizontal="8dp"
@@ -28,7 +29,7 @@
 
             <ImageView
                 android:id="@+id/ivFestivalImage"
-                imageUrl="@{artist.imageUrl}"
+                imageUrl="@{item.imageUrl}"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:importantForAccessibility="no"
@@ -47,7 +48,7 @@
             android:gravity="top|center"
             android:maxLines="2"
             android:minLines="2"
-            android:text="@{artist.name}"
+            android:text="@{item.name}"
             android:textColor="@color/contents_gray_07"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/android/festago/presentation/src/main/res/layout/item_festival_list_festival.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_list_festival.xml
@@ -17,12 +17,12 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        onSingleClick="@{()-> item.onFestivalDetail.invoke(item.id)}"
         android:layout_width="match_parent"
         android:layout_height="132dp"
         android:layout_marginHorizontal="16dp"
         android:layout_marginTop="16dp"
-        android:background="@drawable/bg_festival_list_festival"
-        android:onClick="@{() -> item.onFestivalDetail.invoke(item.id)}">
+        android:background="@drawable/bg_festival_list_festival">
 
 
         <ImageView

--- a/android/festago/presentation/src/main/res/layout/item_festival_list_festival.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_list_festival.xml
@@ -69,14 +69,17 @@
         <TextView
             android:id="@+id/tvFestivalName"
             style="@style/H4Bold16Lh20"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
+            android:layout_marginHorizontal="12dp"
             android:layout_marginTop="10dp"
+            android:ellipsize="end"
+            android:maxLines="1"
             android:text="@{item.name}"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/ivFestivalImage"
             app:layout_constraintTop_toTopOf="@+id/ivFestivalImage"
-            tools:text="중앙대학교 청진난만" />
+            tools:text="중앙대학교 청진난만 중앙대학교 천진난만" />
 
         <TextView
             android:id="@+id/tvFestivalSchedule"

--- a/android/festago/presentation/src/main/res/layout/item_festival_list_festival.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_list_festival.xml
@@ -22,8 +22,7 @@
         android:layout_marginHorizontal="16dp"
         android:layout_marginTop="16dp"
         android:background="@drawable/bg_festival_list_festival"
-        tools:layout_height="132dp"
-        tools:layout_width="328dp">
+        android:onClick="@{() -> item.onFestivalDetail.invoke(item.id)}">
 
 
         <ImageView
@@ -45,9 +44,9 @@
             android:layout_width="56dp"
             android:layout_height="24dp"
             android:background="#FFFA1273"
-            android:visibility="@{LocalDate.now().compareTo(item.endDate) &lt;= 0 ? View.VISIBLE : View.GONE}"
             android:gravity="center"
             android:textColor="@color/background_gray_01"
+            android:visibility="@{LocalDate.now().compareTo(item.endDate) &lt;= 0 ? View.VISIBLE : View.GONE}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="D-1" />

--- a/android/festago/presentation/src/main/res/layout/item_media.xml
+++ b/android/festago/presentation/src/main/res/layout/item_media.xml
@@ -1,49 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
         <variable
             name="imageUrl"
             type="String" />
-
-        <variable
-            name="name"
-            type="String" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/clMedia"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
-
-        <ImageView
-            android:id="@+id/ivMediaImage"
-            imageUrl="@{imageUrl}"
-            android:layout_width="20dp"
-            android:layout_height="20dp"
-            android:contentDescription="@null"
-            app:chipBackgroundColor="@color/transparent"
-            app:chipStrokeWidth="0dp"
-            app:chipSurfaceColor="@color/transparent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:src="@drawable/ic_launcher_background"/>
-
-        <TextView
-            android:id="@+id/tvMediaName"
-            style="@style/B2Medium14Lh20"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginEnd="12dp"
-            android:text="@{name}"
-            android:textColor="@color/contents_gray_06"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/ivMediaImage"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:text="총학생회 인스타그램" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    <ImageView
+        android:id="@+id/ivImage"
+        imageUrl="@{imageUrl}"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_marginEnd="16dp"
+        android:contentDescription="@null"
+        app:chipBackgroundColor="@color/transparent"
+        app:chipStrokeWidth="0dp"
+        app:chipSurfaceColor="@color/transparent" />
 </layout>

--- a/android/festago/presentation/src/main/res/layout/item_media.xml
+++ b/android/festago/presentation/src/main/res/layout/item_media.xml
@@ -1,22 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
         <variable
             name="imageUrl"
             type="String" />
+
+        <variable
+            name="name"
+            type="String" />
     </data>
 
-    <ImageView
-        android:id="@+id/ivImage"
-        imageUrl="@{imageUrl}"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_marginEnd="16dp"
-        android:contentDescription="@null"
-        app:chipBackgroundColor="@color/transparent"
-        app:chipStrokeWidth="0dp"
-        app:chipSurfaceColor="@color/transparent" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/clMedia"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/ivMediaImage"
+            imageUrl="@{imageUrl}"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:contentDescription="@null"
+            app:chipBackgroundColor="@color/transparent"
+            app:chipStrokeWidth="0dp"
+            app:chipSurfaceColor="@color/transparent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@drawable/ic_launcher_background"/>
+
+        <TextView
+            android:id="@+id/tvMediaName"
+            style="@style/B2Medium14Lh20"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="12dp"
+            android:text="@{name}"
+            android:textColor="@color/contents_gray_06"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/ivMediaImage"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="총학생회 인스타그램" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/festago/presentation/src/main/res/layout/item_popular_festival_foreground.xml
+++ b/android/festago/presentation/src/main/res/layout/item_popular_festival_foreground.xml
@@ -20,6 +20,7 @@
         <ImageView
             android:id="@+id/ivPopularFestivalImage"
             imageUrl="@{item.imageUrl}"
+            onSingleClick="@{()-> item.onFestivalDetail.invoke(item.id)}"
             android:layout_width="220dp"
             android:layout_height="220dp"
             android:layout_marginTop="12dp"

--- a/android/festago/presentation/src/main/res/layout/item_school_detail_festival.xml
+++ b/android/festago/presentation/src/main/res/layout/item_school_detail_festival.xml
@@ -45,9 +45,9 @@
             android:layout_width="56dp"
             android:layout_height="24dp"
             android:background="#FFFA1273"
-            android:visibility="@{LocalDate.now().compareTo(item.endDate) &lt;= 0 ? View.VISIBLE : View.GONE}"
             android:gravity="center"
             android:textColor="@color/background_gray_01"
+            android:visibility="@{LocalDate.now().compareTo(item.endDate) &lt;= 0 ? View.VISIBLE : View.GONE}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="D-1" />
@@ -70,14 +70,17 @@
         <TextView
             android:id="@+id/tvFestivalName"
             style="@style/H4Bold16Lh20"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
+            android:layout_marginHorizontal="12dp"
             android:layout_marginTop="10dp"
+            android:ellipsize="end"
+            android:maxLines="1"
             android:text="@{item.name}"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/ivFestivalImage"
             app:layout_constraintTop_toTopOf="@+id/ivFestivalImage"
-            tools:text="중앙대학교 청진난만" />
+            tools:text="중앙대학교 청진난만 중앙대학교 천진난만" />
 
         <TextView
             android:id="@+id/tvFestivalSchedule"

--- a/android/festago/presentation/src/main/res/values/strings.xml
+++ b/android/festago/presentation/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="artist_detail_tv_dday_format">D%1$s</string>
 
     <!-- String related to festival detail -->
-    <string name="festival_detail_tv_dday">D-DAY</string>
+    <string name="festival_detail_tv_dday_in_progress">진행 중</string>
     <string name="festival_detail_tv_dday_format">D%1$s</string>
     <string name="festival_detail_tv_dday_end">종료</string>
 

--- a/android/festago/presentation/src/main/res/values/strings.xml
+++ b/android/festago/presentation/src/main/res/values/strings.xml
@@ -7,7 +7,8 @@
     <string name="home_bottom_nav_bookmark">북마크</string>
     <string name="home_bottom_nav_my_page">마이페이지</string>
     <string name="home_back_pressed">한 번 더 누르면 앱이 종료됩니다</string>
-    <!-- TODO: Remove or change this placeholder text -->
+
+    <!-- Strings related to festival fist -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="festival_list_tv_popular_festival_title">요즘 뜨는 축제</string>
     <string name="festival_list_tv_date_range_format">%s - %s</string>
@@ -21,5 +22,10 @@
 
     <!-- String related to artist detail -->
     <string name="artist_detail_tv_dday_format">D%1$s</string>
+
+    <!-- String related to festival detail -->
+    <string name="festival_detail_tv_dday">D-DAY</string>
+    <string name="festival_detail_tv_dday_format">D%1$s</string>
+    <string name="festival_detail_tv_dday_end">종료</string>
 
 </resources>


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #750 

## ✨ PR 세부 내용

축제 상세페이지 구현 완료했습니다.
디자인이 수정되어서 item_Media 에 name 을 추가해주었습니다.
기존 Stages 객체를 없애고 Stage 를 정의했습니다.

- 축제 상세 화면으로 이동
FestivalList 에 Event 를 추가해주었습니다.
FestivalList 의 Item 에 람다를 넘겨 onFestivalDetail.invoke(id) 를 실행해 Event 를 발생시킵니다.

### 구현된 화면
<img width="300" alt="image" src="https://github.com/woowacourse-teams/2023-festa-go/assets/108349655/25749071-7eb8-4eaf-ae67-34528a01078d">

