### PR TITLE
 [BE] refactor: stage 테스트 패키지에서 엔티티 생성을 픽스쳐를 사용하여 생성하도록 변경 (#813)

### DIFF
--- a/backend/src/main/java/com/festago/artist/domain/ArtistsSerializer.java
+++ b/backend/src/main/java/com/festago/artist/domain/ArtistsSerializer.java
@@ -2,6 +2,7 @@ package com.festago.artist.domain;
 
 import java.util.List;
 
+@FunctionalInterface
 public interface ArtistsSerializer {
 
     String serialize(List<Artist> artists);

--- a/backend/src/test/java/com/festago/stage/application/command/StageCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageCommandServiceIntegrationTest.java
@@ -4,22 +4,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.festago.artist.application.ArtistCommandService;
 import com.festago.artist.domain.Artist;
-import com.festago.artist.dto.command.ArtistCreateCommand;
-import com.festago.festival.application.command.FestivalCreateService;
+import com.festago.artist.repository.ArtistRepository;
 import com.festago.festival.domain.FestivalQueryInfo;
-import com.festago.festival.dto.command.FestivalCreateCommand;
 import com.festago.festival.repository.FestivalInfoRepository;
-import com.festago.school.application.SchoolCommandService;
+import com.festago.festival.repository.FestivalRepository;
+import com.festago.school.domain.School;
 import com.festago.school.domain.SchoolRegion;
-import com.festago.school.dto.SchoolCreateCommand;
+import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.StageQueryInfo;
 import com.festago.stage.dto.command.StageCreateCommand;
 import com.festago.stage.dto.command.StageUpdateCommand;
 import com.festago.stage.repository.StageQueryInfoRepository;
 import com.festago.support.ApplicationIntegrationTest;
 import com.festago.support.TimeInstantProvider;
+import com.festago.support.fixture.ArtistFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.FestivalQueryInfoFixture;
+import com.festago.support.fixture.SchoolFixture;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -46,19 +48,19 @@ public class StageCommandServiceIntegrationTest extends ApplicationIntegrationTe
     StageDeleteService stageDeleteService;
 
     @Autowired
-    FestivalCreateService festivalCreateService;
-
-    @Autowired
-    SchoolCommandService schoolCommandService;
-
-    @Autowired
-    ArtistCommandService artistCommandService;
-
-    @Autowired
-    StageQueryInfoRepository stageQueryInfoRepository;
+    FestivalRepository festivalRepository;
 
     @Autowired
     FestivalInfoRepository festivalInfoRepository;
+
+    @Autowired
+    SchoolRepository schoolRepository;
+
+    @Autowired
+    ArtistRepository artistRepository;
+
+    @Autowired
+    StageQueryInfoRepository stageQueryInfoRepository;
 
     @Autowired
     ObjectMapper objectMapper;
@@ -79,32 +81,22 @@ public class StageCommandServiceIntegrationTest extends ApplicationIntegrationTe
     void setUp() {
         given(clock.instant())
             .willReturn(TimeInstantProvider.from(now));
+        School 테코대학교 = schoolRepository.save(SchoolFixture.builder()
+            .name("테코대학교")
+            .region(SchoolRegion.서울)
+            .build());
+        테코대학교_식별자 = 테코대학교.getId();
+        테코대학교_축제_식별자 = festivalRepository.save(FestivalFixture.builder()
+            .name("테코대학교 축제")
+            .startDate(festivalStartDate)
+            .endDate(festivalEndDate)
+            .school(테코대학교)
+            .build()).getId();
+        festivalInfoRepository.save(FestivalQueryInfoFixture.builder().festivalId(테코대학교_축제_식별자).build());
 
-        테코대학교_식별자 = schoolCommandService.createSchool(new SchoolCreateCommand(
-            "테코대학교",
-            "teco.ac.kr",
-            SchoolRegion.서울,
-            "https://image.com/logo.png",
-            "https://image.com/backgroundImage.png"
-        ));
-        테코대학교_축제_식별자 = festivalCreateService.createFestival(new FestivalCreateCommand(
-            "테코대학교 축제",
-            festivalStartDate,
-            festivalEndDate,
-            "https://image.com/posterImage.png",
-            테코대학교_식별자
-        ));
-        에픽하이_식별자 = artistCommandService.save(createArtistCreateCommand("에픽하이"));
-        소녀시대_식별자 = artistCommandService.save(createArtistCreateCommand("소녀시대"));
-        뉴진스_식별자 = artistCommandService.save(createArtistCreateCommand("뉴진스"));
-    }
-
-    private ArtistCreateCommand createArtistCreateCommand(String name) {
-        return new ArtistCreateCommand(
-            name,
-            "https://image.com/profileImage.png",
-            "https://image.com/backgroundImage.png"
-        );
+        에픽하이_식별자 = artistRepository.save(ArtistFixture.builder().name("에픽하이").build()).getId();
+        소녀시대_식별자 = artistRepository.save(ArtistFixture.builder().name("소녀시대").build()).getId();
+        뉴진스_식별자 = artistRepository.save(ArtistFixture.builder().name("뉴진스").build()).getId();
     }
 
     @Nested

--- a/backend/src/test/java/com/festago/stage/application/command/StageCreateServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageCreateServiceTest.java
@@ -15,6 +15,7 @@ import com.festago.festival.repository.MemoryFestivalRepository;
 import com.festago.stage.dto.command.StageCreateCommand;
 import com.festago.stage.repository.MemoryStageArtistRepository;
 import com.festago.stage.repository.MemoryStageRepository;
+import com.festago.support.fixture.ArtistFixture;
 import com.festago.support.fixture.FestivalFixture;
 import java.time.LocalDate;
 import java.util.List;
@@ -29,8 +30,6 @@ import org.junit.jupiter.api.Test;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class StageCreateServiceTest {
-
-    private static final String PROFILE_IMAGE_URL = "https://image.com/profileImage.png";
 
     MemoryStageRepository stageRepository = new MemoryStageRepository();
     MemoryFestivalRepository festivalRepository = new MemoryFestivalRepository();
@@ -65,9 +64,18 @@ class StageCreateServiceTest {
                 .endDate(festivalEndDate)
                 .build()
         );
-        에픽하이 = artistRepository.save(new Artist("에픽하이", PROFILE_IMAGE_URL));
-        소녀시대 = artistRepository.save(new Artist("소녀시대", PROFILE_IMAGE_URL));
-        뉴진스 = artistRepository.save(new Artist("뉴진스", PROFILE_IMAGE_URL));
+        에픽하이 = artistRepository.save(ArtistFixture.builder()
+            .name("에픽하이")
+            .build()
+        );
+        소녀시대 = artistRepository.save(ArtistFixture.builder()
+            .name("소녀시대")
+            .build()
+        );
+        뉴진스 = artistRepository.save(ArtistFixture.builder()
+            .name("뉴진스")
+            .build()
+        );
     }
 
     @Nested
@@ -113,7 +121,7 @@ class StageCreateServiceTest {
         void ArtistIds의_개수가_10개_이하이면_예외가_발생하지_않는다() {
             // given
             List<Long> artistIds = LongStream.rangeClosed(1, 10)
-                .mapToObj(it -> artistRepository.save(new Artist("Artist " + it, PROFILE_IMAGE_URL)))
+                .mapToObj(it -> artistRepository.save(ArtistFixture.builder().build()))
                 .map(Artist::getId)
                 .toList();
             var command = new StageCreateCommand(

--- a/backend/src/test/java/com/festago/stage/application/command/StageCreateServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageCreateServiceTest.java
@@ -6,15 +6,19 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.mock;
 
 import com.festago.artist.domain.Artist;
+import com.festago.artist.repository.ArtistRepository;
 import com.festago.artist.repository.MemoryArtistRepository;
 import com.festago.common.exception.ErrorCode;
 import com.festago.common.exception.NotFoundException;
 import com.festago.common.exception.ValidException;
 import com.festago.festival.domain.Festival;
+import com.festago.festival.repository.FestivalRepository;
 import com.festago.festival.repository.MemoryFestivalRepository;
 import com.festago.stage.dto.command.StageCreateCommand;
 import com.festago.stage.repository.MemoryStageArtistRepository;
 import com.festago.stage.repository.MemoryStageRepository;
+import com.festago.stage.repository.StageArtistRepository;
+import com.festago.stage.repository.StageRepository;
 import com.festago.support.fixture.ArtistFixture;
 import com.festago.support.fixture.FestivalFixture;
 import java.time.LocalDate;
@@ -31,10 +35,10 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("NonAsciiCharacters")
 class StageCreateServiceTest {
 
-    MemoryStageRepository stageRepository = new MemoryStageRepository();
-    MemoryFestivalRepository festivalRepository = new MemoryFestivalRepository();
-    MemoryArtistRepository artistRepository = new MemoryArtistRepository();
-    MemoryStageArtistRepository stageArtistRepository = new MemoryStageArtistRepository();
+    StageRepository stageRepository = new MemoryStageRepository();
+    FestivalRepository festivalRepository = new MemoryFestivalRepository();
+    ArtistRepository artistRepository = new MemoryArtistRepository();
+    StageArtistRepository stageArtistRepository = new MemoryStageArtistRepository();
     StageCreateService stageCreateService = new StageCreateService(
         stageRepository,
         festivalRepository,
@@ -52,10 +56,17 @@ class StageCreateServiceTest {
 
     @BeforeEach
     void setUp() {
-        stageRepository.clear();
-        festivalRepository.clear();
-        artistRepository.clear();
-        stageArtistRepository.clear();
+        stageRepository = new MemoryStageRepository();
+        festivalRepository = new MemoryFestivalRepository();
+        artistRepository = new MemoryArtistRepository();
+        stageArtistRepository = new MemoryStageArtistRepository();
+        stageCreateService = new StageCreateService(
+            stageRepository,
+            festivalRepository,
+            artistRepository,
+            stageArtistRepository,
+            mock()
+        );
 
         테코대학교_축제 = festivalRepository.save(
             FestivalFixture.builder()
@@ -64,18 +75,10 @@ class StageCreateServiceTest {
                 .endDate(festivalEndDate)
                 .build()
         );
-        에픽하이 = artistRepository.save(ArtistFixture.builder()
-            .name("에픽하이")
-            .build()
-        );
-        소녀시대 = artistRepository.save(ArtistFixture.builder()
-            .name("소녀시대")
-            .build()
-        );
-        뉴진스 = artistRepository.save(ArtistFixture.builder()
-            .name("뉴진스")
-            .build()
-        );
+
+        에픽하이 = artistRepository.save(ArtistFixture.builder().name("에픽하이").build());
+        소녀시대 = artistRepository.save(ArtistFixture.builder().name("소녀시대").build());
+        뉴진스 = artistRepository.save(ArtistFixture.builder().name("뉴진스").build());
     }
 
     @Nested

--- a/backend/src/test/java/com/festago/stage/application/command/StageCreateServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageCreateServiceTest.java
@@ -35,18 +35,11 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("NonAsciiCharacters")
 class StageCreateServiceTest {
 
-    StageRepository stageRepository = new MemoryStageRepository();
-    FestivalRepository festivalRepository = new MemoryFestivalRepository();
-    ArtistRepository artistRepository = new MemoryArtistRepository();
-    StageArtistRepository stageArtistRepository = new MemoryStageArtistRepository();
-    StageCreateService stageCreateService = new StageCreateService(
-        stageRepository,
-        festivalRepository,
-        artistRepository,
-        stageArtistRepository,
-        mock()
-    );
-
+    StageRepository stageRepository;
+    FestivalRepository festivalRepository;
+    ArtistRepository artistRepository;
+    StageArtistRepository stageArtistRepository;
+    StageCreateService stageCreateService;
     LocalDate festivalStartDate = LocalDate.parse("2077-06-30");
     LocalDate festivalEndDate = LocalDate.parse("2077-07-02");
     Festival 테코대학교_축제;

--- a/backend/src/test/java/com/festago/stage/application/command/StageDeleteServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageDeleteServiceTest.java
@@ -5,12 +5,16 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.mock;
 
 import com.festago.artist.domain.Artist;
+import com.festago.artist.repository.ArtistRepository;
 import com.festago.artist.repository.MemoryArtistRepository;
 import com.festago.festival.domain.Festival;
+import com.festago.festival.repository.FestivalRepository;
 import com.festago.festival.repository.MemoryFestivalRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.MemoryStageArtistRepository;
 import com.festago.stage.repository.MemoryStageRepository;
+import com.festago.stage.repository.StageArtistRepository;
+import com.festago.stage.repository.StageRepository;
 import com.festago.support.fixture.ArtistFixture;
 import com.festago.support.fixture.FestivalFixture;
 import com.festago.support.fixture.StageArtistFixture;
@@ -27,15 +31,11 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("NonAsciiCharacters")
 class StageDeleteServiceTest {
 
-    MemoryArtistRepository artistRepository = new MemoryArtistRepository();
-    MemoryFestivalRepository festivalRepository = new MemoryFestivalRepository();
-    MemoryStageRepository stageRepository = new MemoryStageRepository();
-    MemoryStageArtistRepository stageArtistRepository = new MemoryStageArtistRepository();
-    StageDeleteService stageDeleteService = new StageDeleteService(
-        stageRepository,
-        stageArtistRepository,
-        mock()
-    );
+    ArtistRepository artistRepository;
+    FestivalRepository festivalRepository;
+    StageRepository stageRepository;
+    StageArtistRepository stageArtistRepository;
+    StageDeleteService stageDeleteService;
 
     LocalDateTime stageStartTime = LocalDateTime.parse("2077-06-30T18:00:00");
     LocalDateTime ticketOpenTime = stageStartTime.minusWeeks(1);
@@ -47,8 +47,12 @@ class StageDeleteServiceTest {
 
     @BeforeEach
     void setUp() {
-        stageRepository.clear();
-        stageArtistRepository.clear();
+        artistRepository = new MemoryArtistRepository();
+        festivalRepository = new MemoryFestivalRepository();
+        stageRepository = new MemoryStageRepository();
+        stageArtistRepository = new MemoryStageArtistRepository();
+        stageDeleteService = new StageDeleteService(stageRepository, stageArtistRepository, mock());
+
         테코대학교_축제 = festivalRepository.save(
             FestivalFixture.builder()
                 .name("테코대학교 축제")

--- a/backend/src/test/java/com/festago/stage/application/command/StageDeleteServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageDeleteServiceTest.java
@@ -63,18 +63,9 @@ class StageDeleteServiceTest {
                 .ticketOpenTime(ticketOpenTime)
                 .build()
         );
-        에픽하이 = artistRepository.save(ArtistFixture.builder()
-            .name("에픽하이")
-            .build()
-        );
-        소녀시대 = artistRepository.save(ArtistFixture.builder()
-            .name("소녀시대")
-            .build()
-        );
-        뉴진스 = artistRepository.save(ArtistFixture.builder()
-            .name("뉴진스")
-            .build()
-        );
+        에픽하이 = artistRepository.save(ArtistFixture.builder().name("에픽하이").build());
+        소녀시대 = artistRepository.save(ArtistFixture.builder().name("소녀시대").build());
+        뉴진스 = artistRepository.save(ArtistFixture.builder().name("뉴진스").build());
         stageArtistRepository.save(StageArtistFixture.builder(테코대학교_축제_공연.getId(), 에픽하이.getId()).build());
         stageArtistRepository.save(StageArtistFixture.builder(테코대학교_축제_공연.getId(), 소녀시대.getId()).build());
         stageArtistRepository.save(StageArtistFixture.builder(테코대학교_축제_공연.getId(), 뉴진스.getId()).build());

--- a/backend/src/test/java/com/festago/stage/application/command/StageDeleteServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageDeleteServiceTest.java
@@ -9,10 +9,11 @@ import com.festago.artist.repository.MemoryArtistRepository;
 import com.festago.festival.domain.Festival;
 import com.festago.festival.repository.MemoryFestivalRepository;
 import com.festago.stage.domain.Stage;
-import com.festago.stage.domain.StageArtist;
 import com.festago.stage.repository.MemoryStageArtistRepository;
 import com.festago.stage.repository.MemoryStageRepository;
+import com.festago.support.fixture.ArtistFixture;
 import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.StageArtistFixture;
 import com.festago.support.fixture.StageFixture;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,12 +63,21 @@ class StageDeleteServiceTest {
                 .ticketOpenTime(ticketOpenTime)
                 .build()
         );
-        에픽하이 = artistRepository.save(new Artist("에픽하이", "https://image.com/profileImage.png"));
-        소녀시대 = artistRepository.save(new Artist("소녀시대", "https://image.com/profileImage.png"));
-        뉴진스 = artistRepository.save(new Artist("뉴진스", "https://image.com/profileImage.png"));
-        stageArtistRepository.save(new StageArtist(테코대학교_축제_공연.getId(), 에픽하이.getId()));
-        stageArtistRepository.save(new StageArtist(테코대학교_축제_공연.getId(), 소녀시대.getId()));
-        stageArtistRepository.save(new StageArtist(테코대학교_축제_공연.getId(), 뉴진스.getId()));
+        에픽하이 = artistRepository.save(ArtistFixture.builder()
+            .name("에픽하이")
+            .build()
+        );
+        소녀시대 = artistRepository.save(ArtistFixture.builder()
+            .name("소녀시대")
+            .build()
+        );
+        뉴진스 = artistRepository.save(ArtistFixture.builder()
+            .name("뉴진스")
+            .build()
+        );
+        stageArtistRepository.save(StageArtistFixture.builder(테코대학교_축제_공연.getId(), 에픽하이.getId()).build());
+        stageArtistRepository.save(StageArtistFixture.builder(테코대학교_축제_공연.getId(), 소녀시대.getId()).build());
+        stageArtistRepository.save(StageArtistFixture.builder(테코대학교_축제_공연.getId(), 뉴진스.getId()).build());
     }
 
     @Nested

--- a/backend/src/test/java/com/festago/stage/application/command/StageUpdateServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageUpdateServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import com.festago.artist.domain.Artist;
+import com.festago.artist.repository.ArtistRepository;
 import com.festago.artist.repository.MemoryArtistRepository;
 import com.festago.common.exception.ErrorCode;
 import com.festago.common.exception.NotFoundException;
@@ -15,6 +16,8 @@ import com.festago.stage.domain.Stage;
 import com.festago.stage.dto.command.StageUpdateCommand;
 import com.festago.stage.repository.MemoryStageArtistRepository;
 import com.festago.stage.repository.MemoryStageRepository;
+import com.festago.stage.repository.StageArtistRepository;
+import com.festago.stage.repository.StageRepository;
 import com.festago.support.fixture.ArtistFixture;
 import com.festago.support.fixture.FestivalFixture;
 import com.festago.support.fixture.StageArtistFixture;
@@ -33,15 +36,10 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("NonAsciiCharacters")
 class StageUpdateServiceTest {
 
-    MemoryStageRepository stageRepository = new MemoryStageRepository();
-    MemoryArtistRepository artistRepository = new MemoryArtistRepository();
-    MemoryStageArtistRepository stageArtistRepository = new MemoryStageArtistRepository();
-    StageUpdateService stageUpdateService = new StageUpdateService(
-        stageRepository,
-        artistRepository,
-        stageArtistRepository,
-        mock()
-    );
+    StageRepository stageRepository;
+    ArtistRepository artistRepository;
+    StageArtistRepository stageArtistRepository;
+    StageUpdateService stageUpdateService;
 
     LocalDateTime stageStartTime = LocalDateTime.parse("2077-06-30T18:00:00");
     LocalDateTime ticketOpenTime = stageStartTime.minusWeeks(1);
@@ -53,7 +51,11 @@ class StageUpdateServiceTest {
 
     @BeforeEach
     void setUp() {
-        stageRepository.clear();
+        stageRepository = new MemoryStageRepository();
+        artistRepository = new MemoryArtistRepository();
+        stageArtistRepository = new MemoryStageArtistRepository();
+        stageUpdateService = new StageUpdateService(stageRepository, artistRepository, stageArtistRepository, mock());
+
         테코대학교_축제 = FestivalFixture.builder()
             .name("테코대학교 축제")
             .startDate(stageStartTime.toLocalDate())

--- a/backend/src/test/java/com/festago/stage/application/command/StageUpdateServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageUpdateServiceTest.java
@@ -59,25 +59,16 @@ class StageUpdateServiceTest {
             .startDate(stageStartTime.toLocalDate())
             .endDate(stageStartTime.toLocalDate().plusDays(2))
             .build();
-        테코대학교_축제_공연 = stageRepository.save(
-            StageFixture.builder()
-                .festival(테코대학교_축제)
-                .startTime(stageStartTime)
-                .ticketOpenTime(ticketOpenTime)
-                .build()
-        );
-        에픽하이 = artistRepository.save(ArtistFixture.builder()
-            .name("에픽하이")
-            .build()
-        );
-        소녀시대 = artistRepository.save(ArtistFixture.builder()
-            .name("소녀시대")
-            .build()
-        );
-        뉴진스 = artistRepository.save(ArtistFixture.builder()
-            .name("뉴진스")
-            .build()
-        );
+        테코대학교_축제_공연 = stageRepository.save(StageFixture.builder()
+            .festival(테코대학교_축제)
+            .startTime(stageStartTime)
+            .ticketOpenTime(ticketOpenTime)
+            .build());
+
+        에픽하이 = artistRepository.save(ArtistFixture.builder().name("에픽하이").build());
+        소녀시대 = artistRepository.save(ArtistFixture.builder().name("소녀시대").build());
+        뉴진스 = artistRepository.save(ArtistFixture.builder().name("뉴진스").build());
+
         stageArtistRepository.save(StageArtistFixture.builder(테코대학교_축제_공연.getId(), 에픽하이.getId()).build());
         stageArtistRepository.save(StageArtistFixture.builder(테코대학교_축제_공연.getId(), 소녀시대.getId()).build());
         stageArtistRepository.save(StageArtistFixture.builder(테코대학교_축제_공연.getId(), 뉴진스.getId()).build());

--- a/backend/src/test/java/com/festago/stage/application/command/StageUpdateServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageUpdateServiceTest.java
@@ -12,11 +12,12 @@ import com.festago.common.exception.NotFoundException;
 import com.festago.common.exception.ValidException;
 import com.festago.festival.domain.Festival;
 import com.festago.stage.domain.Stage;
-import com.festago.stage.domain.StageArtist;
 import com.festago.stage.dto.command.StageUpdateCommand;
 import com.festago.stage.repository.MemoryStageArtistRepository;
 import com.festago.stage.repository.MemoryStageRepository;
+import com.festago.support.fixture.ArtistFixture;
 import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.StageArtistFixture;
 import com.festago.support.fixture.StageFixture;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,7 +33,6 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("NonAsciiCharacters")
 class StageUpdateServiceTest {
 
-    private static final String PROFILE_IMAGE_URL = "https://image.com/profileImage.png";
     MemoryStageRepository stageRepository = new MemoryStageRepository();
     MemoryArtistRepository artistRepository = new MemoryArtistRepository();
     MemoryStageArtistRepository stageArtistRepository = new MemoryStageArtistRepository();
@@ -66,12 +66,21 @@ class StageUpdateServiceTest {
                 .ticketOpenTime(ticketOpenTime)
                 .build()
         );
-        에픽하이 = artistRepository.save(new Artist("에픽하이", PROFILE_IMAGE_URL));
-        소녀시대 = artistRepository.save(new Artist("소녀시대", PROFILE_IMAGE_URL));
-        뉴진스 = artistRepository.save(new Artist("뉴진스", PROFILE_IMAGE_URL));
-        stageArtistRepository.save(new StageArtist(테코대학교_축제_공연.getId(), 에픽하이.getId()));
-        stageArtistRepository.save(new StageArtist(테코대학교_축제_공연.getId(), 소녀시대.getId()));
-        stageArtistRepository.save(new StageArtist(테코대학교_축제_공연.getId(), 뉴진스.getId()));
+        에픽하이 = artistRepository.save(ArtistFixture.builder()
+            .name("에픽하이")
+            .build()
+        );
+        소녀시대 = artistRepository.save(ArtistFixture.builder()
+            .name("소녀시대")
+            .build()
+        );
+        뉴진스 = artistRepository.save(ArtistFixture.builder()
+            .name("뉴진스")
+            .build()
+        );
+        stageArtistRepository.save(StageArtistFixture.builder(테코대학교_축제_공연.getId(), 에픽하이.getId()).build());
+        stageArtistRepository.save(StageArtistFixture.builder(테코대학교_축제_공연.getId(), 소녀시대.getId()).build());
+        stageArtistRepository.save(StageArtistFixture.builder(테코대학교_축제_공연.getId(), 뉴진스.getId()).build());
     }
 
     @Nested
@@ -115,7 +124,7 @@ class StageUpdateServiceTest {
         void ArtistIds의_개수가_10개_이하이면_예외가_발생하지_않는다() {
             // given
             List<Long> artistIds = LongStream.rangeClosed(1, 10)
-                .mapToObj(it -> artistRepository.save(new Artist("Artist " + it, PROFILE_IMAGE_URL)))
+                .mapToObj(it -> artistRepository.save(ArtistFixture.builder().build()))
                 .map(Artist::getId)
                 .toList();
             var command = new StageUpdateCommand(

--- a/backend/src/test/java/com/festago/stage/domain/validator/festival/OutOfDateStageFestivalUpdateValidatorTest.java
+++ b/backend/src/test/java/com/festago/stage/domain/validator/festival/OutOfDateStageFestivalUpdateValidatorTest.java
@@ -7,6 +7,7 @@ import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.ErrorCode;
 import com.festago.festival.domain.Festival;
 import com.festago.stage.repository.MemoryStageRepository;
+import com.festago.stage.repository.StageRepository;
 import com.festago.support.fixture.FestivalFixture;
 import com.festago.support.fixture.StageFixture;
 import java.time.LocalDate;
@@ -23,13 +24,15 @@ class OutOfDateStageFestivalUpdateValidatorTest {
 
     LocalDate festivalStartDate = LocalDate.parse("2077-02-19");
     LocalDate festivalEndDate = LocalDate.parse("2077-02-21");
-    MemoryStageRepository stageRepository = new MemoryStageRepository();
-    OutOfDateStageFestivalUpdateValidator validator = new OutOfDateStageFestivalUpdateValidator(stageRepository);
+    StageRepository stageRepository;
+    OutOfDateStageFestivalUpdateValidator validator;
     Festival 축제;
 
     @BeforeEach
     void setUp() {
-        stageRepository.clear();
+        stageRepository = new MemoryStageRepository();
+        validator = new OutOfDateStageFestivalUpdateValidator(stageRepository);
+
         축제 = FestivalFixture.builder()
             .startDate(festivalStartDate)
             .endDate(festivalEndDate)

--- a/backend/src/test/java/com/festago/support/fixture/FestivalQueryInfoFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/FestivalQueryInfoFixture.java
@@ -1,11 +1,12 @@
 package com.festago.support.fixture;
 
 import com.festago.festival.domain.FestivalQueryInfo;
+import java.util.Collections;
 
 public class FestivalQueryInfoFixture extends BaseFixture {
 
     private Long festivalId;
-    private String artistInfo;
+    private String artistInfo = "";
 
     private FestivalQueryInfoFixture() {
     }
@@ -24,8 +25,9 @@ public class FestivalQueryInfoFixture extends BaseFixture {
         return this;
     }
 
-    //TODO FestivalQueryInfo에 ArtistInfo를 String으로 넣어줄 수가 없음..
     public FestivalQueryInfo build() {
-        return FestivalQueryInfo.create(festivalId);
+        FestivalQueryInfo festivalQueryInfo = FestivalQueryInfo.create(festivalId);
+        festivalQueryInfo.updateArtistInfo(Collections.emptyList(), artists -> artistInfo);
+        return festivalQueryInfo;
     }
 }

--- a/backend/src/test/java/com/festago/support/fixture/FestivalQueryInfoFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/FestivalQueryInfoFixture.java
@@ -24,9 +24,8 @@ public class FestivalQueryInfoFixture extends BaseFixture {
         return this;
     }
 
+    //TODO FestivalQueryInfo에 ArtistInfo를 String으로 넣어줄 수가 없음..
     public FestivalQueryInfo build() {
-        FestivalQueryInfo festivalQueryInfo = FestivalQueryInfo.create(festivalId);
-        festivalQueryInfo.updateArtistInfo(null, ignore -> artistInfo);
-        return festivalQueryInfo;
+        return FestivalQueryInfo.create(festivalId);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #813 

## ✨ PR 세부 내용

변경한 것 

1. PR 제목 그대로 fixture를 사용하도록 변경
2. 테스트에서 Repository 타입을 fake 구현체가 아닌 interface를 가지도록 변경, ```@BeforeEach```에서 clear 호출 안하고 객체 새로 만들어주는 방식으로 데이터 리셋
3. CommandService로 생성하던 것을 Repository로 생성하도록 변경

4. 지금은 FestivalQueyInfoFixture로 테이블에 저장하는 것이 불가능합니다. 아래와 같이 구현된 상태인데 info 필드가 not null이라서 제약 조건 에러가 발생해요. 그래서 임시적으로 다음과 같이 변경했어요

Before

```
    public FestivalQueryInfo build() {
        FestivalQueryInfo festivalQueryInfo = FestivalQueryInfo.create(festivalId);
        festivalQueryInfo.updateArtistInfo(null, ignore -> artistInfo);
        return festivalQueryInfo;
    }
```

After

```
    //TODO FestivalQueryInfo에 ArtistInfo를 String으로 넣어줄 수가 없음..
    public FestivalQueryInfo build() {
        return FestivalQueryInfo.create(festivalId);
    }
```

FestivalQueryInfo에 생성자를 public으로 하던지.. ArtistInfo 필드를 빌더에서 빼던지 등 수정해야 할 것 같네요.