### PR TITLE
[BE] feat: 컨트롤러의 핸들러 메서드에 어노테이션을 붙여 인증을 수행하는 기능 추가 (#789)

### DIFF
--- a/backend/src/main/java/com/festago/auth/annotation/MemberAuth.java
+++ b/backend/src/main/java/com/festago/auth/annotation/MemberAuth.java
@@ -1,0 +1,12 @@
+package com.festago.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberAuth {
+
+}

--- a/backend/src/main/java/com/festago/auth/config/LoginConfig.java
+++ b/backend/src/main/java/com/festago/auth/config/LoginConfig.java
@@ -3,10 +3,12 @@ package com.festago.auth.config;
 import com.festago.auth.AuthInterceptor;
 import com.festago.auth.AuthenticateContext;
 import com.festago.auth.RoleArgumentResolver;
+import com.festago.auth.annotation.MemberAuth;
 import com.festago.auth.application.AuthExtractor;
 import com.festago.auth.domain.Role;
 import com.festago.auth.infrastructure.CookieTokenExtractor;
 import com.festago.auth.infrastructure.HeaderTokenExtractor;
+import com.festago.common.interceptor.AnnotationDelegateInterceptor;
 import com.festago.common.interceptor.HttpMethodDelegateInterceptor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +46,10 @@ public class LoginConfig implements WebMvcConfigurer {
                 .build())
             .addPathPatterns("/member-tickets/**", "/members/**", "/auth/**", "/students/**")
             .excludePathPatterns("/auth/oauth2");
+        registry.addInterceptor(AnnotationDelegateInterceptor.builder()
+            .annotation(MemberAuth.class)
+            .interceptor(memberAuthInterceptor())
+            .build());
     }
 
     @Bean

