### PR TITLE
fix: Artist 직렬화 ArtistQueryModel로 변환 후 직렬화 하도록 변경 (#831)

### DIFF
--- a/backend/src/main/java/com/festago/artist/infrastructure/JsonArtistsSerializer.java
+++ b/backend/src/main/java/com/festago/artist/infrastructure/JsonArtistsSerializer.java
@@ -20,10 +20,32 @@ public class JsonArtistsSerializer implements ArtistsSerializer {
     @Override
     public String serialize(List<Artist> artists) {
         try {
-            return objectMapper.writeValueAsString(artists);
+            List<ArtistQueryModel> artistQueryModels = artists.stream()
+                .map(ArtistQueryModel::from)
+                .toList();
+            return objectMapper.writeValueAsString(artistQueryModels);
         } catch (JsonProcessingException e) {
             log.error(e.getMessage(), e);
             throw new UnexpectedException("Artist 목록을 직렬화 하는 중에 문제가 발생했습니다.");
+        }
+    }
+
+    /**
+     * 쿼리에서 사용되는 모델이므로, 필드를 추가해도 필드명은 변경되면 절대로 안 됨!!!
+     */
+    private record ArtistQueryModel(
+        Long id,
+        String name,
+        String profileImageUrl,
+        String backgroundImageUrl
+    ) {
+        public static ArtistQueryModel from(Artist artist) {
+            return new ArtistQueryModel(
+                artist.getId(),
+                artist.getName(),
+                artist.getProfileImage(),
+                artist.getBackgroundImageUrl()
+            );
         }
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #831

## ✨ PR 세부 내용

이슈 내용 그대로 Artist를 직렬화할 때 엔티티 그대로 직렬화 하는 것을 `ArtistQueryModel`을 정의하여 직렬화 하도록 했습니다.

해당 이슈 빠르게 처리되지 않으면 클라이언트에서 처리가 불가능하므로 우선 바로 머지하겠습니다.

추가 변경 또는 더 나은 개선 방향이 있다면 새롭게 이슈로 파서 처리하면 될 것 같습니다! 