### PR TITLE
[AN/USER] feat: 이미지 로딩 전까지 기본 이미지를 보여준다.(#775)

### DIFF
--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/bindingadapter/Image.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/bindingadapter/Image.kt
@@ -11,8 +11,9 @@ import jp.wasabeef.glide.transformations.BlurTransformation
 fun ImageView.setImage(imageUrl: String?) {
     Glide.with(context)
         .load(imageUrl)
-        .error(R.drawable.ic_launcher_background)
-        .fallback(R.drawable.ic_launcher_background)
+        .placeholder(R.color.background_gray_03)
+        .error(R.color.background_gray_03)
+        .fallback(R.color.background_gray_03)
         .into(this)
 }
 

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/bindingadapter/Image.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/bindingadapter/Image.kt
@@ -21,8 +21,9 @@ fun ImageView.setBlurImage(imageUrl: String?, blurRadius: Int, blurSampling: Int
     val transformation = BlurTransformation(blurRadius, blurSampling)
     Glide.with(context)
         .load(imageUrl)
+        .placeholder(R.color.background_gray_03)
         .apply(RequestOptions.bitmapTransform(transformation))
-        .error(R.drawable.ic_launcher_background)
-        .fallback(R.drawable.ic_launcher_background)
+        .error(R.color.background_gray_03)
+        .fallback(R.color.background_gray_03)
         .into(this)
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #775 

## ✨ PR 세부 내용

Glide 에 placeholder, fallback, error 이미지를 background_gray_03 color 로 변경했습니다.

placeholder : 이미지 불러오기 전까지 보여준다.
fallback : 이미지가 널이면 보여준다
error : 이미지 불러오기에 실패하면 보여준다. 

## 💻 작업물

https://github.com/woowacourse-teams/2023-festa-go/assets/108349655/e3860774-56a8-4d71-b033-0c958b38dff7


## ⏲️ 작업 시간
10분