### PR TITLE
[BE] refactor: 테스트 픽스쳐 개선 (#806)

### DIFF
--- a/backend/src/test/java/com/festago/auth/application/AuthFacadeServiceTest.java
+++ b/backend/src/test/java/com/festago/auth/application/AuthFacadeServiceTest.java
@@ -12,7 +12,7 @@ import com.festago.auth.dto.LoginMemberDto;
 import com.festago.auth.dto.LoginResponse;
 import com.festago.auth.infrastructure.FestagoOAuth2Client;
 import com.festago.member.domain.Member;
-import com.festago.support.MemberFixture;
+import com.festago.support.fixture.MemberFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -44,7 +44,7 @@ class AuthFacadeServiceTest {
 
     @Test
     void 로그인() {
-        Member member = MemberFixture.member()
+        Member member = MemberFixture.builder()
             .id(1L)
             .build();
 

--- a/backend/src/test/java/com/festago/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/festago/auth/application/AuthServiceTest.java
@@ -14,7 +14,7 @@ import com.festago.auth.dto.LoginMemberDto;
 import com.festago.common.exception.NotFoundException;
 import com.festago.member.domain.Member;
 import com.festago.member.repository.MemberRepository;
-import com.festago.support.MemberFixture;
+import com.festago.support.fixture.MemberFixture;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -46,7 +46,7 @@ class AuthServiceTest {
         @Test
         void 신규_회원으로_로그인() {
             // given
-            Member member = MemberFixture.member()
+            Member member = MemberFixture.builder()
                 .id(1L)
                 .build();
             given(memberRepository.findBySocialIdAndSocialType(anyString(), any(SocialType.class)))
@@ -67,7 +67,7 @@ class AuthServiceTest {
         @Test
         void 기존_회원으로_로그인() {
             // given
-            Member member = MemberFixture.member()
+            Member member = MemberFixture.builder()
                 .id(1L)
                 .build();
             given(memberRepository.findBySocialIdAndSocialType(anyString(), any(SocialType.class)))
@@ -104,7 +104,7 @@ class AuthServiceTest {
         void 성공() {
             // given
             Long memberId = 1L;
-            Member member = MemberFixture.member().id(memberId).build();
+            Member member = MemberFixture.builder().id(memberId).build();
             given(memberRepository.findById(memberId))
                 .willReturn(Optional.of(member));
 

--- a/backend/src/test/java/com/festago/auth/application/integration/AuthFacadeServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/auth/application/integration/AuthFacadeServiceIntegrationTest.java
@@ -8,7 +8,7 @@ import com.festago.auth.domain.SocialType;
 import com.festago.member.domain.Member;
 import com.festago.member.repository.MemberRepository;
 import com.festago.support.ApplicationIntegrationTest;
-import com.festago.support.MemberFixture;
+import com.festago.support.fixture.MemberFixture;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -46,7 +46,7 @@ class AuthFacadeServiceIntegrationTest extends ApplicationIntegrationTest {
     @Test
     void 회원탈퇴() {
         // given
-        Member member = memberRepository.save(MemberFixture.member().build());
+        Member member = memberRepository.save(MemberFixture.builder().build());
 
         // when
         authFacadeService.deleteMember(member.getId());
@@ -70,7 +70,7 @@ class AuthFacadeServiceIntegrationTest extends ApplicationIntegrationTest {
     @Test
     void 탈퇴한_회원은_조회되지않는다() {
         // given
-        Member member = memberRepository.save(MemberFixture.member().build());
+        Member member = memberRepository.save(MemberFixture.builder().build());
 
         // when
         authFacadeService.deleteMember(member.getId());

--- a/backend/src/test/java/com/festago/entry/application/EntryServiceTest.java
+++ b/backend/src/test/java/com/festago/entry/application/EntryServiceTest.java
@@ -23,11 +23,11 @@ import com.festago.entry.dto.event.EntryProcessEvent;
 import com.festago.festival.domain.Festival;
 import com.festago.member.domain.Member;
 import com.festago.stage.domain.Stage;
-import com.festago.support.FestivalFixture;
-import com.festago.support.MemberFixture;
-import com.festago.support.MemberTicketFixture;
-import com.festago.support.StageFixture;
 import com.festago.support.TimeInstantProvider;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.MemberFixture;
+import com.festago.support.fixture.MemberTicketFixture;
+import com.festago.support.fixture.StageFixture;
 import com.festago.ticketing.domain.EntryState;
 import com.festago.ticketing.domain.MemberTicket;
 import com.festago.ticketing.repository.MemberTicketRepository;
@@ -75,16 +75,16 @@ class EntryServiceTest {
         void 입장_시간_전_요청하면_예외() {
             // given
             LocalDateTime entryTime = LocalDateTime.parse("2023-07-30T16:00:00");
-            Festival festival = FestivalFixture.festival()
+            Festival festival = FestivalFixture.builder()
                 .startDate(entryTime.toLocalDate())
                 .endDate(entryTime.toLocalDate())
                 .build();
-            Stage stage = StageFixture.stage()
+            Stage stage = StageFixture.builder()
                 .festival(festival)
                 .startTime(entryTime.plusHours(2))
                 .ticketOpenTime(entryTime.minusHours(1))
                 .build();
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .id(1L)
                 .stage(stage)
                 .entryTime(entryTime)
@@ -106,16 +106,16 @@ class EntryServiceTest {
         void 입장_시간이_24시간이_넘은_경우_예외() {
             // given
             LocalDateTime entryTime = LocalDateTime.parse("2023-07-30T16:00:00");
-            Festival festival = FestivalFixture.festival()
+            Festival festival = FestivalFixture.builder()
                 .startDate(entryTime.toLocalDate())
                 .endDate(entryTime.toLocalDate())
                 .build();
-            Stage stage = StageFixture.stage()
+            Stage stage = StageFixture.builder()
                 .festival(festival)
                 .startTime(entryTime.plusHours(2))
                 .ticketOpenTime(entryTime.minusHours(1))
                 .build();
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .id(1L)
                 .stage(stage)
                 .entryTime(entryTime)
@@ -137,10 +137,10 @@ class EntryServiceTest {
         void 자신의_티켓이_아니면_예외() {
             // given
             Long memberId = 1L;
-            Member other = MemberFixture.member()
+            Member other = MemberFixture.builder()
                 .id(2L)
                 .build();
-            MemberTicket otherTicket = MemberTicketFixture.memberTicket()
+            MemberTicket otherTicket = MemberTicketFixture.builder()
                 .id(1L)
                 .owner(other)
                 .build();
@@ -173,16 +173,16 @@ class EntryServiceTest {
             // given
             LocalDateTime entryTime = LocalDateTime.parse("2023-07-30T16:00:00");
             Instant now = Instant.from(ZonedDateTime.of(entryTime, ZoneId.systemDefault()));
-            Festival festival = FestivalFixture.festival()
+            Festival festival = FestivalFixture.builder()
                 .startDate(entryTime.toLocalDate())
                 .endDate(entryTime.toLocalDate())
                 .build();
-            Stage stage = StageFixture.stage()
+            Stage stage = StageFixture.builder()
                 .festival(festival)
                 .startTime(entryTime.plusHours(2))
                 .ticketOpenTime(entryTime.minusHours(1))
                 .build();
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .id(1L)
                 .stage(stage)
                 .entryTime(entryTime)
@@ -216,7 +216,7 @@ class EntryServiceTest {
         void 예매한_티켓의_입장_상태와_요청의_입장_상태가_같으면_에매한_티켓의_입장_상태를_변경한다() {
             // given
             TicketValidationRequest request = new TicketValidationRequest("code");
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .id(1L)
                 .build();
             given(entryCodeManager.extract(anyString()))
@@ -238,7 +238,7 @@ class EntryServiceTest {
         void 예매한_티켓의_입장_상태와_요청의_입장_상태가_다르면_에매한_티켓의_입장_상태를_변경하지_않는다() {
             // given
             TicketValidationRequest request = new TicketValidationRequest("code");
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .id(1L)
                 .build();
             given(entryCodeManager.extract(anyString()))

--- a/backend/src/test/java/com/festago/entry/infrastructure/JwtEntryCodeProviderTest.java
+++ b/backend/src/test/java/com/festago/entry/infrastructure/JwtEntryCodeProviderTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import com.festago.common.exception.UnexpectedException;
 import com.festago.entry.application.EntryCodeProvider;
 import com.festago.entry.domain.EntryCodePayload;
-import com.festago.support.MemberTicketFixture;
+import com.festago.support.fixture.MemberTicketFixture;
 import com.festago.ticketing.domain.MemberTicket;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -28,7 +28,7 @@ class JwtEntryCodeProviderTest {
         // given
         Date now = new Date();
         Date expiredAt = new Date(now.getTime() - 1_000);
-        MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+        MemberTicket memberTicket = MemberTicketFixture.builder()
             .id(1L)
             .build();
         EntryCodePayload entryCodePayload = EntryCodePayload.from(memberTicket);
@@ -43,7 +43,7 @@ class JwtEntryCodeProviderTest {
     void JWT_토큰을_생성() {
         // given
         long period = 30_000;
-        MemberTicket memberTicket = MemberTicketFixture.memberTicket().id(1L).build();
+        MemberTicket memberTicket = MemberTicketFixture.builder().id(1L).build();
         Date now = new Date();
         Date expiredAt = new Date(now.getTime() + period);
         EntryCodePayload entryCodePayload = EntryCodePayload.from(memberTicket);

--- a/backend/src/test/java/com/festago/festival/application/command/FestivalCreateServiceTest.java
+++ b/backend/src/test/java/com/festago/festival/application/command/FestivalCreateServiceTest.java
@@ -12,8 +12,8 @@ import com.festago.festival.repository.FestivalRepository;
 import com.festago.school.domain.School;
 import com.festago.school.repository.SchoolRepository;
 import com.festago.support.ApplicationIntegrationTest;
-import com.festago.support.SchoolFixture;
 import com.festago.support.TimeInstantProvider;
+import com.festago.support.fixture.SchoolFixture;
 import java.time.Clock;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,7 +52,7 @@ class FestivalCreateServiceTest extends ApplicationIntegrationTest {
         void setUp() {
             given(clock.instant())
                 .willReturn(TimeInstantProvider.from(now));
-            School school = schoolRepository.save(SchoolFixture.school().build());
+            School school = schoolRepository.save(SchoolFixture.builder().build());
             schoolId = school.getId();
         }
 

--- a/backend/src/test/java/com/festago/festival/application/command/FestivalDeleteServiceTest.java
+++ b/backend/src/test/java/com/festago/festival/application/command/FestivalDeleteServiceTest.java
@@ -14,10 +14,10 @@ import com.festago.school.domain.School;
 import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.repository.StageRepository;
 import com.festago.support.ApplicationIntegrationTest;
-import com.festago.support.FestivalFixture;
-import com.festago.support.SchoolFixture;
-import com.festago.support.StageFixture;
 import com.festago.support.TimeInstantProvider;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StageFixture;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -60,8 +60,8 @@ class FestivalDeleteServiceTest extends ApplicationIntegrationTest {
         void setUp() {
             given(clock.instant())
                 .willReturn(TimeInstantProvider.from(now));
-            School school = schoolRepository.save(SchoolFixture.school().build());
-            Festival festival = festivalRepository.save(FestivalFixture.festival()
+            School school = schoolRepository.save(SchoolFixture.builder().build());
+            Festival festival = festivalRepository.save(FestivalFixture.builder()
                 .startDate(now)
                 .endDate(now)
                 .school(school)
@@ -76,7 +76,7 @@ class FestivalDeleteServiceTest extends ApplicationIntegrationTest {
             Festival festival = festivalRepository.getOrThrow(festivalId);
             LocalDateTime startTime = LocalDateTime.now(clock);
             LocalDateTime ticketOpenTime = startTime.minusDays(1);
-            stageRepository.save(StageFixture.stage()
+            stageRepository.save(StageFixture.builder()
                 .festival(festival)
                 .startTime(startTime)
                 .ticketOpenTime(ticketOpenTime)

--- a/backend/src/test/java/com/festago/festival/application/command/FestivalUpdateServiceTest.java
+++ b/backend/src/test/java/com/festago/festival/application/command/FestivalUpdateServiceTest.java
@@ -9,9 +9,9 @@ import com.festago.festival.repository.FestivalRepository;
 import com.festago.school.domain.School;
 import com.festago.school.repository.SchoolRepository;
 import com.festago.support.ApplicationIntegrationTest;
-import com.festago.support.FestivalFixture;
-import com.festago.support.SchoolFixture;
 import com.festago.support.TimeInstantProvider;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.SchoolFixture;
 import java.time.Clock;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,8 +47,8 @@ class FestivalUpdateServiceTest extends ApplicationIntegrationTest {
         void setUp() {
             given(clock.instant())
                 .willReturn(TimeInstantProvider.from(now));
-            School school = schoolRepository.save(SchoolFixture.school().build());
-            Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
+            School school = schoolRepository.save(SchoolFixture.builder().build());
+            Festival festival = festivalRepository.save(FestivalFixture.builder().school(school).build());
             festivalId = festival.getId();
         }
 

--- a/backend/src/test/java/com/festago/festival/domain/FestivalTest.java
+++ b/backend/src/test/java/com/festago/festival/domain/FestivalTest.java
@@ -6,8 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.festago.common.exception.BadRequestException;
 import com.festago.school.domain.School;
-import com.festago.support.FestivalFixture;
-import com.festago.support.SchoolFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.SchoolFixture;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -23,7 +23,7 @@ class FestivalTest {
     void 시작일자가_종료일자_이전이면_예외() {
         // given
         LocalDate today = LocalDate.now();
-        School school = SchoolFixture.school().build();
+        School school = SchoolFixture.builder().build();
         LocalDate tomorrow = today.plusDays(1);
 
         // when & then
@@ -39,7 +39,7 @@ class FestivalTest {
         void 축제_시작_일자_이전이면_참() {
             // given
             LocalDateTime time = LocalDateTime.now();
-            Festival festival = FestivalFixture.festival()
+            Festival festival = FestivalFixture.builder()
                 .startDate(time.plusDays(1).toLocalDate())
                 .endDate(time.plusDays(4).toLocalDate())
                 .build();
@@ -55,7 +55,7 @@ class FestivalTest {
         void 축제_종료_일자_이후이면_참() {
             // given
             LocalDateTime time = LocalDateTime.now();
-            Festival festival = FestivalFixture.festival()
+            Festival festival = FestivalFixture.builder()
                 .startDate(time.minusDays(4).toLocalDate())
                 .endDate(time.minusDays(1).toLocalDate())
                 .build();
@@ -71,7 +71,7 @@ class FestivalTest {
         void 축제_기간중이면_거짓() {
             // given
             LocalDateTime time = LocalDateTime.now();
-            Festival festival = FestivalFixture.festival()
+            Festival festival = FestivalFixture.builder()
                 .startDate(time.minusDays(1).toLocalDate())
                 .endDate(time.toLocalDate())
                 .build();

--- a/backend/src/test/java/com/festago/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/festago/member/repository/MemberRepositoryTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.festago.member.domain.Member;
-import com.festago.support.MemberFixture;
 import com.festago.support.RepositoryTest;
+import com.festago.support.fixture.MemberFixture;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -26,7 +26,7 @@ class MemberRepositoryTest {
     @Test
     void 소셜_아이디와_소셜_타입으로_멤버를_찾는다() {
         // given
-        Member member = MemberFixture.member()
+        Member member = MemberFixture.builder()
             .build();
         Member expected = memberRepository.save(member);
 
@@ -41,7 +41,7 @@ class MemberRepositoryTest {
     @Test
     void 회원_삭제() {
         // given
-        Member member = MemberFixture.member()
+        Member member = MemberFixture.builder()
             .build();
         Member expected = memberRepository.save(member);
 

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolCommandServiceIntegrationTest.java
@@ -14,7 +14,7 @@ import com.festago.school.dto.SchoolCreateCommand;
 import com.festago.school.dto.SchoolUpdateCommand;
 import com.festago.school.repository.SchoolRepository;
 import com.festago.support.ApplicationIntegrationTest;
-import com.festago.support.SchoolFixture;
+import com.festago.support.fixture.SchoolFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -44,7 +44,7 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
         @Test
         void 같은_도메인의_학교가_저장되어_있으면_예외가_발생한다() {
             // given
-            schoolRepository.save(SchoolFixture.school().domain("teco.ac.kr").build());
+            schoolRepository.save(SchoolFixture.builder().domain("teco.ac.kr").build());
 
             // when & then
             assertThatThrownBy(() -> schoolCommandService.createSchool(command))
@@ -55,7 +55,7 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
         @Test
         void 같은_이름의_학교가_저장되어_있으면_예외가_발생한다() {
             // given
-            schoolRepository.save(SchoolFixture.school().name("테코대학교").build());
+            schoolRepository.save(SchoolFixture.builder().name("테코대학교").build());
 
             // when & then
             assertThatThrownBy(() -> schoolCommandService.createSchool(command))
@@ -87,7 +87,7 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
 
         @BeforeEach
         void setUp() {
-            school = schoolRepository.save(SchoolFixture.school()
+            school = schoolRepository.save(SchoolFixture.builder()
                 .name("우테대학교")
                 .domain("wote.ac.kr")
                 .region(SchoolRegion.대구)
@@ -112,7 +112,7 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
         void 같은_도메인의_학교가_저장되어_있으면_예외가_발생한다() {
             // given
             Long schoolId = school.getId();
-            schoolRepository.save(SchoolFixture.school().domain("teco.ac.kr").build());
+            schoolRepository.save(SchoolFixture.builder().domain("teco.ac.kr").build());
 
             // when & then
             assertThatThrownBy(() -> schoolCommandService.updateSchool(schoolId, command))
@@ -124,7 +124,7 @@ class SchoolCommandServiceIntegrationTest extends ApplicationIntegrationTest {
         void 같은_이름의_학교가_저장되어_있으면_예외가_발생한다() {
             // given
             Long schoolId = school.getId();
-            schoolRepository.save(SchoolFixture.school().name("테코대학교").build());
+            schoolRepository.save(SchoolFixture.builder().name("테코대학교").build());
 
             // when & then
             assertThatThrownBy(() -> schoolCommandService.updateSchool(schoolId, command))

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolDeleteServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolDeleteServiceIntegrationTest.java
@@ -15,10 +15,10 @@ import com.festago.school.repository.SchoolRepository;
 import com.festago.student.domain.Student;
 import com.festago.student.repository.StudentRepository;
 import com.festago.support.ApplicationIntegrationTest;
-import com.festago.support.FestivalFixture;
-import com.festago.support.MemberFixture;
-import com.festago.support.SchoolFixture;
-import com.festago.support.StudentFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.MemberFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StudentFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -58,14 +58,14 @@ class SchoolDeleteServiceIntegrationTest extends ApplicationIntegrationTest {
 
         @BeforeEach
         void setUp() {
-            school = schoolRepository.save(SchoolFixture.school().build());
+            school = schoolRepository.save(SchoolFixture.builder().build());
         }
 
         @Test
         void 학교에_등록된_축제가_있으면_삭제에_실패한다() {
             // given
             Long schoolId = school.getId();
-            Festival festival = FestivalFixture.festival().school(school).build();
+            Festival festival = FestivalFixture.builder().school(school).build();
             festivalRepository.save(festival);
 
             // when & then
@@ -78,8 +78,8 @@ class SchoolDeleteServiceIntegrationTest extends ApplicationIntegrationTest {
         void 학교에_등록된_학생이_있으면_삭제에_실패한다() {
             // given
             Long schoolId = school.getId();
-            Member member = memberRepository.save(MemberFixture.member().build());
-            Student student = StudentFixture.student().member(member).school(school).build();
+            Member member = memberRepository.save(MemberFixture.builder().build());
+            Student student = StudentFixture.builder().member(member).school(school).build();
             studentRepository.save(student);
 
             // when & then

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolV1QueryServiceIntegrationTest.java
@@ -18,8 +18,8 @@ import com.festago.socialmedia.domain.SocialMedia;
 import com.festago.socialmedia.domain.SocialMediaType;
 import com.festago.socialmedia.repository.SocialMediaRepository;
 import com.festago.support.ApplicationIntegrationTest;
-import com.festago.support.FestivalFixture;
-import com.festago.support.SchoolFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.SchoolFixture;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +61,7 @@ class SchoolV1QueryServiceIntegrationTest extends ApplicationIntegrationTest {
         @Test
         void 학교에_소셜미디어가_존재하지_않아도_조회된다() {
             // given
-            School school = schoolRepository.save(SchoolFixture.school().build());
+            School school = schoolRepository.save(SchoolFixture.builder().build());
 
             // when
             SchoolDetailV1Response actual = schoolV1QueryService.findDetailById(school.getId());
@@ -76,7 +76,7 @@ class SchoolV1QueryServiceIntegrationTest extends ApplicationIntegrationTest {
         @Test
         void 아티스트의_소셜미디어는_아이디가_같아도_조회되지_않는다() {
             // given
-            School school = schoolRepository.save(SchoolFixture.school().build());
+            School school = schoolRepository.save(SchoolFixture.builder().build());
             saveSocialMedia(school.getId(), OwnerType.SCHOOL, SocialMediaType.X);
             saveSocialMedia(school.getId(), OwnerType.ARTIST, SocialMediaType.YOUTUBE);
 
@@ -90,7 +90,7 @@ class SchoolV1QueryServiceIntegrationTest extends ApplicationIntegrationTest {
         @Test
         void 학교와_포함된_소셜미디어를_모두_조회한다() {
             // given
-            School school = schoolRepository.save(SchoolFixture.school().build());
+            School school = schoolRepository.save(SchoolFixture.builder().build());
             saveSocialMedia(school.getId(), OwnerType.SCHOOL, SocialMediaType.X);
             saveSocialMedia(school.getId(), OwnerType.SCHOOL, SocialMediaType.YOUTUBE);
 
@@ -117,7 +117,7 @@ class SchoolV1QueryServiceIntegrationTest extends ApplicationIntegrationTest {
 
         @BeforeEach
         void setUp() {
-            school = schoolRepository.save(SchoolFixture.school().build());
+            school = schoolRepository.save(SchoolFixture.builder().build());
         }
 
         @Test
@@ -272,7 +272,7 @@ class SchoolV1QueryServiceIntegrationTest extends ApplicationIntegrationTest {
 
         private Festival saveFestival(LocalDate startDate, LocalDate endDate) {
             return festivalRepository.save(
-                FestivalFixture.festival()
+                FestivalFixture.builder()
                     .startDate(startDate)
                     .endDate(endDate)
                     .school(school)

--- a/backend/src/test/java/com/festago/stage/application/command/StageCreateServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageCreateServiceTest.java
@@ -15,7 +15,7 @@ import com.festago.festival.repository.MemoryFestivalRepository;
 import com.festago.stage.dto.command.StageCreateCommand;
 import com.festago.stage.repository.MemoryStageArtistRepository;
 import com.festago.stage.repository.MemoryStageRepository;
-import com.festago.support.FestivalFixture;
+import com.festago.support.fixture.FestivalFixture;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
@@ -59,7 +59,7 @@ class StageCreateServiceTest {
         stageArtistRepository.clear();
 
         테코대학교_축제 = festivalRepository.save(
-            FestivalFixture.festival()
+            FestivalFixture.builder()
                 .name("테코대학교 축제")
                 .startDate(festivalStartDate)
                 .endDate(festivalEndDate)

--- a/backend/src/test/java/com/festago/stage/application/command/StageDeleteServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageDeleteServiceTest.java
@@ -12,8 +12,8 @@ import com.festago.stage.domain.Stage;
 import com.festago.stage.domain.StageArtist;
 import com.festago.stage.repository.MemoryStageArtistRepository;
 import com.festago.stage.repository.MemoryStageRepository;
-import com.festago.support.FestivalFixture;
-import com.festago.support.StageFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.StageFixture;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -49,14 +49,14 @@ class StageDeleteServiceTest {
         stageRepository.clear();
         stageArtistRepository.clear();
         테코대학교_축제 = festivalRepository.save(
-            FestivalFixture.festival()
+            FestivalFixture.builder()
                 .name("테코대학교 축제")
                 .startDate(stageStartTime.toLocalDate())
                 .endDate(stageStartTime.toLocalDate().plusDays(2))
                 .build()
         );
         테코대학교_축제_공연 = stageRepository.save(
-            StageFixture.stage()
+            StageFixture.builder()
                 .festival(테코대학교_축제)
                 .startTime(stageStartTime)
                 .ticketOpenTime(ticketOpenTime)

--- a/backend/src/test/java/com/festago/stage/application/command/StageUpdateServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageUpdateServiceTest.java
@@ -16,8 +16,8 @@ import com.festago.stage.domain.StageArtist;
 import com.festago.stage.dto.command.StageUpdateCommand;
 import com.festago.stage.repository.MemoryStageArtistRepository;
 import com.festago.stage.repository.MemoryStageRepository;
-import com.festago.support.FestivalFixture;
-import com.festago.support.StageFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.StageFixture;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -54,13 +54,13 @@ class StageUpdateServiceTest {
     @BeforeEach
     void setUp() {
         stageRepository.clear();
-        테코대학교_축제 = FestivalFixture.festival()
+        테코대학교_축제 = FestivalFixture.builder()
             .name("테코대학교 축제")
             .startDate(stageStartTime.toLocalDate())
             .endDate(stageStartTime.toLocalDate().plusDays(2))
             .build();
         테코대학교_축제_공연 = stageRepository.save(
-            StageFixture.stage()
+            StageFixture.builder()
                 .festival(테코대학교_축제)
                 .startTime(stageStartTime)
                 .ticketOpenTime(ticketOpenTime)

--- a/backend/src/test/java/com/festago/stage/domain/StageTest.java
+++ b/backend/src/test/java/com/festago/stage/domain/StageTest.java
@@ -7,8 +7,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.festago.common.exception.BadRequestException;
 import com.festago.festival.domain.Festival;
-import com.festago.support.FestivalFixture;
-import com.festago.support.StageFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.StageFixture;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -25,13 +25,13 @@ class StageTest {
         // given
         LocalDateTime startTime = LocalDateTime.parse("2023-07-26T18:00:00");
         LocalDateTime ticketOpenTime = LocalDateTime.parse("2023-07-26T17:00:00");
-        Festival festival = FestivalFixture.festival()
+        Festival festival = FestivalFixture.builder()
             .startDate(startTime.plusDays(1).toLocalDate())
             .endDate(startTime.plusDays(1).toLocalDate())
             .build();
 
         // when & then
-        assertThatThrownBy(() -> StageFixture.stage()
+        assertThatThrownBy(() -> StageFixture.builder()
             .startTime(startTime)
             .ticketOpenTime(ticketOpenTime)
             .festival(festival)
@@ -46,13 +46,13 @@ class StageTest {
         // given
         LocalDateTime startTime = LocalDateTime.parse("2023-07-26T18:00:00");
         LocalDateTime ticketOpenTime = LocalDateTime.parse("2023-07-26T17:00:00");
-        Festival festival = FestivalFixture.festival()
+        Festival festival = FestivalFixture.builder()
             .startDate(startTime.minusDays(1).toLocalDate())
             .endDate(startTime.minusDays(1).toLocalDate())
             .build();
 
         // when & then
-        assertThatThrownBy(() -> StageFixture.stage()
+        assertThatThrownBy(() -> StageFixture.builder()
             .startTime(startTime)
             .ticketOpenTime(ticketOpenTime)
             .festival(festival)
@@ -67,13 +67,13 @@ class StageTest {
     void 티켓_오픈_시간이_무대_시작시간과_같거나_이후이면_예외(LocalDateTime ticketOpenTime) {
         // given
         LocalDateTime startTime = LocalDateTime.parse("2023-07-26T18:00:00");
-        Festival festival = FestivalFixture.festival()
+        Festival festival = FestivalFixture.builder()
             .startDate(startTime.toLocalDate())
             .endDate(startTime.toLocalDate())
             .build();
 
         // when & then
-        assertThatThrownBy(() -> StageFixture.stage()
+        assertThatThrownBy(() -> StageFixture.builder()
             .startTime(startTime)
             .ticketOpenTime(ticketOpenTime)
             .festival(festival)
@@ -88,13 +88,13 @@ class StageTest {
         // given
         LocalDateTime startTime = LocalDateTime.parse("2023-07-26T18:00:00");
         LocalDateTime ticketOpenTime = LocalDateTime.parse("2023-07-26T17:00:00");
-        Festival festival = FestivalFixture.festival()
+        Festival festival = FestivalFixture.builder()
             .startDate(startTime.toLocalDate())
             .endDate(startTime.toLocalDate())
             .build();
 
         // when & then
-        assertThatNoException().isThrownBy(() -> StageFixture.stage()
+        assertThatNoException().isThrownBy(() -> StageFixture.builder()
             .startTime(startTime)
             .ticketOpenTime(ticketOpenTime)
             .festival(festival)

--- a/backend/src/test/java/com/festago/stage/domain/validator/festival/OutOfDateStageFestivalUpdateValidatorTest.java
+++ b/backend/src/test/java/com/festago/stage/domain/validator/festival/OutOfDateStageFestivalUpdateValidatorTest.java
@@ -7,8 +7,8 @@ import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.ErrorCode;
 import com.festago.festival.domain.Festival;
 import com.festago.stage.repository.MemoryStageRepository;
-import com.festago.support.FestivalFixture;
-import com.festago.support.StageFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.StageFixture;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +30,7 @@ class OutOfDateStageFestivalUpdateValidatorTest {
     @BeforeEach
     void setUp() {
         stageRepository.clear();
-        축제 = FestivalFixture.festival()
+        축제 = FestivalFixture.builder()
             .startDate(festivalStartDate)
             .endDate(festivalEndDate)
             .build();
@@ -45,7 +45,7 @@ class OutOfDateStageFestivalUpdateValidatorTest {
             // 19, 20, 21 일자의 공연 생성
             for (int i = 0; i <= 2; i++) {
                 stageRepository.save(
-                    StageFixture.stage()
+                    StageFixture.builder()
                         .festival(축제)
                         .ticketOpenTime(ticketOpenTime)
                         .startTime(festivalStartDate.plusDays(i).atTime(18, 0))

--- a/backend/src/test/java/com/festago/stage/repository/StageRepositoryTest.java
+++ b/backend/src/test/java/com/festago/stage/repository/StageRepositoryTest.java
@@ -8,11 +8,11 @@ import com.festago.festival.repository.FestivalRepository;
 import com.festago.school.domain.School;
 import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
-import com.festago.support.FestivalFixture;
 import com.festago.support.RepositoryTest;
-import com.festago.support.SchoolFixture;
-import com.festago.support.StageFixture;
-import com.festago.support.TicketFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StageFixture;
+import com.festago.support.fixture.TicketFixture;
 import com.festago.ticket.domain.Ticket;
 import com.festago.ticket.domain.TicketType;
 import com.festago.ticket.repository.TicketRepository;
@@ -46,10 +46,10 @@ class StageRepositoryTest {
     @Test
     void 티켓이_존재하지_않을때도_무대가_조회된다() {
         // given
-        School school = schoolRepository.save(SchoolFixture.school().build());
-        Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
-        Stage stage1 = stageRepository.save(StageFixture.stage().festival(festival).build());
-        Stage stage2 = stageRepository.save(StageFixture.stage().festival(festival).build());
+        School school = schoolRepository.save(SchoolFixture.builder().build());
+        Festival festival = festivalRepository.save(FestivalFixture.builder().school(school).build());
+        Stage stage1 = stageRepository.save(StageFixture.builder().festival(festival).build());
+        Stage stage2 = stageRepository.save(StageFixture.builder().festival(festival).build());
 
         // when
         List<Stage> actual = stageRepository.findAllDetailByFestivalId(festival.getId());
@@ -64,9 +64,9 @@ class StageRepositoryTest {
     @Test
     void 해당_축제의_무대가_모두_조회된다() {
         // given
-        School school = schoolRepository.save(SchoolFixture.school().build());
-        Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
-        stageRepository.save(StageFixture.stage().festival(festival).build());
+        School school = schoolRepository.save(SchoolFixture.builder().build());
+        Festival festival = festivalRepository.save(FestivalFixture.builder().school(school).build());
+        stageRepository.save(StageFixture.builder().festival(festival).build());
 
         // when
         List<Stage> actual = stageRepository.findAllDetailByFestivalId(festival.getId());
@@ -78,13 +78,13 @@ class StageRepositoryTest {
     @Test
     void 티켓_정보까지_모두_조회된다() {
         // given
-        School school = schoolRepository.save(SchoolFixture.school().build());
-        Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
-        Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
+        School school = schoolRepository.save(SchoolFixture.builder().build());
+        Festival festival = festivalRepository.save(FestivalFixture.builder().school(school).build());
+        Stage stage = stageRepository.save(StageFixture.builder().festival(festival).build());
         Ticket ticket1 = ticketRepository.save(
-            TicketFixture.ticket().ticketType(TicketType.STUDENT).stage(stage).build());
+            TicketFixture.builder().ticketType(TicketType.STUDENT).stage(stage).build());
         Ticket ticket2 = ticketRepository.save(
-            TicketFixture.ticket().ticketType(TicketType.VISITOR).stage(stage).build());
+            TicketFixture.builder().ticketType(TicketType.VISITOR).stage(stage).build());
         ticket1.getTicketAmount().addTotalAmount(100);
         ticket2.getTicketAmount().addTotalAmount(200);
         entityManager.flush();

--- a/backend/src/test/java/com/festago/student/application/StudentServiceTest.java
+++ b/backend/src/test/java/com/festago/student/application/StudentServiceTest.java
@@ -30,10 +30,10 @@ import com.festago.student.infrastructure.MockMailClient;
 import com.festago.student.infrastructure.RandomVerificationCodeProvider;
 import com.festago.student.repository.StudentCodeRepository;
 import com.festago.student.repository.StudentRepository;
-import com.festago.support.MemberFixture;
-import com.festago.support.SchoolFixture;
 import com.festago.support.SetUpMockito;
-import com.festago.support.StudentFixture;
+import com.festago.support.fixture.MemberFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StudentFixture;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -85,8 +85,8 @@ class StudentServiceTest {
         @BeforeEach
         void setUp() {
             request = new StudentSendMailRequest("ash", 1L);
-            Member member = MemberFixture.member().id(1L).build();
-            School school = SchoolFixture.school().id(1L).build();
+            Member member = MemberFixture.builder().id(1L).build();
+            School school = SchoolFixture.builder().id(1L).build();
 
             SetUpMockito
                 .given(memberRepository.findById(anyLong()))
@@ -183,7 +183,7 @@ class StudentServiceTest {
             Long memberId = 1L;
             StudentVerificateRequest request = new StudentVerificateRequest("123456");
             given(memberRepository.findById(anyLong()))
-                .willReturn(Optional.of(MemberFixture.member().build()));
+                .willReturn(Optional.of(MemberFixture.builder().build()));
             given(studentCodeRepository.findByCodeAndMember(any(), any()))
                 .willReturn(Optional.empty());
 
@@ -198,7 +198,7 @@ class StudentServiceTest {
             // given
             Long memberId = 1L;
             StudentVerificateRequest request = new StudentVerificateRequest("123456");
-            Member member = MemberFixture.member().build();
+            Member member = MemberFixture.builder().build();
             given(memberRepository.findById(anyLong()))
                 .willReturn(Optional.of(member));
             given(studentCodeRepository.findByCodeAndMember(any(), any()))
@@ -223,8 +223,8 @@ class StudentServiceTest {
         void 학생_인증된_멤버의_경우() {
             // given
             Long memberId = 1L;
-            School school = SchoolFixture.school().id(2L).build();
-            Student student = StudentFixture.student().id(3L).school(school).build();
+            School school = SchoolFixture.builder().id(2L).build();
+            Student student = StudentFixture.builder().id(3L).school(school).build();
             given(studentRepository.findByMemberIdWithFetch(memberId))
                 .willReturn(Optional.of(student));
 

--- a/backend/src/test/java/com/festago/student/domain/StudentCodeTest.java
+++ b/backend/src/test/java/com/festago/student/domain/StudentCodeTest.java
@@ -9,8 +9,8 @@ import com.festago.common.exception.UnexpectedException;
 import com.festago.common.exception.ValidException;
 import com.festago.member.domain.Member;
 import com.festago.school.domain.School;
-import com.festago.support.MemberFixture;
-import com.festago.support.SchoolFixture;
+import com.festago.support.fixture.MemberFixture;
+import com.festago.support.fixture.SchoolFixture;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -27,8 +27,8 @@ class StudentCodeTest {
     @Test
     void 성공() {
         // given
-        Member member = MemberFixture.member().build();
-        School school = SchoolFixture.school().build();
+        Member member = MemberFixture.builder().build();
+        School school = SchoolFixture.builder().build();
         LocalDateTime issuedAt = LocalDateTime.parse("2023-11-19T02:00:00");
         VerificationCode verificationCode = new VerificationCode("123456");
 
@@ -42,8 +42,8 @@ class StudentCodeTest {
     @Test
     void username의_길이가_255자를_초과하면_예외() {
         // given
-        Member member = MemberFixture.member().build();
-        School school = SchoolFixture.school().build();
+        Member member = MemberFixture.builder().build();
+        School school = SchoolFixture.builder().build();
         LocalDateTime issuedAt = LocalDateTime.parse("2023-11-19T02:00:00");
         VerificationCode verificationCode = new VerificationCode("123456");
         String username = "1".repeat(256);
@@ -59,8 +59,8 @@ class StudentCodeTest {
     @ValueSource(strings = {"", " ", "\t", "\n"})
     void username이_null_또는_공백이면_예외(String username) {
         // given
-        Member member = MemberFixture.member().build();
-        School school = SchoolFixture.school().build();
+        Member member = MemberFixture.builder().build();
+        School school = SchoolFixture.builder().build();
         LocalDateTime issuedAt = LocalDateTime.parse("2023-11-19T02:00:00");
         VerificationCode verificationCode = new VerificationCode("123456");
 
@@ -73,8 +73,8 @@ class StudentCodeTest {
     @Test
     void 이메일_반환_성공() {
         // given
-        Member member = MemberFixture.member().build();
-        School school = SchoolFixture.school().domain("fiddich.com").build();
+        Member member = MemberFixture.builder().build();
+        School school = SchoolFixture.builder().domain("fiddich.com").build();
         LocalDateTime issuedAt = LocalDateTime.parse("2023-11-19T02:00:00");
         VerificationCode verificationCode = new VerificationCode("123456");
 
@@ -91,8 +91,8 @@ class StudentCodeTest {
         @Test
         void 재발급할_코드에_식별자가_있으면_예외() {
             // given
-            Member member = MemberFixture.member().build();
-            School school = SchoolFixture.school().build();
+            Member member = MemberFixture.builder().build();
+            School school = SchoolFixture.builder().build();
             LocalDateTime issuedAt = LocalDateTime.parse("2023-11-19T02:00:00");
             VerificationCode verificationCode = new VerificationCode("123456");
             StudentCode studentCode = new StudentCode(1L, verificationCode, school, member, "ash", issuedAt);
@@ -110,8 +110,8 @@ class StudentCodeTest {
         @ValueSource(longs = {0, 1, 30})
         void 발급한지_30초_이내면_예외(long second) {
             // given
-            Member member = MemberFixture.member().build();
-            School school = SchoolFixture.school().build();
+            Member member = MemberFixture.builder().build();
+            School school = SchoolFixture.builder().build();
             LocalDateTime issuedAt = LocalDateTime.parse("2023-11-19T02:00:00");
             VerificationCode verificationCode = new VerificationCode("123456");
             StudentCode studentCode = new StudentCode(1L, verificationCode, school, member, "ash", issuedAt);
@@ -129,8 +129,8 @@ class StudentCodeTest {
         @ValueSource(longs = {31, 999, 9999})
         void 발급한지_30초_이후면_성공(long second) {
             // given
-            Member member = MemberFixture.member().build();
-            School school = SchoolFixture.school().build();
+            Member member = MemberFixture.builder().build();
+            School school = SchoolFixture.builder().build();
             LocalDateTime issuedAt = LocalDateTime.parse("2023-11-19T02:00:00");
             VerificationCode verificationCode = new VerificationCode("123456");
             StudentCode studentCode = new StudentCode(1L, verificationCode, school, member, "ash", issuedAt);

--- a/backend/src/test/java/com/festago/student/repository/StudentRepositoryTest.java
+++ b/backend/src/test/java/com/festago/student/repository/StudentRepositoryTest.java
@@ -7,10 +7,10 @@ import com.festago.member.repository.MemberRepository;
 import com.festago.school.domain.School;
 import com.festago.school.repository.SchoolRepository;
 import com.festago.student.domain.Student;
-import com.festago.support.MemberFixture;
 import com.festago.support.RepositoryTest;
-import com.festago.support.SchoolFixture;
-import com.festago.support.StudentFixture;
+import com.festago.support.fixture.MemberFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StudentFixture;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -34,9 +34,9 @@ class StudentRepositoryTest {
     @Test
     void 멤버id로_조회() {
         // given
-        Member member = memberRepository.save(MemberFixture.member().build());
-        School school = schoolRepository.save(SchoolFixture.school().build());
-        Student student = studentRepository.save(StudentFixture.student().school(school).member(member).build());
+        Member member = memberRepository.save(MemberFixture.builder().build());
+        School school = schoolRepository.save(SchoolFixture.builder().build());
+        Student student = studentRepository.save(StudentFixture.builder().school(school).member(member).build());
 
         // when
         Optional<Student> actual = studentRepository.findByMemberIdWithFetch(member.getId());

--- a/backend/src/test/java/com/festago/support/fixture/AdminFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/AdminFixture.java
@@ -1,0 +1,33 @@
+package com.festago.support.fixture;
+
+import com.festago.admin.domain.Admin;
+
+public class AdminFixture extends BaseFixture {
+
+    private String username;
+    private String password = "123456";
+
+    private AdminFixture() {
+    }
+
+    public static AdminFixture builder() {
+        return new AdminFixture();
+    }
+
+    public AdminFixture username(String username) {
+        this.username = username;
+        return this;
+    }
+
+    public AdminFixture password(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public Admin build() {
+        return new Admin(
+            uniqueValue("admin", username),
+            password
+        );
+    }
+}

--- a/backend/src/test/java/com/festago/support/fixture/ArtistFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/ArtistFixture.java
@@ -1,0 +1,44 @@
+package com.festago.support.fixture;
+
+import com.festago.artist.domain.Artist;
+
+public class ArtistFixture extends BaseFixture {
+
+    private Long id;
+    private String name;
+    private String profileImageUrl = "https://www.festago-image.com/profile.png";
+    private String backgroundImageUrl = "https://www.festago-image.com/background.png";
+
+    public static ArtistFixture builder() {
+        return new ArtistFixture();
+    }
+
+    public ArtistFixture id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public ArtistFixture name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public ArtistFixture profileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+        return this;
+    }
+
+    public ArtistFixture backgroundImageUrl(String backgroundImageUrl) {
+        this.backgroundImageUrl = backgroundImageUrl;
+        return this;
+    }
+
+    public Artist build() {
+        return new Artist(
+            id,
+            uniqueValue("아티스트", name),
+            profileImageUrl,
+            backgroundImageUrl
+        );
+    }
+}

--- a/backend/src/test/java/com/festago/support/fixture/BaseFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/BaseFixture.java
@@ -1,0 +1,23 @@
+package com.festago.support.fixture;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.util.StringUtils;
+
+public abstract class BaseFixture {
+
+    protected static final AtomicLong sequence = new AtomicLong();
+
+    /**
+     * value가 null 또는 빈 문자열이면 baseValue 뒤에 숫자를 붙여서 유니크한 이름을 만듭니다.
+     *
+     * @param defaultValue 기본 값이 될 문자열
+     * @param value        null 또는 빈 문자열이 될 수 있는 이름
+     * @return value가 null 또는 빈 문자열이면 defaultValue 뒤에 숫자가 붙은 문자열 그게 아니면 value 그대로 반환
+     */
+    protected String uniqueValue(String defaultValue, String value) {
+        if (!StringUtils.hasText(value)) {
+            return defaultValue + sequence.incrementAndGet();
+        }
+        return value;
+    }
+}

--- a/backend/src/test/java/com/festago/support/fixture/FestivalFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/FestivalFixture.java
@@ -1,22 +1,22 @@
-package com.festago.support;
+package com.festago.support.fixture;
 
 import com.festago.festival.domain.Festival;
 import com.festago.school.domain.School;
 import java.time.LocalDate;
 
-public class FestivalFixture {
+public class FestivalFixture extends BaseFixture {
 
     private Long id;
-    private String name = "테코 대학교";
+    private String name;
     private LocalDate startDate = LocalDate.now();
     private LocalDate endDate = LocalDate.now().plusDays(3L);
-    private String thumbnail = "https://picsum.photos/536/354";
-    private School school = SchoolFixture.school().build();
+    private String posterImageUrl = "https://picsum.photos/536/354";
+    private School school = SchoolFixture.builder().build();
 
     private FestivalFixture() {
     }
 
-    public static FestivalFixture festival() {
+    public static FestivalFixture builder() {
         return new FestivalFixture();
     }
 
@@ -40,8 +40,8 @@ public class FestivalFixture {
         return this;
     }
 
-    public FestivalFixture thumbnail(String thumbnail) {
-        this.thumbnail = thumbnail;
+    public FestivalFixture posterImageUrl(String posterImageUrl) {
+        this.posterImageUrl = posterImageUrl;
         return this;
     }
 
@@ -51,6 +51,6 @@ public class FestivalFixture {
     }
 
     public Festival build() {
-        return new Festival(id, name, startDate, endDate, thumbnail, school);
+        return new Festival(id, uniqueValue("페스타고 대학교 축제", name), startDate, endDate, posterImageUrl, school);
     }
 }

--- a/backend/src/test/java/com/festago/support/fixture/FestivalQueryInfoFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/FestivalQueryInfoFixture.java
@@ -1,0 +1,32 @@
+package com.festago.support.fixture;
+
+import com.festago.festival.domain.FestivalQueryInfo;
+
+public class FestivalQueryInfoFixture extends BaseFixture {
+
+    private Long festivalId;
+    private String artistInfo;
+
+    private FestivalQueryInfoFixture() {
+    }
+
+    public static FestivalQueryInfoFixture builder() {
+        return new FestivalQueryInfoFixture();
+    }
+
+    public FestivalQueryInfoFixture festivalId(Long festivalId) {
+        this.festivalId = festivalId;
+        return this;
+    }
+
+    public FestivalQueryInfoFixture artistInfo(String artistInfo) {
+        this.artistInfo = artistInfo;
+        return this;
+    }
+
+    public FestivalQueryInfo build() {
+        FestivalQueryInfo festivalQueryInfo = FestivalQueryInfo.create(festivalId);
+        festivalQueryInfo.updateArtistInfo(null, ignore -> artistInfo);
+        return festivalQueryInfo;
+    }
+}

--- a/backend/src/test/java/com/festago/support/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/MemberFixture.java
@@ -1,17 +1,17 @@
-package com.festago.support;
+package com.festago.support.fixture;
 
 import com.festago.auth.domain.SocialType;
 import com.festago.member.domain.Member;
 
-public class MemberFixture {
+public class MemberFixture extends BaseFixture {
 
     private Long id;
-    private String socialId = "123";
-    private SocialType socialType = SocialType.KAKAO;
-    private String nickname = "nickname";
-    private String profileImage = "https://profileImage.com/image.png";
+    private String socialId;
+    private SocialType socialType = SocialType.FESTAGO;
+    private String nickname;
+    private String profileImageUrl = "https://image.com/profileImage.png";
 
-    public static MemberFixture member() {
+    public static MemberFixture builder() {
         return new MemberFixture();
     }
 
@@ -35,12 +35,18 @@ public class MemberFixture {
         return this;
     }
 
-    public MemberFixture profileImage(String profileImage) {
-        this.profileImage = profileImage;
+    public MemberFixture profileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
         return this;
     }
 
     public Member build() {
-        return new Member(this.id, this.socialId, this.socialType, this.nickname, this.profileImage);
+        return new Member(
+            id,
+            uniqueValue("", socialId),
+            socialType,
+            uniqueValue("nickname", nickname),
+            profileImageUrl
+        );
     }
 }

--- a/backend/src/test/java/com/festago/support/fixture/MemberTicketFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/MemberTicketFixture.java
@@ -1,4 +1,4 @@
-package com.festago.support;
+package com.festago.support.fixture;
 
 import com.festago.member.domain.Member;
 import com.festago.stage.domain.Stage;
@@ -6,11 +6,12 @@ import com.festago.ticket.domain.TicketType;
 import com.festago.ticketing.domain.MemberTicket;
 import java.time.LocalDateTime;
 
+@Deprecated
 public class MemberTicketFixture {
 
     private Long id;
-    private Member owner = MemberFixture.member().build();
-    private Stage stage = StageFixture.stage().build();
+    private Member owner = MemberFixture.builder().build();
+    private Stage stage = StageFixture.builder().build();
     private TicketType ticketType = TicketType.VISITOR;
     private LocalDateTime entryTime = LocalDateTime.now();
     private int number = 1;
@@ -18,7 +19,7 @@ public class MemberTicketFixture {
     private MemberTicketFixture() {
     }
 
-    public static MemberTicketFixture memberTicket() {
+    public static MemberTicketFixture builder() {
         return new MemberTicketFixture();
     }
 

--- a/backend/src/test/java/com/festago/support/fixture/SchoolFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/SchoolFixture.java
@@ -1,26 +1,21 @@
-package com.festago.support;
+package com.festago.support.fixture;
 
 import com.festago.school.domain.School;
 import com.festago.school.domain.SchoolRegion;
 
-public class SchoolFixture {
+public class SchoolFixture extends BaseFixture {
 
     private Long id;
-
-    private String domain = "festago.com";
-
-    private String name = "페스타고 대학교";
-
+    private String domain;
+    private String name;
     private SchoolRegion region = SchoolRegion.서울;
-
     private String logoUrl = "https://image.com/logo.png";
-
     private String backgroundImageUrl = "https://image.com/backgroundImage.png";
 
     private SchoolFixture() {
     }
 
-    public static SchoolFixture school() {
+    public static SchoolFixture builder() {
         return new SchoolFixture();
     }
 
@@ -55,6 +50,13 @@ public class SchoolFixture {
     }
 
     public School build() {
-        return new School(id, domain, name, logoUrl, backgroundImageUrl, region);
+        return new School(
+            id,
+            uniqueValue("festago.com", domain),
+            uniqueValue("페스타고 대학교", name),
+            logoUrl,
+            backgroundImageUrl,
+            region
+        );
     }
 }

--- a/backend/src/test/java/com/festago/support/fixture/SocialMediaFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/SocialMediaFixture.java
@@ -1,0 +1,67 @@
+package com.festago.support.fixture;
+
+import com.festago.socialmedia.domain.OwnerType;
+import com.festago.socialmedia.domain.SocialMedia;
+import com.festago.socialmedia.domain.SocialMediaType;
+
+public class SocialMediaFixture {
+
+    private Long id;
+    private Long ownerId;
+    private OwnerType ownerType;
+    private SocialMediaType mediaType = SocialMediaType.INSTAGRAM;
+    private String name = "총학생회 인스타그램";
+    private String logoUrl = "https://image.com/logo.png";
+    private String url = "https://instagram.com";
+
+    public static SocialMediaFixture builder() {
+        return new SocialMediaFixture();
+    }
+
+    public SocialMediaFixture id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public SocialMediaFixture ownerId(Long ownerId) {
+        this.ownerId = ownerId;
+        return this;
+    }
+
+    public SocialMediaFixture ownerType(OwnerType ownerType) {
+        this.ownerType = ownerType;
+        return this;
+    }
+
+    public SocialMediaFixture mediaType(SocialMediaType mediaType) {
+        this.mediaType = mediaType;
+        return this;
+    }
+
+    public SocialMediaFixture name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public SocialMediaFixture logoUrl(String logoUrl) {
+        this.logoUrl = logoUrl;
+        return this;
+    }
+
+    public SocialMediaFixture url(String url) {
+        this.url = url;
+        return this;
+    }
+
+    public SocialMedia build() {
+        return new SocialMedia(
+            id,
+            ownerId,
+            ownerType,
+            mediaType,
+            name,
+            logoUrl,
+            url
+        );
+    }
+}

--- a/backend/src/test/java/com/festago/support/fixture/StageArtistFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/StageArtistFixture.java
@@ -1,0 +1,30 @@
+package com.festago.support.fixture;
+
+import com.festago.stage.domain.StageArtist;
+
+public class StageArtistFixture extends BaseFixture {
+
+    private Long id;
+    private Long stageId;
+    private Long artistId;
+
+    public static StageArtistFixture builder(Long stageId, Long artistId) {
+        StageArtistFixture stageArtistFixture = new StageArtistFixture();
+        stageArtistFixture.stageId = stageId;
+        stageArtistFixture.artistId = artistId;
+        return stageArtistFixture;
+    }
+
+    public StageArtistFixture id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public StageArtist build() {
+        return new StageArtist(
+            id,
+            stageId,
+            artistId
+        );
+    }
+}

--- a/backend/src/test/java/com/festago/support/fixture/StageFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/StageFixture.java
@@ -1,20 +1,20 @@
-package com.festago.support;
+package com.festago.support.fixture;
 
 import com.festago.festival.domain.Festival;
 import com.festago.stage.domain.Stage;
 import java.time.LocalDateTime;
 
-public class StageFixture {
+public class StageFixture extends BaseFixture {
 
     private Long id;
     private LocalDateTime startTime = LocalDateTime.now();
-    private LocalDateTime ticketOpenTime = startTime.minusWeeks(1);
-    private Festival festival = FestivalFixture.festival().build();
+    private LocalDateTime ticketOpenTime;
+    private Festival festival = FestivalFixture.builder().build();
 
     private StageFixture() {
     }
 
-    public static StageFixture stage() {
+    public static StageFixture builder() {
         return new StageFixture();
     }
 
@@ -33,13 +33,17 @@ public class StageFixture {
         return this;
     }
 
-
     public StageFixture festival(Festival festival) {
         this.festival = festival;
         return this;
     }
 
     public Stage build() {
-        return new Stage(id, startTime, ticketOpenTime, festival);
+        return new Stage(
+            id,
+            startTime,
+            ticketOpenTime == null ? startTime.minusWeeks(1) : ticketOpenTime,
+            festival
+        );
     }
 }

--- a/backend/src/test/java/com/festago/support/fixture/StageQueryInfoFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/StageQueryInfoFixture.java
@@ -1,0 +1,30 @@
+package com.festago.support.fixture;
+
+import com.festago.stage.domain.StageQueryInfo;
+
+public class StageQueryInfoFixture extends BaseFixture {
+
+    private Long stageId;
+    private String artistInfo;
+
+    private StageQueryInfoFixture() {
+    }
+
+    public static StageQueryInfoFixture builder() {
+        return new StageQueryInfoFixture();
+    }
+
+    public StageQueryInfoFixture stageId(Long stageId) {
+        this.stageId = stageId;
+        return this;
+    }
+
+    public StageQueryInfoFixture artistInfo(String artistInfo) {
+        this.artistInfo = artistInfo;
+        return this;
+    }
+
+    public StageQueryInfo build() {
+        return StageQueryInfo.of(stageId, null, ignore -> artistInfo);
+    }
+}

--- a/backend/src/test/java/com/festago/support/fixture/StudentCodeFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/StudentCodeFixture.java
@@ -1,4 +1,4 @@
-package com.festago.support;
+package com.festago.support.fixture;
 
 import com.festago.member.domain.Member;
 import com.festago.school.domain.School;
@@ -6,19 +6,20 @@ import com.festago.student.domain.StudentCode;
 import com.festago.student.domain.VerificationCode;
 import java.time.LocalDateTime;
 
+@Deprecated
 public class StudentCodeFixture {
 
     private Long id;
     private VerificationCode code = new VerificationCode("123456");
-    private School school = SchoolFixture.school().build();
-    private Member member = MemberFixture.member().build();
+    private School school = SchoolFixture.builder().build();
+    private Member member = MemberFixture.builder().build();
     private String username = "ash";
     private LocalDateTime issuedAt = LocalDateTime.now();
 
     private StudentCodeFixture() {
     }
 
-    public static StudentCodeFixture studentCode() {
+    public static StudentCodeFixture builder() {
         return new StudentCodeFixture();
     }
 

--- a/backend/src/test/java/com/festago/support/fixture/StudentFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/StudentFixture.java
@@ -1,20 +1,21 @@
-package com.festago.support;
+package com.festago.support.fixture;
 
 import com.festago.member.domain.Member;
 import com.festago.school.domain.School;
 import com.festago.student.domain.Student;
 
+@Deprecated
 public class StudentFixture {
 
     private Long id;
-    private Member member = MemberFixture.member().build();
-    private School school = SchoolFixture.school().build();
+    private Member member = MemberFixture.builder().build();
+    private School school = SchoolFixture.builder().build();
     private String username = "xxeol2";
 
     private StudentFixture() {
     }
 
-    public static StudentFixture student() {
+    public static StudentFixture builder() {
         return new StudentFixture();
     }
 

--- a/backend/src/test/java/com/festago/support/fixture/TicketFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/TicketFixture.java
@@ -1,20 +1,21 @@
-package com.festago.support;
+package com.festago.support.fixture;
 
 import com.festago.stage.domain.Stage;
 import com.festago.ticket.domain.Ticket;
 import com.festago.ticket.domain.TicketType;
 
+@Deprecated
 public class TicketFixture {
 
     private Long id;
-    private Stage stage = StageFixture.stage().build();
+    private Stage stage = StageFixture.builder().build();
     private TicketType ticketType = TicketType.VISITOR;
     private Long schoolId = 1L;
 
     private TicketFixture() {
     }
 
-    public static TicketFixture ticket() {
+    public static TicketFixture builder() {
         return new TicketFixture();
     }
 

--- a/backend/src/test/java/com/festago/ticket/application/TicketServiceTest.java
+++ b/backend/src/test/java/com/festago/ticket/application/TicketServiceTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import com.festago.stage.domain.Stage;
-import com.festago.support.StageFixture;
-import com.festago.support.TicketFixture;
+import com.festago.support.fixture.StageFixture;
+import com.festago.support.fixture.TicketFixture;
 import com.festago.ticket.domain.Ticket;
 import com.festago.ticket.domain.TicketType;
 import com.festago.ticket.dto.StageTicketResponse;
@@ -35,10 +35,10 @@ class TicketServiceTest {
     void 공연_아이디로_모든_티켓의_정보_조회() {
         // given
         long stageId = 1L;
-        Stage stage = StageFixture.stage().id(stageId).build();
+        Stage stage = StageFixture.builder().id(stageId).build();
         List<Ticket> tickets = List.of(
-            TicketFixture.ticket().id(1L).ticketType(TicketType.STUDENT).stage(stage).build(),
-            TicketFixture.ticket().id(2L).ticketType(TicketType.VISITOR).stage(stage).build()
+            TicketFixture.builder().id(1L).ticketType(TicketType.STUDENT).stage(stage).build(),
+            TicketFixture.builder().id(2L).ticketType(TicketType.VISITOR).stage(stage).build()
         );
         given(ticketRepository.findAllByStageIdWithFetch(stageId))
             .willReturn(tickets);

--- a/backend/src/test/java/com/festago/ticket/application/integration/TicketServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/ticket/application/integration/TicketServiceIntegrationTest.java
@@ -13,9 +13,9 @@ import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
 import com.festago.support.ApplicationIntegrationTest;
-import com.festago.support.FestivalFixture;
-import com.festago.support.SchoolFixture;
-import com.festago.support.StageFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StageFixture;
 import com.festago.ticket.application.TicketService;
 import com.festago.ticket.domain.TicketAmount;
 import com.festago.ticket.domain.TicketType;
@@ -78,13 +78,13 @@ class TicketServiceIntegrationTest extends ApplicationIntegrationTest {
         LocalDateTime stageStartTime = LocalDateTime.parse("2022-07-26T18:00:00");
         doReturn(stageStartTime.minusWeeks(1).toInstant(ZoneOffset.UTC))
             .when(clock).instant();
-        School school = schoolRepository.save(SchoolFixture.school().build());
-        Festival festival = festivalRepository.save(FestivalFixture.festival()
+        School school = schoolRepository.save(SchoolFixture.builder().build());
+        Festival festival = festivalRepository.save(FestivalFixture.builder()
             .school(school)
             .startDate(stageStartTime.toLocalDate())
             .endDate(stageStartTime.toLocalDate())
             .build());
-        Stage stage = stageRepository.save(StageFixture.stage()
+        Stage stage = stageRepository.save(StageFixture.builder()
             .festival(festival)
             .startTime(stageStartTime)
             .ticketOpenTime(stageStartTime.minusDays(1))
@@ -106,13 +106,13 @@ class TicketServiceIntegrationTest extends ApplicationIntegrationTest {
         LocalDateTime stageStartTime = LocalDateTime.parse("2022-07-26T18:00:00");
         doReturn(stageStartTime.minusWeeks(1).toInstant(ZoneOffset.UTC))
             .when(clock).instant();
-        School school = schoolRepository.save(SchoolFixture.school().build());
-        Festival festival = festivalRepository.save(FestivalFixture.festival()
+        School school = schoolRepository.save(SchoolFixture.builder().build());
+        Festival festival = festivalRepository.save(FestivalFixture.builder()
             .school(school)
             .startDate(stageStartTime.toLocalDate())
             .endDate(stageStartTime.toLocalDate())
             .build());
-        Stage stage = stageRepository.save(StageFixture.stage()
+        Stage stage = stageRepository.save(StageFixture.builder()
             .festival(festival)
             .startTime(stageStartTime)
             .ticketOpenTime(stageStartTime.minusDays(1))

--- a/backend/src/test/java/com/festago/ticket/domain/TicketTest.java
+++ b/backend/src/test/java/com/festago/ticket/domain/TicketTest.java
@@ -12,10 +12,10 @@ import com.festago.common.exception.BadRequestException;
 import com.festago.festival.domain.Festival;
 import com.festago.member.domain.Member;
 import com.festago.stage.domain.Stage;
-import com.festago.support.FestivalFixture;
-import com.festago.support.MemberFixture;
-import com.festago.support.StageFixture;
-import com.festago.support.TicketFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.MemberFixture;
+import com.festago.support.fixture.StageFixture;
+import com.festago.support.fixture.TicketFixture;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -36,11 +36,11 @@ class TicketTest {
         void 입장시간이_티켓오픈시간_이전이면_예외(long minute) {
             // given
             LocalDateTime now = LocalDateTime.now();
-            Stage stage = StageFixture.stage()
+            Stage stage = StageFixture.builder()
                 .startTime(now.plusDays(1))
                 .ticketOpenTime(now)
                 .build();
-            Ticket ticket = TicketFixture.ticket()
+            Ticket ticket = TicketFixture.builder()
                 .stage(stage)
                 .build();
 
@@ -55,7 +55,7 @@ class TicketTest {
         @ValueSource(longs = {0, 1})
         void 입장_시간이_축제_시작_시간보다_같거나_이후면_예외(long minute) {
             // given
-            Ticket ticket = TicketFixture.ticket()
+            Ticket ticket = TicketFixture.builder()
                 .build();
 
             Stage stage = ticket.getStage();
@@ -72,7 +72,7 @@ class TicketTest {
         @Test
         void 입장_시간이_공연_시작_12시간_이전이면_예외() {
             // given
-            Ticket ticket = TicketFixture.ticket()
+            Ticket ticket = TicketFixture.builder()
                 .build();
 
             Stage stage = ticket.getStage();
@@ -89,10 +89,10 @@ class TicketTest {
         @Test
         void 티켓_오픈_이후_티켓생성시_예외() {
             // given
-            Stage stage = StageFixture.stage()
+            Stage stage = StageFixture.builder()
                 .ticketOpenTime(LocalDateTime.now().minusHours(1))
                 .build();
-            Ticket ticket = TicketFixture.ticket()
+            Ticket ticket = TicketFixture.builder()
                 .build();
 
             LocalDateTime startTime = stage.getStartTime();
@@ -107,7 +107,7 @@ class TicketTest {
         void 입장시간을_추가한다() {
             // given
             Ticket ticket = TicketFixture
-                .ticket()
+                .builder()
                 .build();
 
             Stage stage = ticket.getStage();
@@ -134,19 +134,19 @@ class TicketTest {
             // given
             LocalDateTime stageStartTime = LocalDateTime.parse("2022-08-12T18:00:00");
             LocalDateTime now = stageStartTime.minusHours(6);
-            Festival festival = FestivalFixture.festival()
+            Festival festival = FestivalFixture.builder()
                 .startDate(stageStartTime.toLocalDate())
                 .endDate(stageStartTime.toLocalDate())
                 .build();
-            Stage stage = StageFixture.stage()
+            Stage stage = StageFixture.builder()
                 .startTime(stageStartTime)
                 .ticketOpenTime(stageStartTime.minusDays(1))
                 .festival(festival)
                 .build();
-            Ticket ticket = TicketFixture.ticket()
+            Ticket ticket = TicketFixture.builder()
                 .stage(stage)
                 .build();
-            Member member = MemberFixture.member()
+            Member member = MemberFixture.builder()
                 .id(1L)
                 .build();
 

--- a/backend/src/test/java/com/festago/ticket/repository/TicketRepositoryTest.java
+++ b/backend/src/test/java/com/festago/ticket/repository/TicketRepositoryTest.java
@@ -8,11 +8,11 @@ import com.festago.school.domain.School;
 import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
-import com.festago.support.FestivalFixture;
 import com.festago.support.RepositoryTest;
-import com.festago.support.SchoolFixture;
-import com.festago.support.StageFixture;
-import com.festago.support.TicketFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StageFixture;
+import com.festago.support.fixture.TicketFixture;
 import com.festago.ticket.domain.Ticket;
 import com.festago.ticket.domain.TicketType;
 import java.util.List;
@@ -41,14 +41,14 @@ class TicketRepositoryTest {
     @Test
     void 공연의_ID로_티켓을_모두_조회() {
         // given
-        School school = schoolRepository.save(SchoolFixture.school().build());
-        Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
-        Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
-        Stage otherStage = stageRepository.save(StageFixture.stage().festival(festival).build());
+        School school = schoolRepository.save(SchoolFixture.builder().build());
+        Festival festival = festivalRepository.save(FestivalFixture.builder().school(school).build());
+        Stage stage = stageRepository.save(StageFixture.builder().festival(festival).build());
+        Stage otherStage = stageRepository.save(StageFixture.builder().festival(festival).build());
 
-        ticketRepository.save(TicketFixture.ticket().stage(stage).ticketType(TicketType.STUDENT).build());
-        ticketRepository.save(TicketFixture.ticket().stage(stage).ticketType(TicketType.VISITOR).build());
-        ticketRepository.save(TicketFixture.ticket().stage(otherStage).build());
+        ticketRepository.save(TicketFixture.builder().stage(stage).ticketType(TicketType.STUDENT).build());
+        ticketRepository.save(TicketFixture.builder().stage(stage).ticketType(TicketType.VISITOR).build());
+        ticketRepository.save(TicketFixture.builder().stage(otherStage).build());
 
         // when
         List<Ticket> actual = ticketRepository.findAllByStageIdWithFetch(stage.getId());

--- a/backend/src/test/java/com/festago/ticketing/application/MemberTicketServiceTest.java
+++ b/backend/src/test/java/com/festago/ticketing/application/MemberTicketServiceTest.java
@@ -12,8 +12,8 @@ import static org.mockito.BDDMockito.given;
 import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.NotFoundException;
 import com.festago.member.domain.Member;
-import com.festago.support.MemberFixture;
-import com.festago.support.MemberTicketFixture;
+import com.festago.support.fixture.MemberFixture;
+import com.festago.support.fixture.MemberTicketFixture;
 import com.festago.ticketing.domain.MemberTicket;
 import com.festago.ticketing.dto.MemberTicketResponse;
 import com.festago.ticketing.dto.MemberTicketsResponse;
@@ -71,11 +71,11 @@ class MemberTicketServiceTest {
             // given
             Long memberId = 1L;
             Long memberTicketId = 1L;
-            Member other = MemberFixture.member()
+            Member other = MemberFixture.builder()
                 .id(2L)
                 .build();
 
-            MemberTicket otherMemberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket otherMemberTicket = MemberTicketFixture.builder()
                 .id(memberTicketId)
                 .owner(other)
                 .build();
@@ -94,10 +94,10 @@ class MemberTicketServiceTest {
             // given
             Long memberId = 1L;
             Long memberTicketId = 1L;
-            Member member = MemberFixture.member()
+            Member member = MemberFixture.builder()
                 .id(memberId)
                 .build();
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .id(memberTicketId)
                 .owner(member)
                 .build();
@@ -132,10 +132,10 @@ class MemberTicketServiceTest {
         void 성공() {
             // given
             Long memberId = 1L;
-            MemberTicket first = MemberTicketFixture.memberTicket()
+            MemberTicket first = MemberTicketFixture.builder()
                 .id(1L)
                 .build();
-            MemberTicket second = MemberTicketFixture.memberTicket()
+            MemberTicket second = MemberTicketFixture.builder()
                 .id(2L)
                 .build();
             given(memberTicketRepository.findAllByOwnerId(eq(memberId), any(Pageable.class)))
@@ -156,7 +156,7 @@ class MemberTicketServiceTest {
         void 입장시간이_24시간_지난_티켓은_조회되지_않는다() {
             // given
             Long memberId = 1L;
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .entryTime(LocalDateTime.now().minusHours(25))
                 .build();
 
@@ -174,11 +174,11 @@ class MemberTicketServiceTest {
         void 활성화된_티켓이_먼저_조회된다() {
             // given
             Long memberId = 1L;
-            MemberTicket pendingMemberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket pendingMemberTicket = MemberTicketFixture.builder()
                 .id(1L)
                 .entryTime(LocalDateTime.now().plusHours(1))
                 .build();
-            MemberTicket activateMemberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket activateMemberTicket = MemberTicketFixture.builder()
                 .id(2L)
                 .entryTime(LocalDateTime.now().minusHours(1))
                 .build();
@@ -200,19 +200,19 @@ class MemberTicketServiceTest {
         void 활성화_및_비활성화_내에서는_현재시간과_가까운순으로_정렬되어_조회된다() {
             // given
             Long memberId = 1L;
-            MemberTicket pendingMemberTicket1 = MemberTicketFixture.memberTicket()
+            MemberTicket pendingMemberTicket1 = MemberTicketFixture.builder()
                 .id(1L)
                 .entryTime(LocalDateTime.now().plusHours(1))
                 .build();
-            MemberTicket pendingMemberTicket2 = MemberTicketFixture.memberTicket()
+            MemberTicket pendingMemberTicket2 = MemberTicketFixture.builder()
                 .id(2L)
                 .entryTime(LocalDateTime.now().plusHours(2))
                 .build();
-            MemberTicket activateMemberTicket1 = MemberTicketFixture.memberTicket()
+            MemberTicket activateMemberTicket1 = MemberTicketFixture.builder()
                 .id(3L)
                 .entryTime(LocalDateTime.now().minusHours(2))
                 .build();
-            MemberTicket activateMemberTicket2 = MemberTicketFixture.memberTicket()
+            MemberTicket activateMemberTicket2 = MemberTicketFixture.builder()
                 .id(4L)
                 .entryTime(LocalDateTime.now().minusHours(1))
                 .build();

--- a/backend/src/test/java/com/festago/ticketing/application/TicketingServiceTest.java
+++ b/backend/src/test/java/com/festago/ticketing/application/TicketingServiceTest.java
@@ -11,8 +11,8 @@ import com.festago.member.domain.Member;
 import com.festago.member.repository.MemberRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.student.repository.StudentRepository;
-import com.festago.support.MemberFixture;
-import com.festago.support.TicketFixture;
+import com.festago.support.fixture.MemberFixture;
+import com.festago.support.fixture.TicketFixture;
 import com.festago.ticket.domain.TicketType;
 import com.festago.ticket.repository.TicketAmountRepository;
 import com.festago.ticket.repository.TicketRepository;
@@ -60,12 +60,12 @@ class TicketingServiceTest {
         // given
         TicketingRequest request = new TicketingRequest(1L);
         given(memberRepository.findById(anyLong()))
-            .willReturn(Optional.of(MemberFixture.member().build()));
+            .willReturn(Optional.of(MemberFixture.builder().build()));
         given(memberTicketRepository.existsByOwnerAndStage(any(Member.class), any(Stage.class)))
             .willReturn(false);
 
         given(ticketRepository.findByIdWithFetch(anyLong()))
-            .willReturn(Optional.of(TicketFixture.ticket().ticketType(TicketType.STUDENT).build()));
+            .willReturn(Optional.of(TicketFixture.builder().ticketType(TicketType.STUDENT).build()));
         given(studentRepository.existsByMemberAndSchoolId(any(Member.class), anyLong()))
             .willReturn(false);
 

--- a/backend/src/test/java/com/festago/ticketing/application/integration/MemberTicketIntegrationTest.java
+++ b/backend/src/test/java/com/festago/ticketing/application/integration/MemberTicketIntegrationTest.java
@@ -11,11 +11,11 @@ import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
 import com.festago.support.ApplicationIntegrationTest;
-import com.festago.support.FestivalFixture;
-import com.festago.support.MemberFixture;
-import com.festago.support.MemberTicketFixture;
-import com.festago.support.SchoolFixture;
-import com.festago.support.StageFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.MemberFixture;
+import com.festago.support.fixture.MemberTicketFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StageFixture;
 import com.festago.ticket.repository.TicketRepository;
 import com.festago.ticketing.application.MemberTicketService;
 import com.festago.ticketing.dto.MemberTicketsResponse;
@@ -54,12 +54,12 @@ class MemberTicketIntegrationTest extends ApplicationIntegrationTest {
     @Test
     void 예매한_티켓_조회시_Pageable_적용() {
         // given
-        School school = schoolRepository.save(SchoolFixture.school().build());
-        Member member = memberRepository.save(MemberFixture.member().build());
-        Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
-        Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
+        School school = schoolRepository.save(SchoolFixture.builder().build());
+        Member member = memberRepository.save(MemberFixture.builder().build());
+        Festival festival = festivalRepository.save(FestivalFixture.builder().school(school).build());
+        Stage stage = stageRepository.save(StageFixture.builder().festival(festival).build());
         for (int i = 0; i < 20; i++) {
-            memberTicketRepository.save(MemberTicketFixture.memberTicket()
+            memberTicketRepository.save(MemberTicketFixture.builder()
                 .stage(stage)
                 .owner(member)
                 .build()

--- a/backend/src/test/java/com/festago/ticketing/application/integration/TicketingServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/ticketing/application/integration/TicketingServiceIntegrationTest.java
@@ -12,7 +12,7 @@ import com.festago.member.repository.MemberRepository;
 import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.support.ApplicationIntegrationTest;
-import com.festago.support.MemberFixture;
+import com.festago.support.fixture.MemberFixture;
 import com.festago.ticketing.application.TicketingService;
 import com.festago.ticketing.dto.TicketingRequest;
 import com.festago.ticketing.repository.MemberTicketRepository;
@@ -54,7 +54,7 @@ class TicketingServiceIntegrationTest extends ApplicationIntegrationTest {
     void 동시에_100명이_예약() {
         // given
         int tryCount = 100;
-        Member member = memberRepository.save(MemberFixture.member().build());
+        Member member = memberRepository.save(MemberFixture.builder().build());
         TicketingRequest request = new TicketingRequest(1L);
         ExecutorService executor = Executors.newFixedThreadPool(16);
         doReturn(false)
@@ -80,7 +80,7 @@ class TicketingServiceIntegrationTest extends ApplicationIntegrationTest {
     @Sql("/ticketing-test-data.sql")
     void 하나의_공연에_중복으로_티켓을_예매하면_예외() {
         // given
-        Member member = memberRepository.save(MemberFixture.member().build());
+        Member member = memberRepository.save(MemberFixture.builder().build());
         TicketingRequest request = new TicketingRequest(1L);
         Long memberId = member.getId();
         doReturn(Instant.parse("2023-07-24T03:21:31Z"))

--- a/backend/src/test/java/com/festago/ticketing/domain/MemberTicketTest.java
+++ b/backend/src/test/java/com/festago/ticketing/domain/MemberTicketTest.java
@@ -11,11 +11,11 @@ import com.festago.common.exception.ErrorCode;
 import com.festago.festival.domain.Festival;
 import com.festago.member.domain.Member;
 import com.festago.stage.domain.Stage;
-import com.festago.support.FestivalFixture;
-import com.festago.support.MemberFixture;
-import com.festago.support.MemberTicketFixture;
-import com.festago.support.StageFixture;
-import com.festago.support.TicketFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.MemberFixture;
+import com.festago.support.fixture.MemberTicketFixture;
+import com.festago.support.fixture.StageFixture;
+import com.festago.support.fixture.TicketFixture;
 import com.festago.ticket.domain.ReservationSequence;
 import com.festago.ticket.domain.Ticket;
 import java.time.LocalDateTime;
@@ -38,19 +38,19 @@ class MemberTicketTest {
             // given
             LocalDateTime stageStartTime = LocalDateTime.parse("2022-08-12T18:00:00");
             LocalDateTime now = stageStartTime.plusHours(1);
-            Festival festival = FestivalFixture.festival()
+            Festival festival = FestivalFixture.builder()
                 .startDate(stageStartTime.toLocalDate())
                 .endDate(stageStartTime.toLocalDate())
                 .build();
-            Stage stage = StageFixture.stage()
+            Stage stage = StageFixture.builder()
                 .startTime(stageStartTime)
                 .ticketOpenTime(stageStartTime.minusDays(1))
                 .festival(festival)
                 .build();
-            Ticket ticket = TicketFixture.ticket()
+            Ticket ticket = TicketFixture.builder()
                 .stage(stage)
                 .build();
-            Member member = MemberFixture.member()
+            Member member = MemberFixture.builder()
                 .id(1L)
                 .build();
 
@@ -68,19 +68,19 @@ class MemberTicketTest {
             // given
             LocalDateTime stageStartTime = LocalDateTime.parse("2022-08-12T18:00:00");
             LocalDateTime now = stageStartTime.minusHours(6);
-            Festival festival = FestivalFixture.festival()
+            Festival festival = FestivalFixture.builder()
                 .startDate(stageStartTime.toLocalDate())
                 .endDate(stageStartTime.toLocalDate())
                 .build();
-            Stage stage = StageFixture.stage()
+            Stage stage = StageFixture.builder()
                 .startTime(stageStartTime)
                 .ticketOpenTime(stageStartTime.minusDays(1))
                 .festival(festival)
                 .build();
-            Ticket ticket = TicketFixture.ticket()
+            Ticket ticket = TicketFixture.builder()
                 .stage(stage)
                 .build();
-            Member member = MemberFixture.member()
+            Member member = MemberFixture.builder()
                 .id(1L)
                 .build();
 
@@ -107,7 +107,7 @@ class MemberTicketTest {
             LocalDateTime entryTime = LocalDateTime.now();
             LocalDateTime time = entryTime.minusMinutes(10);
 
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .entryTime(entryTime)
                 .build();
 
@@ -121,7 +121,7 @@ class MemberTicketTest {
             LocalDateTime entryTime = LocalDateTime.now();
             LocalDateTime time = entryTime.plusHours(24);
 
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .entryTime(entryTime)
                 .build();
 
@@ -134,16 +134,16 @@ class MemberTicketTest {
         void 입장_가능(LocalDateTime time) {
             // given
             LocalDateTime entryTime = LocalDateTime.parse("2023-07-27T18:00:00");
-            Festival festival = FestivalFixture.festival()
+            Festival festival = FestivalFixture.builder()
                 .startDate(entryTime.toLocalDate())
                 .endDate(entryTime.plusDays(4).toLocalDate())
                 .build();
-            Stage stage = StageFixture.stage()
+            Stage stage = StageFixture.builder()
                 .startTime(entryTime.plusHours(4))
                 .ticketOpenTime(entryTime.minusWeeks(1))
                 .festival(festival)
                 .build();
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .stage(stage)
                 .entryTime(entryTime)
                 .build();
@@ -162,7 +162,7 @@ class MemberTicketTest {
             LocalDateTime entryTime = LocalDateTime.now();
             LocalDateTime time = entryTime.plusHours(1);
 
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .entryTime(entryTime)
                 .build();
 
@@ -175,15 +175,15 @@ class MemberTicketTest {
             // given
             LocalDateTime entryTime = LocalDateTime.now();
             LocalDateTime time = entryTime.minusHours(12).plusSeconds(1);
-            Festival festival = FestivalFixture.festival()
+            Festival festival = FestivalFixture.builder()
                 .startDate(entryTime.toLocalDate())
                 .endDate(entryTime.plusDays(4).toLocalDate())
                 .build();
-            Stage stage = StageFixture.stage()
+            Stage stage = StageFixture.builder()
                 .startTime(entryTime.plusHours(4))
                 .festival(festival)
                 .build();
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .stage(stage)
                 .entryTime(entryTime)
                 .build();
@@ -199,7 +199,7 @@ class MemberTicketTest {
         @Test
         void 상태_변경시_기존의_상태와_다르면_기존_상태가_유지된다() {
             // given
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket().build();
+            MemberTicket memberTicket = MemberTicketFixture.builder().build();
 
             // when
             memberTicket.changeState(AFTER_ENTRY);
@@ -211,7 +211,7 @@ class MemberTicketTest {
         @Test
         void 출입_전_상태에서_상태를_변경하면_출입_후_상태로_변경() {
             // given
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket().build();
+            MemberTicket memberTicket = MemberTicketFixture.builder().build();
 
             // when
             memberTicket.changeState(BEFORE_ENTRY);
@@ -223,7 +223,7 @@ class MemberTicketTest {
         @Test
         void 출입_후_상태에서_상태를_변경하면_외출_상태로_변경() {
             // given
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket().build();
+            MemberTicket memberTicket = MemberTicketFixture.builder().build();
             memberTicket.changeState(BEFORE_ENTRY);
 
             // when
@@ -236,7 +236,7 @@ class MemberTicketTest {
         @Test
         void 외출_상태에서_상태를_변경하면_출입_후_상태로_변경() {
             // given
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket().build();
+            MemberTicket memberTicket = MemberTicketFixture.builder().build();
             memberTicket.changeState(BEFORE_ENTRY);
             memberTicket.changeState(AFTER_ENTRY);
 
@@ -256,7 +256,7 @@ class MemberTicketTest {
             // given
             Long memberId = 1L;
             Member member = new Member(memberId);
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .owner(member)
                 .build();
 
@@ -270,7 +270,7 @@ class MemberTicketTest {
             Long memberId = 1L;
             Long ownerId = 2L;
             Member owner = new Member(ownerId);
-            MemberTicket memberTicket = MemberTicketFixture.memberTicket()
+            MemberTicket memberTicket = MemberTicketFixture.builder()
                 .owner(owner)
                 .build();
 

--- a/backend/src/test/java/com/festago/ticketing/repository/MemberTicketRepositoryTest.java
+++ b/backend/src/test/java/com/festago/ticketing/repository/MemberTicketRepositoryTest.java
@@ -11,12 +11,12 @@ import com.festago.school.domain.School;
 import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
-import com.festago.support.FestivalFixture;
-import com.festago.support.MemberFixture;
-import com.festago.support.MemberTicketFixture;
 import com.festago.support.RepositoryTest;
-import com.festago.support.SchoolFixture;
-import com.festago.support.StageFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.MemberFixture;
+import com.festago.support.fixture.MemberTicketFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StageFixture;
 import com.festago.ticket.repository.TicketRepository;
 import com.festago.ticketing.domain.MemberTicket;
 import java.util.ArrayList;
@@ -60,17 +60,17 @@ class MemberTicketRepositoryTest {
         @Test
         void 성공() {
             // given
-            Member member1 = memberRepository.save(MemberFixture.member().socialId("abc").build());
-            Member member2 = memberRepository.save(MemberFixture.member().socialId("def").build());
+            Member member1 = memberRepository.save(MemberFixture.builder().socialId("abc").build());
+            Member member2 = memberRepository.save(MemberFixture.builder().socialId("def").build());
 
-            School school = schoolRepository.save(SchoolFixture.school().build());
-            Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
-            Stage stage1 = stageRepository.save(StageFixture.stage().festival(festival).build());
-            Stage stage2 = stageRepository.save(StageFixture.stage().festival(festival).build());
+            School school = schoolRepository.save(SchoolFixture.builder().build());
+            Festival festival = festivalRepository.save(FestivalFixture.builder().school(school).build());
+            Stage stage1 = stageRepository.save(StageFixture.builder().festival(festival).build());
+            Stage stage2 = stageRepository.save(StageFixture.builder().festival(festival).build());
 
-            memberTicketRepository.save(MemberTicketFixture.memberTicket().stage(stage1).owner(member1).build());
-            memberTicketRepository.save(MemberTicketFixture.memberTicket().stage(stage2).owner(member1).build());
-            memberTicketRepository.save(MemberTicketFixture.memberTicket().stage(stage1).owner(member2).build());
+            memberTicketRepository.save(MemberTicketFixture.builder().stage(stage1).owner(member1).build());
+            memberTicketRepository.save(MemberTicketFixture.builder().stage(stage2).owner(member1).build());
+            memberTicketRepository.save(MemberTicketFixture.builder().stage(stage1).owner(member2).build());
 
             // when
             List<MemberTicket> memberTickets = memberTicketRepository.findAllByOwnerId(member1.getId(),
@@ -84,14 +84,14 @@ class MemberTicketRepositoryTest {
         void 지정한_갯수만큼_조회() {
             // given
             int expected = 10;
-            Member member = memberRepository.save(MemberFixture.member().build());
+            Member member = memberRepository.save(MemberFixture.builder().build());
 
-            School school = schoolRepository.save(SchoolFixture.school().build());
-            Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
-            Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
+            School school = schoolRepository.save(SchoolFixture.builder().build());
+            Festival festival = festivalRepository.save(FestivalFixture.builder().school(school).build());
+            Stage stage = stageRepository.save(StageFixture.builder().festival(festival).build());
 
             for (int i = 0; i < 20; i++) {
-                memberTicketRepository.save(MemberTicketFixture.memberTicket().stage(stage).owner(member).build());
+                memberTicketRepository.save(MemberTicketFixture.builder().stage(stage).owner(member).build());
             }
 
             // when
@@ -105,15 +105,15 @@ class MemberTicketRepositoryTest {
         @Test
         void 지정한_정렬으로_조회() {
             // given
-            Member member = memberRepository.save(MemberFixture.member().build());
+            Member member = memberRepository.save(MemberFixture.builder().build());
 
-            School school = schoolRepository.save(SchoolFixture.school().build());
-            Festival festival = festivalRepository.save(FestivalFixture.festival().school(school).build());
-            Stage stage = stageRepository.save(StageFixture.stage().festival(festival).build());
+            School school = schoolRepository.save(SchoolFixture.builder().build());
+            Festival festival = festivalRepository.save(FestivalFixture.builder().school(school).build());
+            Stage stage = stageRepository.save(StageFixture.builder().festival(festival).build());
 
             List<MemberTicket> memberTickets = new ArrayList<>();
             for (int i = 0; i < 20; i++) {
-                memberTickets.add(MemberTicketFixture.memberTicket().stage(stage).owner(member).build());
+                memberTickets.add(MemberTicketFixture.builder().stage(stage).owner(member).build());
             }
             memberTicketRepository.saveAll(memberTickets);
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #806

## ✨ PR 세부 내용

다 같이 작업했으므로, 자세한 내용은 남기지 않겠습니다.

다만 도메인 단위 테스트에서도 픽스쳐 사용이 보이는데, 도메인 단위 테스트에서 픽스쳐를 사용해야 하는가에 대해 얘기가 필요할 것 같습니다.

```java
class StageTest {
    @Test
    void 공연이_축제_시작_일자_이전이면_예외() {
        // given
        LocalDateTime startTime = LocalDateTime.parse("2023-07-26T18:00:00");
        LocalDateTime ticketOpenTime = LocalDateTime.parse("2023-07-26T17:00:00");
        Festival festival = FestivalFixture.builder()
            .startDate(startTime.plusDays(1).toLocalDate())
            .endDate(startTime.plusDays(1).toLocalDate())
            .build();

        // when & then
        assertThatThrownBy(() -> StageFixture.builder()
            .startTime(startTime)
            .ticketOpenTime(ticketOpenTime)
            .festival(festival)
            .build()
        )
            .isInstanceOf(BadRequestException.class)
            .hasMessage(INVALID_STAGE_START_TIME.getMessage());
    }
}
```

Stage의 경우 의존하는 Festival을 픽스쳐로 사용하는 것은 상관 없다고 보나, Stage 테스트에서 Stage를 픽스쳐로 생성하는 것은 결국 픽스쳐를 테스트하는 느낌이 드네요.
(물론 픽스쳐에서 Stage 객체를 생성하니까 문제가 발생하지는 않겠지만, 픽스쳐에서 null 값을 기본 값으로 세팅했을 때, 예외가 발생해야 하는데 발생하지 않는 경우)

해당 PR 머지되면 각 도메인 패키지에서 엔티티의 생성자로 생성하던 로직을 픽스쳐를 사용한 방법으로 리팩터링하면 될 것 같습니다.