### PR TITLE
[BE] fix: AnnotationDelegateInterceptor에 경로 추가하여 ClassCastException 방지 (#804)

### DIFF
--- a/backend/src/main/java/com/festago/auth/config/LoginConfig.java
+++ b/backend/src/main/java/com/festago/auth/config/LoginConfig.java
@@ -47,9 +47,10 @@ public class LoginConfig implements WebMvcConfigurer {
             .addPathPatterns("/member-tickets/**", "/members/**", "/auth/**", "/students/**", "/member-fcm/**")
             .excludePathPatterns("/auth/oauth2");
         registry.addInterceptor(AnnotationDelegateInterceptor.builder()
-            .annotation(MemberAuth.class)
-            .interceptor(memberAuthInterceptor())
-            .build());
+                .annotation(MemberAuth.class)
+                .interceptor(memberAuthInterceptor())
+                .build())
+            .addPathPatterns("/api/**");
     }
 
     @Bean

--- a/backend/src/test/java/com/festago/auth/config/LoginConfigTest.java
+++ b/backend/src/test/java/com/festago/auth/config/LoginConfigTest.java
@@ -34,14 +34,14 @@ class LoginConfigTest {
         @Test
         @WithMockAuth(role = Role.ANONYMOUS)
         void 토큰이_없으면_401_응답이_반환된다() throws Exception {
-            mockMvc.perform(get("/annotation-member-auth"))
+            mockMvc.perform(get("/api/annotation-member-auth"))
                 .andExpect(status().isUnauthorized());
         }
 
         @Test
         @WithMockAuth
         void 토큰이_있으면_200_응답이_반환된다() throws Exception {
-            mockMvc.perform(get("/annotation-member-auth")
+            mockMvc.perform(get("/api/annotation-member-auth")
                     .header(HttpHeaders.AUTHORIZATION, "Bearer token"))
                 .andExpect(status().isOk());
         }
@@ -49,7 +49,7 @@ class LoginConfigTest {
         @Test
         @WithMockAuth(role = Role.ADMIN)
         void 토큰의_권한이_어드민이면_404_응답이_반환된다() throws Exception {
-            mockMvc.perform(get("/annotation-member-auth")
+            mockMvc.perform(get("/api/annotation-member-auth")
                     .header(HttpHeaders.AUTHORIZATION, "Bearer token"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value(ErrorCode.NOT_ENOUGH_PERMISSION.name()));
@@ -61,7 +61,7 @@ class LoginConfigTest {
 class AnnotationMemberAuthController {
 
     @MemberAuth
-    @GetMapping("/annotation-member-auth")
+    @GetMapping("/api/annotation-member-auth")
     public ResponseEntity<Void> testAuthHandler() {
         return ResponseEntity.ok().build();
     }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #804 

## ✨ PR 세부 내용

이슈 내용과 같이 정적 파일 접근 시 `ResourceHttpRequestHandler` 타입의 클래스를 `HandlerMethod`로 형변환 하는 도중 발생하던 `ClassCastException` 문제를 수정했습니다.

`AnnotationDelegateInterceptor`에 `/api/**` 경로를 지정하여, 정적 파일 접근 시 해당 인터셉터 사용을 제외하였습니다.

큰 수정이 없고, 놔둔다면 에러가 계속 발생하므로 바로 머지 처리하겠습니다. 