### PR TITLE
[AN/USER] 축제 목록, 공연 목록의 디자인을 수정한다.(#777)

### DIFF
--- a/android/festago/presentation/src/main/res/layout/item_artist_detail_artist.xml
+++ b/android/festago/presentation/src/main/res/layout/item_artist_detail_artist.xml
@@ -12,8 +12,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="66dp"
-        android:layout_height="66dp"
-        android:background="@color/background_gray_02">
+        android:layout_height="66dp">
 
         <androidx.cardview.widget.CardView
             android:id="@+id/cvFestivalImage"

--- a/android/festago/presentation/src/main/res/layout/item_festival_detail_stage.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_detail_stage.xml
@@ -36,7 +36,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:background="@color/background_gray_02"
+            android:background="@drawable/bg_festival_list_festival"
             android:paddingVertical="16dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/android/festago/presentation/src/main/res/layout/item_festival_list_artist.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_list_artist.xml
@@ -12,8 +12,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="66dp"
-        android:layout_height="66dp"
-        android:background="@color/background_gray_02">
+        android:layout_height="66dp">
 
         <androidx.cardview.widget.CardView
             android:id="@+id/cvFestivalImage"

--- a/android/festago/presentation/src/main/res/layout/item_school_detail_artist.xml
+++ b/android/festago/presentation/src/main/res/layout/item_school_detail_artist.xml
@@ -12,8 +12,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="66dp"
-        android:layout_height="66dp"
-        android:background="@color/background_gray_02">
+        android:layout_height="66dp">
 
         <androidx.cardview.widget.CardView
             android:id="@+id/cvFestivalImage"


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #777 

## 작업 전

https://github.com/woowacourse-teams/2023-festa-go/assets/108349655/9927df7e-0dd7-47b9-b3af-d040c9db5e15

아티스트 아이템 뒤에 배경색이 있어서 테두리와 겹쳐지는 문제가 있습니다.



## ✨ PR 세부 내용

아티스트 아이템 뒤에 배경색을 없앴습니다.
축제 상세 아이템 배경테두리있는 drawable 로 바꿔주었습니다.

## ⏲️ 작업 시간
10분

