### PR TITLE
[AN/USER] feat: 축제 목록 화면 스크롤 민감도를 줄인다(#764)

### DIFF
--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/customview/OrientationAwareRecyclerView.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/customview/OrientationAwareRecyclerView.kt
@@ -1,0 +1,59 @@
+package com.festago.festago.presentation.ui.customview
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import androidx.recyclerview.widget.RecyclerView
+
+/**
+ * A RecyclerView that only handles scroll events with the same orientation of its LayoutManager.
+ * Avoids situations where nested recyclerviews don't receive touch events properly:
+ */
+class OrientationAwareRecyclerView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet,
+    defStyleAttr: Int = 0,
+) : RecyclerView(context, attrs, defStyleAttr) {
+
+    private var lastX = 0.0f
+    private var lastY = 0.0f
+    private var scrolling = false
+
+    init {
+        addOnScrollListener(object : OnScrollListener() {
+            override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                super.onScrollStateChanged(recyclerView, newState)
+                scrolling = newState != SCROLL_STATE_IDLE
+            }
+        })
+    }
+
+    override fun onInterceptTouchEvent(e: MotionEvent): Boolean {
+        val lm = layoutManager ?: return super.onInterceptTouchEvent(e)
+        var allowScroll = true
+        when (e.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                lastX = e.x
+                lastY = e.y
+                // If we were scrolling, stop now by faking a touch release
+                if (scrolling) {
+                    val newEvent = MotionEvent.obtain(e)
+                    newEvent.action = MotionEvent.ACTION_UP
+                    return super.onInterceptTouchEvent(newEvent)
+                }
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                // We're moving, so check if we're trying
+                // to scroll vertically or horizontally so we don't intercept the wrong event.
+                val currentX = e.x
+                val currentY = e.y
+                val dx = Math.abs(currentX - lastX)
+                val dy = Math.abs(currentY - lastY)
+                allowScroll = if (dy > dx) lm.canScrollVertically() else lm.canScrollHorizontally()
+            }
+        }
+        if (!allowScroll) return false
+        return super.onInterceptTouchEvent(e)
+    }
+}

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
@@ -77,6 +77,7 @@ class FestivalListFragment : Fragment() {
             vm.loadFestivals()
             binding.srlFestivalList.isRefreshing = false
         }
+        binding.srlFestivalList.setDistanceToTriggerSync(400)
         binding.ivSearch.setOnClickListener { // 임시 연결
             showSchoolDetail()
         }

--- a/android/festago/presentation/src/main/res/layout/fragment_festival_list.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_festival_list.xml
@@ -69,7 +69,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/containerAppBarFestivalList">
 
-            <androidx.recyclerview.widget.RecyclerView
+            <com.festago.festago.presentation.ui.customview.OrientationAwareRecyclerView
                 android:id="@+id/rvFestivalList"
                 visibility="@{uiState.shouldShowSuccess}"
                 android:layout_width="match_parent"


### PR DESCRIPTION

## 📌 관련 이슈

- closed: #764

## ✨ PR 세부 내용

refresh, viewPager, recyclerView 세가지가 중첩되어 있어서 생기는 문제를 해결했습니다.

1. 리사이클러뷰를 상속받은 커스텀 리사이클러뷰를 사용합니다.
2. swipeRefreshLayout 의 distanceToTriggerSync 속성을 120(default) 에서 400 으로 증가시켜 민감도를 낮췄습니다.

- 참고자료
[찰스의 안드로이드](https://www.charlezz.com/?p=1402)
