### PR TITLE
[BE] admin 테스트 패키지에서 엔티티 생성을 픽스쳐를 사용하여 생성하도록 변경 (#815)

### DIFF
--- a/backend/src/test/java/com/festago/admin/application/integration/AdminFestivalV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/admin/application/integration/AdminFestivalV1QueryServiceIntegrationTest.java
@@ -17,6 +17,9 @@ import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
 import com.festago.stage.repository.StageRepository;
 import com.festago.support.ApplicationIntegrationTest;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StageFixture;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,14 +63,49 @@ class AdminFestivalV1QueryServiceIntegrationTest extends ApplicationIntegrationT
     @BeforeEach
     void setUp() {
         LocalDateTime ticketOpenTime = now.atStartOfDay().minusWeeks(1);
-        테코대학교 = schoolRepository.save(new School("teco.ac.kr", "테코대학교", SchoolRegion.서울));
-        우테대학교 = schoolRepository.save(new School("wote.ac.kr", "우테대학교", SchoolRegion.서울));
-        테코대학교_축제 = festivalRepository.save(new Festival("테코대학교 축제", now, now, 테코대학교));
-        테코대학교_공연_없는_축제 = festivalRepository.save(new Festival("테코대학교 공연 없는 축제", tomorrow, tomorrow, 테코대학교));
-        우테대학교_축제 = festivalRepository.save(new Festival("우테대학교 축제", now, tomorrow, 우테대학교));
-        테코대학교_공연 = stageRepository.save(new Stage(now.atTime(18, 0), ticketOpenTime, 테코대학교_축제));
-        우테대학교_첫째날_공연 = stageRepository.save(new Stage(now.atTime(18, 0), ticketOpenTime, 우테대학교_축제));
-        우테대학교_둘째날_공연 = stageRepository.save(new Stage(tomorrow.atTime(18, 0), ticketOpenTime, 우테대학교_축제));
+        우테대학교 = schoolRepository.save(SchoolFixture.builder()
+            .name("우테대학교")
+            .region(SchoolRegion.서울)
+            .build());
+        테코대학교 = schoolRepository.save(SchoolFixture.builder()
+            .name("테코대학교")
+            .region(SchoolRegion.서울)
+            .build());
+
+        테코대학교_축제 = festivalRepository.save(FestivalFixture.builder()
+            .name("테코대학교 축제")
+            .startDate(now)
+            .endDate(now)
+            .school(테코대학교)
+            .build());
+        테코대학교_공연_없는_축제 = festivalRepository.save(FestivalFixture.builder()
+            .name("테코대학교 공연 없는 축제")
+            .startDate(tomorrow)
+            .endDate(tomorrow)
+            .school(테코대학교)
+            .build());
+        우테대학교_축제 = festivalRepository.save(FestivalFixture.builder()
+            .name("우테대학교 축제")
+            .startDate(now)
+            .endDate(tomorrow)
+            .school(우테대학교)
+            .build());
+
+        테코대학교_공연 = stageRepository.save(StageFixture.builder()
+            .startTime(now.atTime(18, 0))
+            .ticketOpenTime(ticketOpenTime)
+            .festival(테코대학교_축제)
+            .build());
+        우테대학교_첫째날_공연 = stageRepository.save(StageFixture.builder()
+            .startTime(now.atTime(18, 0))
+            .ticketOpenTime(ticketOpenTime)
+            .festival(우테대학교_축제)
+            .build());
+        우테대학교_둘째날_공연 = stageRepository.save(StageFixture.builder()
+            .startTime(tomorrow.atTime(18, 0))
+            .ticketOpenTime(ticketOpenTime)
+            .festival(우테대학교_축제)
+            .build());
     }
 
     @Nested

--- a/backend/src/test/java/com/festago/admin/application/integration/AdminSchoolV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/admin/application/integration/AdminSchoolV1QueryServiceIntegrationTest.java
@@ -13,6 +13,7 @@ import com.festago.school.domain.School;
 import com.festago.school.domain.SchoolRegion;
 import com.festago.school.repository.SchoolRepository;
 import com.festago.support.ApplicationIntegrationTest;
+import com.festago.support.fixture.SchoolFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -40,9 +41,21 @@ class AdminSchoolV1QueryServiceIntegrationTest extends ApplicationIntegrationTes
 
     @BeforeEach
     void setUp() {
-        테코대학교 = schoolRepository.save(new School("teco.ac.kr", "테코대학교", SchoolRegion.서울));
-        우테대학교 = schoolRepository.save(new School("wote.ac.kr", "우테대학교", SchoolRegion.서울));
-        글렌대학교 = schoolRepository.save(new School("glen.ac.kr", "글렌대학교", SchoolRegion.대구));
+        테코대학교 = schoolRepository.save(SchoolFixture.builder()
+            .name("테코대학교")
+            .domain("teco.ac.kr")
+            .region(SchoolRegion.서울)
+            .build());
+        우테대학교 = schoolRepository.save(SchoolFixture.builder()
+            .name("우테대학교")
+            .domain("wote.ac.kr")
+            .region(SchoolRegion.서울)
+            .build());
+        글렌대학교 = schoolRepository.save(SchoolFixture.builder()
+            .name("글렌대학교")
+            .domain("glen.ac.kr")
+            .region(SchoolRegion.대구)
+            .build());
     }
 
     @Nested

--- a/backend/src/test/java/com/festago/admin/application/integration/ArtistV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/admin/application/integration/ArtistV1QueryServiceIntegrationTest.java
@@ -1,11 +1,13 @@
-package com.festago.admin.application;
+package com.festago.admin.application.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.festago.admin.application.AdminArtistV1QueryService;
 import com.festago.admin.dto.artist.AdminArtistV1Response;
 import com.festago.artist.domain.Artist;
 import com.festago.artist.repository.ArtistRepository;
 import com.festago.support.ApplicationIntegrationTest;
+import com.festago.support.fixture.ArtistFixture;
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -25,7 +27,7 @@ class ArtistV1QueryServiceIntegrationTest extends ApplicationIntegrationTest {
     @Test
     void 아티스트를_단건_조회한다() {
         // given
-        Artist expected = artistRepository.save(new Artist("윤하", "www.naver.com"));
+        Artist expected = artistRepository.save(ArtistFixture.builder().build());
 
         // when
         AdminArtistV1Response actual = adminArtistV1QueryService.findById(expected.getId());
@@ -39,9 +41,9 @@ class ArtistV1QueryServiceIntegrationTest extends ApplicationIntegrationTest {
     void 아티스트_정보를_변경한다() {
         // given
         List<Artist> expected = List.of(
-            artistRepository.save(new Artist("윤하", "www.naver.com")),
-            artistRepository.save(new Artist("Lana Del Rey", "www.kakao.com")),
-            artistRepository.save(new Artist("윤종신", "www.daum.com"))
+            artistRepository.save(ArtistFixture.builder().name("윤하").build()),
+            artistRepository.save(ArtistFixture.builder().name("Lana del rey").build()),
+            artistRepository.save(ArtistFixture.builder().name("악동뮤지션").build())
         );
 
         // when


### PR DESCRIPTION
- closed: #815 

## ✨ PR 세부 내용

목표로한 작업 외에
```ArtistV1QueryServiceIntegrationTest``` 라는 클래스가 application 에 위치하고 있었는데 application/intergration으로 위치하게 같이 바꿨습니다.

