### PR TITLE
[BE] feat: 관리자 로그인 응답 변경 및 AdminController 버저닝 적용 (#797)

### DIFF
--- a/backend/src/main/java/com/festago/admin/domain/Admin.java
+++ b/backend/src/main/java/com/festago/admin/domain/Admin.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -54,6 +55,10 @@ public class Admin extends BaseTimeEntity {
         this.password = password;
     }
 
+    public static Admin createRootAdmin(String password) {
+        return new Admin(ROOT_ADMIN_NAME, password);
+    }
+
     private void validate(String username, String password) {
         validateUsername(username);
         validatePassword(password);
@@ -71,6 +76,10 @@ public class Admin extends BaseTimeEntity {
         Validator.notBlank(password, fieldName);
         Validator.minLength(password, MIN_PASSWORD_LENGTH, fieldName);
         Validator.maxLength(password, MAX_PASSWORD_LENGTH, fieldName);
+    }
+
+    public boolean isRootAdmin() {
+        return Objects.equals(username, ROOT_ADMIN_NAME);
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/festago/auth/application/AdminAuthService.java
+++ b/backend/src/main/java/com/festago/auth/application/AdminAuthService.java
@@ -17,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Deprecated(forRemoval = true)
 @Service
 @Transactional
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/festago/auth/application/command/AdminAuthCommandService.java
+++ b/backend/src/main/java/com/festago/auth/application/command/AdminAuthCommandService.java
@@ -1,0 +1,84 @@
+package com.festago.auth.application.command;
+
+import com.festago.admin.domain.Admin;
+import com.festago.admin.repository.AdminRepository;
+import com.festago.auth.application.AuthProvider;
+import com.festago.auth.domain.AuthPayload;
+import com.festago.auth.domain.AuthType;
+import com.festago.auth.domain.Role;
+import com.festago.auth.dto.command.AdminLoginCommand;
+import com.festago.auth.dto.command.AdminLoginResult;
+import com.festago.auth.dto.command.AdminSignupCommand;
+import com.festago.common.exception.BadRequestException;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.ForbiddenException;
+import com.festago.common.exception.UnauthorizedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminAuthCommandService {
+
+    private final AuthProvider authProvider;
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional(readOnly = true)
+    public AdminLoginResult login(AdminLoginCommand command) {
+        Admin admin = findAdminWithAuthenticate(command);
+        AuthPayload authPayload = new AuthPayload(admin.getId(), Role.ADMIN);
+        String accessToken = authProvider.provide(authPayload);
+        return new AdminLoginResult(
+            admin.getUsername(),
+            getAuthType(admin),
+            accessToken
+        );
+    }
+
+    private Admin findAdminWithAuthenticate(AdminLoginCommand request) {
+        return adminRepository.findByUsername(request.username())
+            .filter(admin -> passwordEncoder.matches(request.password(), admin.getPassword()))
+            .orElseThrow(() -> new UnauthorizedException(ErrorCode.INCORRECT_PASSWORD_OR_ACCOUNT));
+    }
+
+    private AuthType getAuthType(Admin admin) {
+        if (admin.isRootAdmin()) {
+            return AuthType.ROOT;
+        }
+        return AuthType.ADMIN;
+    }
+
+    public void signup(Long adminId, AdminSignupCommand command) {
+        validateRootAdmin(adminId);
+        String username = command.username();
+        String password = passwordEncoder.encode(command.password());
+        validateExistsUsername(username);
+        adminRepository.save(new Admin(username, password));
+    }
+
+    private void validateRootAdmin(Long adminId) {
+        adminRepository.findById(adminId)
+            .filter(Admin::isRootAdmin)
+            .ifPresentOrElse(ignore -> {
+            }, () -> {
+                throw new ForbiddenException(ErrorCode.NOT_ENOUGH_PERMISSION);
+            });
+    }
+
+    private void validateExistsUsername(String username) {
+        if (adminRepository.existsByUsername(username)) {
+            throw new BadRequestException(ErrorCode.DUPLICATE_ACCOUNT_USERNAME);
+        }
+    }
+
+    public void initializeRootAdmin(String password) {
+        adminRepository.findByUsername(Admin.ROOT_ADMIN_NAME)
+            .ifPresentOrElse(ignore -> {
+                throw new BadRequestException(ErrorCode.DUPLICATE_ACCOUNT_USERNAME);
+            }, () -> adminRepository.save(Admin.createRootAdmin(password)));
+    }
+}

--- a/backend/src/main/java/com/festago/auth/application/command/AdminAuthCommandService.java
+++ b/backend/src/main/java/com/festago/auth/application/command/AdminAuthCommandService.java
@@ -79,6 +79,6 @@ public class AdminAuthCommandService {
         adminRepository.findByUsername(Admin.ROOT_ADMIN_NAME)
             .ifPresentOrElse(ignore -> {
                 throw new BadRequestException(ErrorCode.DUPLICATE_ACCOUNT_USERNAME);
-            }, () -> adminRepository.save(Admin.createRootAdmin(password)));
+            }, () -> adminRepository.save(Admin.createRootAdmin(passwordEncoder.encode(password))));
     }
 }