--- a/backend/src/main/java/com/festago/common/interceptor/AnnotationDelegateInterceptor.java
+++ b/backend/src/main/java/com/festago/common/interceptor/AnnotationDelegateInterceptor.java
@@ -34,7 +34,7 @@ public class AnnotationDelegateInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
         throws Exception {
         HandlerMethod handlerMethod = (HandlerMethod) handler;
-        if (handlerMethod.getMethodAnnotation(annotation) != null) {
+        if (handlerMethod.hasMethodAnnotation(annotation)) {
             return interceptor.preHandle(request, response, handler);
         }
         return true;

--- a/backend/src/main/java/com/festago/common/interceptor/AnnotationDelegateInterceptor.java
+++ b/backend/src/main/java/com/festago/common/interceptor/AnnotationDelegateInterceptor.java
@@ -1,0 +1,62 @@
+package com.festago.common.interceptor;
+
+import com.festago.common.exception.UnexpectedException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.annotation.Annotation;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class AnnotationDelegateInterceptor implements HandlerInterceptor {
+
+    private final Class<? extends Annotation> annotation;
+    private final HandlerInterceptor interceptor;
+
+    protected AnnotationDelegateInterceptor(
+        Class<? extends Annotation> annotation,
+        HandlerInterceptor interceptor
+    ) {
+        if (annotation == null) {
+            throw new UnexpectedException("annotation은 null이 될 수 없습니다.");
+        }
+        if (interceptor == null) {
+            throw new UnexpectedException("interceptor는 null이 될 수 없습니다.");
+        }
+        this.annotation = annotation;
+        this.interceptor = interceptor;
+    }
+
+    public static AnnotationsDelegateInterceptorBuilder builder() {
+        return new AnnotationsDelegateInterceptorBuilder();
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+        throws Exception {
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        if (handlerMethod.getMethodAnnotation(annotation) != null) {
+            return interceptor.preHandle(request, response, handler);
+        }
+        return true;
+    }
+
+    public static class AnnotationsDelegateInterceptorBuilder {
+
+        private Class<? extends Annotation> annotation;
+        private HandlerInterceptor interceptor;
+
+        public AnnotationsDelegateInterceptorBuilder annotation(Class<? extends Annotation> annotation) {
+            this.annotation = annotation;
+            return this;
+        }
+
+        public AnnotationsDelegateInterceptorBuilder interceptor(HandlerInterceptor interceptor) {
+            this.interceptor = interceptor;
+            return this;
+        }
+
+        public AnnotationDelegateInterceptor build() {
+            return new AnnotationDelegateInterceptor(annotation, interceptor);
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/auth/config/LoginConfigTest.java
+++ b/backend/src/test/java/com/festago/auth/config/LoginConfigTest.java
@@ -1,0 +1,65 @@
+package com.festago.auth.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.festago.auth.annotation.MemberAuth;
+import com.festago.auth.domain.Role;
+import com.festago.common.exception.ErrorCode;
+import com.festago.support.CustomWebMvcTest;
+import com.festago.support.WithMockAuth;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@CustomWebMvcTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class LoginConfigTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Nested
+    class MemberAuth_어노테이션이_붙은_핸들러_메서드는_인증_기능이_수행된다 {
+
+        @Test
+        @WithMockAuth(role = Role.ANONYMOUS)
+        void 토큰이_없으면_401_응답이_반환된다() throws Exception {
+            mockMvc.perform(get("/annotation-member-auth")).andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @WithMockAuth
+        void 토큰이_있으면_200_응답이_반환된다() throws Exception {
+            mockMvc.perform(get("/annotation-member-auth").header(HttpHeaders.AUTHORIZATION, "Bearer token"))
+                .andExpect(status().isOk());
+        }
+
+        @Test
+        @WithMockAuth(role = Role.ADMIN)
+        void 토큰의_권한이_어드민이면_404_응답이_반환된다() throws Exception {
+            mockMvc.perform(get("/annotation-member-auth").header(HttpHeaders.AUTHORIZATION, "Bearer token"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.NOT_ENOUGH_PERMISSION.name()));
+        }
+    }
+}
+
+@RestController
+class AnnotationMemberAuthController {
+
+    @MemberAuth
+    @GetMapping("/annotation-member-auth")
+    public ResponseEntity<Void> testAuthHandler() {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/test/java/com/festago/auth/config/LoginConfigTest.java
+++ b/backend/src/test/java/com/festago/auth/config/LoginConfigTest.java
@@ -34,20 +34,23 @@ class LoginConfigTest {
         @Test
         @WithMockAuth(role = Role.ANONYMOUS)
         void 토큰이_없으면_401_응답이_반환된다() throws Exception {
-            mockMvc.perform(get("/annotation-member-auth")).andExpect(status().isUnauthorized());
+            mockMvc.perform(get("/annotation-member-auth"))
+                .andExpect(status().isUnauthorized());
         }
 
         @Test
         @WithMockAuth
         void 토큰이_있으면_200_응답이_반환된다() throws Exception {
-            mockMvc.perform(get("/annotation-member-auth").header(HttpHeaders.AUTHORIZATION, "Bearer token"))
+            mockMvc.perform(get("/annotation-member-auth")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer token"))
                 .andExpect(status().isOk());
         }
 
         @Test
         @WithMockAuth(role = Role.ADMIN)
         void 토큰의_권한이_어드민이면_404_응답이_반환된다() throws Exception {
-            mockMvc.perform(get("/annotation-member-auth").header(HttpHeaders.AUTHORIZATION, "Bearer token"))
+            mockMvc.perform(get("/annotation-member-auth")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer token"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value(ErrorCode.NOT_ENOUGH_PERMISSION.name()));
         }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #789 

## ✨ PR 세부 내용

이슈 내용 그대로 컨트롤러의 핸들러 메서드에 어노테이션을 붙여 인증을 수행하는 기능을 추가했습니다.

구현은 위임 패턴을 사용한 `AnnotationDelegateInterceptor`에 핸들러 메서드에 붙일 어노테이션 클래스와 동작하게 할 인터셉터를 추가하면 되도록 했습니다.

위임 패턴을 사용한 이유는 추후 `Member` 외 `Manager` 또는 `Staff` 권한에 대한 인증이 필요할 수 있기 때문입니다.
따라서 다른 권한에 대한 인증 인터셉터 클래스를 만들지 않고 기능을 추가할 수 있도록 했습니다.

굳이 인증이 아니라도 로깅, 횟수 제한 등 여러 용도로 사용이 가능할 것 같네요.

어드민 패키지에 사용되는 컨트롤러에는 모두 인증이 필요하므로 기존 `HttpMethodDelegateInterceptor`를 그대로 사용하면 될 것 같네요.
(그게 아니라면 모든 핸들러 메서드마다 `@AdminAuth`를 붙여야 하니..)