--- a/backend/src/main/java/com/festago/auth/config/LoginConfig.java
+++ b/backend/src/main/java/com/festago/auth/config/LoginConfig.java
@@ -38,8 +38,9 @@ public class LoginConfig implements WebMvcConfigurer {
                 .allowMethod(HttpMethod.GET, HttpMethod.POST, HttpMethod.DELETE, HttpMethod.PUT, HttpMethod.PATCH)
                 .interceptor(adminAuthInterceptor())
                 .build())
-            .addPathPatterns("/admin/**", "/js/admin/**")
-            .excludePathPatterns("/admin/login", "/admin/api/login", "/admin/api/initialize");
+            .addPathPatterns("/admin/**")
+            .excludePathPatterns("/admin/api/login", "/admin/api/initialize", "/admin/api/v1/auth/login",
+                "/admin/api/v1/auth/initialize"); // TODO #797 이슈 해결되면 레거시 API 경로 삭제할 것
         registry.addInterceptor(HttpMethodDelegateInterceptor.builder()
                 .allowMethod(HttpMethod.GET, HttpMethod.POST, HttpMethod.DELETE, HttpMethod.PUT, HttpMethod.PATCH)
                 .interceptor(memberAuthInterceptor())

--- a/backend/src/main/java/com/festago/auth/domain/AuthType.java
+++ b/backend/src/main/java/com/festago/auth/domain/AuthType.java
@@ -1,0 +1,7 @@
+package com.festago.auth.domain;
+
+public enum AuthType {
+    ROOT,
+    ADMIN,
+    ;
+}

--- a/backend/src/main/java/com/festago/auth/dto/AdminLoginRequest.java
+++ b/backend/src/main/java/com/festago/auth/dto/AdminLoginRequest.java
@@ -2,6 +2,7 @@ package com.festago.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+@Deprecated(forRemoval = true)
 public record AdminLoginRequest(
     @NotBlank(message = "username은 공백일 수 없습니다.")
     String username,

--- a/backend/src/main/java/com/festago/auth/dto/AdminLoginV1Request.java
+++ b/backend/src/main/java/com/festago/auth/dto/AdminLoginV1Request.java
@@ -1,0 +1,16 @@
+package com.festago.auth.dto;
+
+import com.festago.auth.dto.command.AdminLoginCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminLoginV1Request(
+    @NotBlank
+    String username,
+    @NotBlank
+    String password
+) {
+
+    public AdminLoginCommand toCommand() {
+        return new AdminLoginCommand(username, password);
+    }
+}

--- a/backend/src/main/java/com/festago/auth/dto/AdminLoginV1Response.java
+++ b/backend/src/main/java/com/festago/auth/dto/AdminLoginV1Response.java
@@ -1,0 +1,10 @@
+package com.festago.auth.dto;
+
+import com.festago.auth.domain.AuthType;
+
+public record AdminLoginV1Response(
+    String username,
+    AuthType authType
+) {
+
+}

--- a/backend/src/main/java/com/festago/auth/dto/AdminSignupRequest.java
+++ b/backend/src/main/java/com/festago/auth/dto/AdminSignupRequest.java
@@ -2,6 +2,7 @@ package com.festago.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+@Deprecated(forRemoval = true)
 public record AdminSignupRequest(
     @NotBlank(message = "username은 공백일 수 없습니다.")
     String username,

--- a/backend/src/main/java/com/festago/auth/dto/AdminSignupResponse.java
+++ b/backend/src/main/java/com/festago/auth/dto/AdminSignupResponse.java
@@ -1,5 +1,6 @@
 package com.festago.auth.dto;
 
+@Deprecated(forRemoval = true)
 public record AdminSignupResponse(
     String username
 ) {

--- a/backend/src/main/java/com/festago/auth/dto/AdminSignupV1Request.java
+++ b/backend/src/main/java/com/festago/auth/dto/AdminSignupV1Request.java
@@ -1,0 +1,16 @@
+package com.festago.auth.dto;
+
+import com.festago.auth.dto.command.AdminSignupCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminSignupV1Request(
+    @NotBlank
+    String username,
+    @NotBlank
+    String password
+) {
+
+    public AdminSignupCommand toCommand() {
+        return new AdminSignupCommand(username, password);
+    }
+}

--- a/backend/src/main/java/com/festago/auth/dto/command/AdminLoginCommand.java
+++ b/backend/src/main/java/com/festago/auth/dto/command/AdminLoginCommand.java
@@ -1,0 +1,8 @@
+package com.festago.auth.dto.command;
+
+public record AdminLoginCommand(
+    String username,
+    String password
+) {
+
+}

--- a/backend/src/main/java/com/festago/auth/dto/command/AdminLoginResult.java
+++ b/backend/src/main/java/com/festago/auth/dto/command/AdminLoginResult.java
@@ -1,0 +1,18 @@
+package com.festago.auth.dto.command;
+
+import com.festago.auth.domain.AuthType;
+
+// TODO Command에서 반환하는 객체의 이름을 어떻게 하면 좋을까
+// 버저닝을 사용하지 않고 AdminLoginResponse라고 한 뒤 버저닝 된 컨트롤러에서 AdminLoginV1Response 객체로 변환하여 사용?
+// 혹은 지금과 같이 AdminLoginResult와 같이 Response라는 이름을 빼고 반환할지..?
+// Controller에서 필요한 응답은 username과 authType임.
+// 그리고 accessToken은 쿠키로 반환하기 때문에 다음과 같이 accessToken이 필드로 있게 되면 필요하지 않은 응답이 나감
+// 클라이언트에서 필요하지 않은 필드는 무시하지만, accessToken과 같은 보안에 관련된 값일때 필요하지 않은 값은
+// 필요가 없다면 보내지 않는게 좋지 않을까?
+public record AdminLoginResult(
+    String username,
+    AuthType authType,
+    String accessToken
+) {
+
+}

--- a/backend/src/main/java/com/festago/auth/dto/command/AdminSignupCommand.java
+++ b/backend/src/main/java/com/festago/auth/dto/command/AdminSignupCommand.java
@@ -1,0 +1,8 @@
+package com.festago.auth.dto.command;
+
+public record AdminSignupCommand(
+    String username,
+    String password
+) {
+
+}

--- a/backend/src/main/java/com/festago/auth/presentation/AdminAuthController.java
+++ b/backend/src/main/java/com/festago/auth/presentation/AdminAuthController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Deprecated(forRemoval = true)
 @RestController
 @RequestMapping("/admin/api")
 @Hidden

--- a/backend/src/main/java/com/festago/auth/presentation/v1/AdminAuthV1Controller.java
+++ b/backend/src/main/java/com/festago/auth/presentation/v1/AdminAuthV1Controller.java
@@ -1,0 +1,82 @@
+package com.festago.auth.presentation.v1;
+
+import com.festago.auth.annotation.Admin;
+import com.festago.auth.application.command.AdminAuthCommandService;
+import com.festago.auth.dto.AdminLoginV1Request;
+import com.festago.auth.dto.AdminLoginV1Response;
+import com.festago.auth.dto.AdminSignupV1Request;
+import com.festago.auth.dto.RootAdminInitializeRequest;
+import com.festago.auth.dto.command.AdminLoginResult;
+import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.Valid;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/api/v1/auth")
+@Hidden
+@RequiredArgsConstructor
+public class AdminAuthV1Controller {
+
+    private final AdminAuthCommandService adminAuthCommandService;
+
+    @PostMapping("/login")
+    public ResponseEntity<AdminLoginV1Response> login(
+        @RequestBody @Valid AdminLoginV1Request request
+    ) {
+        AdminLoginResult result = adminAuthCommandService.login(request.toCommand());
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, createLoginCookie(result.accessToken()))
+            .body(new AdminLoginV1Response(result.username(), result.authType()));
+    }
+
+    private String createLoginCookie(String token) {
+        return ResponseCookie.from("token", token)
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("None")
+            .path("/")
+            .build().toString();
+    }
+
+    @GetMapping("/logout")
+    public ResponseEntity<Void> logout() {
+        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, createLogoutCookie())
+            .build();
+    }
+
+    private String createLogoutCookie() {
+        return ResponseCookie.from("token", "")
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("None")
+            .path("/")
+            .maxAge(Duration.ZERO)
+            .build().toString();
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signupAdminAccount(
+        @RequestBody @Valid AdminSignupV1Request request,
+        @Admin Long adminId
+    ) {
+        adminAuthCommandService.signup(adminId, request.toCommand());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/initialize")
+    public ResponseEntity<Void> initializeRootAdmin(
+        @RequestBody @Valid RootAdminInitializeRequest request
+    ) {
+        adminAuthCommandService.initializeRootAdmin(request.password());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/test/java/com/festago/auth/application/AdminAuthServiceTest.java
+++ b/backend/src/test/java/com/festago/auth/application/AdminAuthServiceTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 
+@Deprecated(forRemoval = true)
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class AdminAuthServiceTest {

--- a/backend/src/test/java/com/festago/auth/application/command/AdminAuthCommandServiceTest.java
+++ b/backend/src/test/java/com/festago/auth/application/command/AdminAuthCommandServiceTest.java
@@ -19,6 +19,7 @@ import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.ErrorCode;
 import com.festago.common.exception.ForbiddenException;
 import com.festago.common.exception.UnauthorizedException;
+import com.festago.support.fixture.AdminFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -64,7 +65,10 @@ class AdminAuthCommandServiceTest {
         @Test
         void 비밀번호가_틀리면_예외() {
             // given
-            adminRepository.save(new Admin("admin", "{noop}password"));
+            adminRepository.save(AdminFixture.builder()
+                .username("admin")
+                .password("{noop}password")
+                .build());
             var command = new AdminLoginCommand("admin", "admin");
 
             // when & then
@@ -76,7 +80,10 @@ class AdminAuthCommandServiceTest {
         @Test
         void 성공() {
             // given
-            adminRepository.save(new Admin("admin", "{noop}password"));
+            adminRepository.save(AdminFixture.builder()
+                .username("admin")
+                .password("{noop}password")
+                .build());
             var command = new AdminLoginCommand("admin", "password");
             given(authProvider.provide(any()))
                 .willReturn("token");
@@ -108,7 +115,10 @@ class AdminAuthCommandServiceTest {
         @Test
         void Root_어드민이_아니면_예외() {
             // given
-            Admin admin = adminRepository.save(new Admin("glen", "{noop}password"));
+            Admin admin = adminRepository.save(AdminFixture.builder()
+                .username("glen")
+                .password("{noop}password")
+                .build());
             var command = new AdminSignupCommand("newAdmin", "password");
 
             // when & then

--- a/backend/src/test/java/com/festago/auth/application/command/AdminAuthCommandServiceTest.java
+++ b/backend/src/test/java/com/festago/auth/application/command/AdminAuthCommandServiceTest.java
@@ -1,0 +1,160 @@
+package com.festago.auth.application.command;
+
+import static com.festago.common.exception.ErrorCode.DUPLICATE_ACCOUNT_USERNAME;
+import static com.festago.common.exception.ErrorCode.INCORRECT_PASSWORD_OR_ACCOUNT;
+import static com.festago.common.exception.ErrorCode.NOT_ENOUGH_PERMISSION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.festago.admin.domain.Admin;
+import com.festago.admin.repository.AdminRepository;
+import com.festago.admin.repository.MemoryAdminRepository;
+import com.festago.auth.application.AuthProvider;
+import com.festago.auth.dto.command.AdminLoginCommand;
+import com.festago.auth.dto.command.AdminSignupCommand;
+import com.festago.common.exception.BadRequestException;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.ForbiddenException;
+import com.festago.common.exception.UnauthorizedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class AdminAuthCommandServiceTest {
+
+    AdminRepository adminRepository;
+
+    AuthProvider authProvider;
+
+    AdminAuthCommandService adminAuthCommandService;
+
+    @BeforeEach
+    void setUp() {
+        adminRepository = new MemoryAdminRepository();
+        authProvider = mock(AuthProvider.class);
+        adminAuthCommandService = new AdminAuthCommandService(
+            authProvider,
+            adminRepository,
+            PasswordEncoderFactories.createDelegatingPasswordEncoder()
+        );
+    }
+
+    @Nested
+    class 로그인 {
+
+        @Test
+        void 계정이_없으면_예외() {
+            // given
+            var command = new AdminLoginCommand("admin", "password");
+
+            // when & then
+            assertThatThrownBy(() -> adminAuthCommandService.login(command))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage(INCORRECT_PASSWORD_OR_ACCOUNT.getMessage());
+        }
+
+        @Test
+        void 비밀번호가_틀리면_예외() {
+            // given
+            adminRepository.save(new Admin("admin", "{noop}password"));
+            var command = new AdminLoginCommand("admin", "admin");
+
+            // when & then
+            assertThatThrownBy(() -> adminAuthCommandService.login(command))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage(INCORRECT_PASSWORD_OR_ACCOUNT.getMessage());
+        }
+
+        @Test
+        void 성공() {
+            // given
+            adminRepository.save(new Admin("admin", "{noop}password"));
+            var command = new AdminLoginCommand("admin", "password");
+            given(authProvider.provide(any()))
+                .willReturn("token");
+
+            // when
+            var result = adminAuthCommandService.login(command);
+
+            // then
+            assertThat(result.accessToken()).isEqualTo("token");
+        }
+    }
+
+    @Nested
+    class 가입 {
+
+        @Test
+        void 닉네임이_중복이면_예외() {
+            // given
+            Admin rootAdmin = adminRepository.save(Admin.createRootAdmin("{noop}password"));
+            var command = new AdminSignupCommand("admin", "password");
+
+            // when & then
+            Long rootAdminId = rootAdmin.getId();
+            assertThatThrownBy(() -> adminAuthCommandService.signup(rootAdminId, command))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(DUPLICATE_ACCOUNT_USERNAME.getMessage());
+        }
+
+        @Test
+        void Root_어드민이_아니면_예외() {
+            // given
+            Admin admin = adminRepository.save(new Admin("glen", "{noop}password"));
+            var command = new AdminSignupCommand("newAdmin", "password");
+
+            // when & then
+            Long adminId = admin.getId();
+            assertThatThrownBy(() -> adminAuthCommandService.signup(adminId, command))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage(NOT_ENOUGH_PERMISSION.getMessage());
+        }
+
+        @Test
+        void 성공() {
+            // given
+            Admin rootAdmin = adminRepository.save(Admin.createRootAdmin("{noop}password"));
+            var command = new AdminSignupCommand("newAdmin", "password");
+
+            // when
+            adminAuthCommandService.signup(rootAdmin.getId(), command);
+
+            // then
+            assertThat(adminRepository.existsByUsername(command.username())).isTrue();
+        }
+    }
+
+    @Nested
+    class 루트_어드민_초기화 {
+
+        @Test
+        void 루트_어드민을_활성화하면_저장된다() {
+            // when
+            adminAuthCommandService.initializeRootAdmin("1234");
+
+            // then
+            Admin rootAdmin = Admin.createRootAdmin("1234");
+            assertThat(adminRepository.existsByUsername(rootAdmin.getUsername()))
+                .isTrue();
+        }
+
+        @Test
+        void 루트_어드민이_존재하는데_초기화하면_예외() {
+            // given
+            adminAuthCommandService.initializeRootAdmin("1234");
+
+            // when & then
+            assertThatThrownBy(() -> adminAuthCommandService.initializeRootAdmin("1234"))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.DUPLICATE_ACCOUNT_USERNAME.getMessage());
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/auth/presentation/AdminAuthControllerTest.java
+++ b/backend/src/test/java/com/festago/auth/presentation/AdminAuthControllerTest.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+@Deprecated(forRemoval = true)
 @CustomWebMvcTest
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")

--- a/backend/src/test/java/com/festago/auth/presentation/v1/AdminAuthV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/auth/presentation/v1/AdminAuthV1ControllerTest.java
@@ -1,0 +1,194 @@
+package com.festago.auth.presentation.v1;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.auth.application.command.AdminAuthCommandService;
+import com.festago.auth.domain.AuthType;
+import com.festago.auth.domain.Role;
+import com.festago.auth.dto.AdminLoginV1Request;
+import com.festago.auth.dto.AdminSignupV1Request;
+import com.festago.auth.dto.RootAdminInitializeRequest;
+import com.festago.auth.dto.command.AdminLoginCommand;
+import com.festago.auth.dto.command.AdminLoginResult;
+import com.festago.support.CustomWebMvcTest;
+import com.festago.support.WithMockAuth;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class AdminAuthV1ControllerTest {
+
+    private static final Cookie TOKEN_COOKIE = new Cookie("token", "token");
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    AdminAuthCommandService adminAuthCommandService;
+
+    @Nested
+    class 어드민_로그인 {
+
+        final String uri = "/admin/api/v1/auth/login";
+
+        @Nested
+        @DisplayName("POST " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            void 요청을_보내면_200_응답과_로그인_토큰이_담긴_쿠키가_반환된다() throws Exception {
+                // given
+                var request = new AdminLoginV1Request("admin", "1234");
+                given(adminAuthCommandService.login(any(AdminLoginCommand.class)))
+                    .willReturn(new AdminLoginResult("admin", AuthType.ROOT, "token"));
+
+                // when & then
+                mockMvc.perform(post(uri)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(cookie().exists(TOKEN_COOKIE.getName()))
+                    .andExpect(cookie().path(TOKEN_COOKIE.getName(), "/"))
+                    .andExpect(cookie().secure(TOKEN_COOKIE.getName(), true))
+                    .andExpect(cookie().httpOnly(TOKEN_COOKIE.getName(), true))
+                    .andExpect(cookie().sameSite(TOKEN_COOKIE.getName(), "None"));
+            }
+        }
+    }
+
+    @Nested
+    class 어드민_로그아웃 {
+
+        final String uri = "/admin/api/v1/auth/logout";
+
+        @Nested
+        @DisplayName("GET " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답과_비어있는_값의_로그인_토큰이_담긴_쿠키가_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isOk())
+                    .andExpect(cookie().exists(TOKEN_COOKIE.getName()))
+                    .andExpect(cookie().value(TOKEN_COOKIE.getName(), ""))
+                    .andExpect(cookie().path(TOKEN_COOKIE.getName(), "/"))
+                    .andExpect(cookie().secure(TOKEN_COOKIE.getName(), true))
+                    .andExpect(cookie().httpOnly(TOKEN_COOKIE.getName(), true))
+                    .andExpect(cookie().sameSite(TOKEN_COOKIE.getName(), "None"));
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
+
+    @Nested
+    class 어드민_회원가입 {
+
+        final String uri = "/admin/api/v1/auth/signup";
+
+        @Nested
+        @DisplayName("POST " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답과_생성한_계정이_반환된다() throws Exception {
+                var request = new AdminSignupV1Request("newAdmin", "1234");
+
+                // when & then
+                mockMvc.perform(post(uri)
+                        .cookie(TOKEN_COOKIE)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
+
+    @Nested
+    class 루트_어드민_활성화 {
+
+        final String uri = "/admin/api/v1/auth/initialize";
+
+        @Nested
+        @DisplayName("POST " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                // given
+                var request = new RootAdminInitializeRequest("1234");
+
+                // when & then
+                mockMvc.perform(post(uri)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.ANONYMOUS)
+            void 권한이_없어도_200_응답이_반환된다() throws Exception {
+                // given
+                var request = new RootAdminInitializeRequest("1234");
+
+                // when & then
+                mockMvc.perform(post(uri)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #797

## ✨ PR 세부 내용

이슈 내용과 같이 관리자 페이지에서 사용해야 할 기능을 위해 로그인 시 새로운 응답을 추가했습니다.
(해당 PR이 머지되면 관리자 페이지에서 로그인이 불가능해지므로, 기존 기능들은 Deprecated 처리 했습니다!)

구현하며 논의하고 싶은 내용이 있는데, `AdminLoginResult` 클래스의 TODO 주석으로 길게 남겼지만,  Command Service에서 반환하는 객체의 이름을 무엇으로 해야할지 모르겠네요. 😂

지금은 버저닝이 적용되었다 하더라도, V2와 같은 새로운 버전이 필요하지 않기 때문에 Service에서 View에 필요한 Response를 그대로 반환해도 되지만, 어드민 로그인 응답의 토큰 값은 응답의 JSON 필드가 아닌, 쿠키로 전송되어야 합니다.

또한 클라이언트에서 불필요한 JSON 필드는 무시하기 때문에 Service에서 반환한 필드를 그대로 반환해도 상관 없으나, 토큰과 같이 보안에 직접적으로 관련된 값은 클라이언트에서 굳이 필요하지 않다면 보내지 않는 것이 올바른 것 같습니다.

따라서 Controller에서 Service에서 반환한 값을 그대로 반환하기엔 무리가 있습니다.
(레이어드 아키텍쳐 관점에서 어긋나기도 하구요 😂)

따라서 `AdminLoginResult`와 같이 View에 의존적이지 않은 응답 객체를 보내어 Controller에서 가공하여 사용하도록 했습니다.
(Response라고 이름을 지으려니, Controller에서 그대로 반환해도 될 객체 같아 Result로 했습니다)

다른 의견이 있으시면 남겨주세요!!