### PR TITLE
[BE] refactor: festival 테스트 패키지에서 엔티티 생성을 픽스쳐를 사용하여 생성하도록 변경 (#814)

### DIFF
--- a/backend/src/test/java/com/festago/festival/application/integration/command/FestivalCreateServiceTest.java
+++ b/backend/src/test/java/com/festago/festival/application/integration/command/FestivalCreateServiceTest.java
@@ -1,4 +1,4 @@
-package com.festago.festival.application.command;
+package com.festago.festival.application.integration.command;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.ErrorCode;
+import com.festago.festival.application.command.FestivalCreateService;
 import com.festago.festival.dto.command.FestivalCreateCommand;
 import com.festago.festival.repository.FestivalInfoRepository;
 import com.festago.festival.repository.FestivalRepository;

--- a/backend/src/test/java/com/festago/festival/application/integration/command/FestivalDeleteServiceTest.java
+++ b/backend/src/test/java/com/festago/festival/application/integration/command/FestivalDeleteServiceTest.java
@@ -1,4 +1,4 @@
-package com.festago.festival.application.command;
+package com.festago.festival.application.integration.command;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.festago.common.exception.BadRequestException;
 import com.festago.common.exception.ErrorCode;
+import com.festago.festival.application.command.FestivalDeleteService;
 import com.festago.festival.domain.Festival;
 import com.festago.festival.domain.FestivalQueryInfo;
 import com.festago.festival.repository.FestivalInfoRepository;

--- a/backend/src/test/java/com/festago/festival/application/integration/command/FestivalUpdateServiceTest.java
+++ b/backend/src/test/java/com/festago/festival/application/integration/command/FestivalUpdateServiceTest.java
@@ -1,8 +1,9 @@
-package com.festago.festival.application.command;
+package com.festago.festival.application.integration.command;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 
+import com.festago.festival.application.command.FestivalUpdateService;
 import com.festago.festival.domain.Festival;
 import com.festago.festival.dto.command.FestivalUpdateCommand;
 import com.festago.festival.repository.FestivalRepository;

--- a/backend/src/test/java/com/festago/festival/application/integration/query/FestivalDetailV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/festival/application/integration/query/FestivalDetailV1QueryServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.festago.festival.application.integration;
+package com.festago.festival.application.integration.query;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;

--- a/backend/src/test/java/com/festago/festival/application/integration/query/FestivalDetailV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/festival/application/integration/query/FestivalDetailV1QueryServiceIntegrationTest.java
@@ -15,12 +15,12 @@ import com.festago.school.application.SchoolCommandService;
 import com.festago.school.domain.SchoolRegion;
 import com.festago.school.dto.SchoolCreateCommand;
 import com.festago.socialmedia.domain.OwnerType;
-import com.festago.socialmedia.domain.SocialMedia;
 import com.festago.socialmedia.domain.SocialMediaType;
 import com.festago.socialmedia.repository.SocialMediaRepository;
 import com.festago.stage.application.command.StageCreateService;
 import com.festago.stage.dto.command.StageCreateCommand;
 import com.festago.support.ApplicationIntegrationTest;
+import com.festago.support.fixture.SocialMediaFixture;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -95,12 +95,23 @@ class FestivalDetailV1QueryServiceIntegrationTest extends ApplicationIntegration
             우테대학교_축제_식별자, now.atTime(18, 0), ticketOpenTime, List.of(아티스트_식별자)
         ));
 
-        socialMediaRepository.save(
-            new SocialMedia(테코대학교_식별자, OwnerType.SCHOOL, SocialMediaType.INSTAGRAM, "총학생회 인스타그램",
-                "https://logo.com/instagram.png", "https://instagram.com/테코대학교_총학생회"));
-        socialMediaRepository.save(
-            new SocialMedia(테코대학교_식별자, OwnerType.SCHOOL, SocialMediaType.FACEBOOK, "총학생회 페이스북",
-                "https://logo.com/facebook.png", "https://facebook.com/테코대학교_총학생회"));
+        socialMediaRepository.save(SocialMediaFixture.builder()
+            .ownerId(테코대학교_식별자)
+            .ownerType(OwnerType.SCHOOL)
+            .mediaType(SocialMediaType.INSTAGRAM)
+            .name("총학생회 인스타그램")
+            .logoUrl("https://logo.com/instagram.png")
+            .url("https://instagram.com/테코대학교_총학생회")
+            .build());
+        socialMediaRepository.save(SocialMediaFixture.builder()
+            .ownerId(테코대학교_식별자)
+            .ownerType(OwnerType.SCHOOL)
+            .mediaType(SocialMediaType.FACEBOOK)
+            .name("총학생회 페이스북")
+            .logoUrl("https://logo.com/instagram.png")
+            .url("https://facebook.com/테코대학교_총학생회")
+            .build()
+        );
     }
 
     private Long createArtist(String artistName) {

--- a/backend/src/test/java/com/festago/festival/application/integration/query/FestivalSearchV1QueryServiceTest.java
+++ b/backend/src/test/java/com/festago/festival/application/integration/query/FestivalSearchV1QueryServiceTest.java
@@ -15,14 +15,17 @@ import com.festago.school.domain.School;
 import com.festago.school.domain.SchoolRegion;
 import com.festago.school.repository.SchoolRepository;
 import com.festago.stage.domain.Stage;
-import com.festago.stage.domain.StageArtist;
 import com.festago.stage.repository.StageArtistRepository;
 import com.festago.stage.repository.StageRepository;
 import com.festago.support.ApplicationIntegrationTest;
+import com.festago.support.fixture.ArtistFixture;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StageArtistFixture;
+import com.festago.support.fixture.StageFixture;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -64,24 +67,60 @@ class FestivalSearchV1QueryServiceTest extends ApplicationIntegrationTest {
         LocalDate nowDate = LocalDate.now();
         LocalDateTime nowDateTime = LocalDateTime.now();
 
-        School 부산_학교 = schoolRepository.save(new School("domain1", "부산 학교", SchoolRegion.부산));
-        School 서울_학교 = schoolRepository.save(new School("domain2", "서울 학교", SchoolRegion.서울));
-        School 대구_학교 = schoolRepository.save(new School("domain3", "대구 학교", SchoolRegion.대구));
+        School 부산_학교 = schoolRepository.save(SchoolFixture.builder()
+            .domain("domain1")
+            .name("부산 학교")
+            .region(SchoolRegion.부산)
+            .build());
+        School 서울_학교 = schoolRepository.save(SchoolFixture.builder()
+            .domain("domain2")
+            .name("서울 학교")
+            .region(SchoolRegion.서울)
+            .build());
+        School 대구_학교 = schoolRepository.save(SchoolFixture.builder()
+            .domain("domain3")
+            .name("대구 학교")
+            .region(SchoolRegion.대구)
+            .build());
 
-        Festival 부산_축제 = festivalRepository.save(
-            new Festival("부산대학교 축제", nowDate.minusDays(5), nowDate.minusDays(1), 부산_학교));
-        Festival 서울_축제 = festivalRepository.save(
-            new Festival("서울대학교 축제", nowDate.minusDays(1), nowDate.plusDays(3), 서울_학교));
-        Festival 대구_축제 = festivalRepository.save(
-            new Festival("대구대학교 축제", nowDate.plusDays(1), nowDate.plusDays(5), 대구_학교));
+        Festival 부산_축제 = festivalRepository.save(FestivalFixture.builder()
+            .name("부산대학교 축제")
+            .startDate(nowDate.minusDays(5))
+            .endDate(nowDate.minusDays(1))
+            .school(부산_학교)
+            .build());
+        Festival 서울_축제 = festivalRepository.save(FestivalFixture.builder()
+            .name("서울대학교 축제")
+            .startDate(nowDate.minusDays(1))
+            .endDate(nowDate.plusDays(3))
+            .school(서울_학교)
+            .build());
+        Festival 대구_축제 = festivalRepository.save(FestivalFixture.builder()
+            .name("대구대학교 축제")
+            .startDate(nowDate.plusDays(1))
+            .endDate(nowDate.plusDays(5))
+            .school(대구_학교)
+            .build());
 
         festivalInfoRepository.save(FestivalQueryInfo.create(부산_축제.getId()));
         festivalInfoRepository.save(FestivalQueryInfo.create(서울_축제.getId()));
         festivalInfoRepository.save(FestivalQueryInfo.create(대구_축제.getId()));
 
-        부산_공연 = stageRepository.save(new Stage(nowDateTime.minusDays(5L), nowDateTime.minusDays(6L), 부산_축제));
-        서울_공연 = stageRepository.save(new Stage(nowDateTime.minusDays(1L), nowDateTime.minusDays(2L), 서울_축제));
-        대구_공연 = stageRepository.save(new Stage(nowDateTime.plusDays(1L), nowDateTime, 대구_축제));
+        부산_공연 = stageRepository.save(StageFixture.builder()
+            .startTime(nowDateTime.minusDays(5L))
+            .ticketOpenTime(nowDateTime.minusDays(6L))
+            .festival(부산_축제)
+            .build());
+        서울_공연 = stageRepository.save(StageFixture.builder()
+            .startTime(nowDateTime.minusDays(1L))
+            .ticketOpenTime(nowDateTime.minusDays(2L))
+            .festival(서울_축제)
+            .build());
+        대구_공연 = stageRepository.save(StageFixture.builder()
+            .startTime(nowDateTime.plusDays(1L))
+            .ticketOpenTime(nowDateTime)
+            .festival(대구_축제)
+            .build());
     }
 
     @Nested
@@ -127,17 +166,23 @@ class FestivalSearchV1QueryServiceTest extends ApplicationIntegrationTest {
             @Test
             void 키워드가_두_글자_이상일_때_해당_키워드를_가진_아티스트의_정보를_반환한다() {
                 // given
-                Artist 오리 = artistRepository.save(new Artist("오리", "image.jpg"));
-                Artist 우푸우 = artistRepository.save(new Artist("우푸우", "image.jpg"));
-                Artist 글렌 = artistRepository.save(new Artist("글렌", "image.jpg"));
+                Artist 오리 = artistRepository.save(ArtistFixture.builder()
+                    .name("오리")
+                    .build());
+                Artist 우푸우 = artistRepository.save(ArtistFixture.builder()
+                    .name("우푸우")
+                    .build());
+                Artist 글렌 = artistRepository.save(ArtistFixture.builder()
+                    .name("글렌")
+                    .build());
 
-                stageArtistRepository.save(new StageArtist(부산_공연.getId(), 오리.getId()));
-                stageArtistRepository.save(new StageArtist(부산_공연.getId(), 우푸우.getId()));
+                stageArtistRepository.save(StageArtistFixture.builder(부산_공연.getId(), 오리.getId()).build());
+                stageArtistRepository.save(StageArtistFixture.builder(부산_공연.getId(), 우푸우.getId()).build());
 
-                stageArtistRepository.save(new StageArtist(서울_공연.getId(), 오리.getId()));
-                stageArtistRepository.save(new StageArtist(서울_공연.getId(), 글렌.getId()));
+                stageArtistRepository.save(StageArtistFixture.builder(서울_공연.getId(), 오리.getId()).build());
+                stageArtistRepository.save(StageArtistFixture.builder(서울_공연.getId(), 글렌.getId()).build());
 
-                stageArtistRepository.save(new StageArtist(대구_공연.getId(), 우푸우.getId()));
+                stageArtistRepository.save(StageArtistFixture.builder(대구_공연.getId(), 우푸우.getId()).build());
 
                 // when
                 List<FestivalSearchV1Response> actual = festivalSearchV1QueryService.search("푸우");
@@ -153,17 +198,23 @@ class FestivalSearchV1QueryServiceTest extends ApplicationIntegrationTest {
             @Test
             void 해당하는_키워드의_아티스트가_없으면_빈_리스트을_반환한다() {
                 // given
-                Artist 오리 = artistRepository.save(new Artist("오리", "image.jpg"));
-                Artist 우푸우 = artistRepository.save(new Artist("우푸우", "image.jpg"));
-                Artist 글렌 = artistRepository.save(new Artist("글렌", "image.jpg"));
+                Artist 오리 = artistRepository.save(ArtistFixture.builder()
+                    .name("오리")
+                    .build());
+                Artist 우푸우 = artistRepository.save(ArtistFixture.builder()
+                    .name("우푸우")
+                    .build());
+                Artist 글렌 = artistRepository.save(ArtistFixture.builder()
+                    .name("글렌")
+                    .build());
 
-                stageArtistRepository.save(new StageArtist(부산_공연.getId(), 오리.getId()));
-                stageArtistRepository.save(new StageArtist(부산_공연.getId(), 우푸우.getId()));
+                stageArtistRepository.save(StageArtistFixture.builder(부산_공연.getId(), 오리.getId()).build());
+                stageArtistRepository.save(StageArtistFixture.builder(부산_공연.getId(), 우푸우.getId()).build());
 
-                stageArtistRepository.save(new StageArtist(서울_공연.getId(), 오리.getId()));
-                stageArtistRepository.save(new StageArtist(서울_공연.getId(), 글렌.getId()));
+                stageArtistRepository.save(StageArtistFixture.builder(서울_공연.getId(), 오리.getId()).build());
+                stageArtistRepository.save(StageArtistFixture.builder(서울_공연.getId(), 글렌.getId()).build());
 
-                stageArtistRepository.save(new StageArtist(대구_공연.getId(), 우푸우.getId()));
+                stageArtistRepository.save(StageArtistFixture.builder(대구_공연.getId(), 우푸우.getId()).build());
 
                 // when
                 List<FestivalSearchV1Response> actual = festivalSearchV1QueryService.search("렌글");
@@ -175,7 +226,9 @@ class FestivalSearchV1QueryServiceTest extends ApplicationIntegrationTest {
             @Test
             void 아티스트가_공연에_참여하고_있지_않으면_빈_리스트가_반환된다() {
                 // given
-                Artist 우푸우 = artistRepository.save(new Artist("우푸우", "image.jpg"));
+                artistRepository.save(ArtistFixture.builder()
+                    .name("우푸우")
+                    .build());
 
                 // when
                 List<FestivalSearchV1Response> actual = festivalSearchV1QueryService.search("우푸");
@@ -192,13 +245,17 @@ class FestivalSearchV1QueryServiceTest extends ApplicationIntegrationTest {
             @Test
             void 두_글자_이상_아티스트와_함께_검색되지_않는다() {
                 // given
-                Artist 푸우 = artistRepository.save(new Artist("푸우", "image.jpg"));
-                Artist 푸 = artistRepository.save(new Artist("푸", "image.jpg"));
+                Artist 푸우 = artistRepository.save(ArtistFixture.builder()
+                    .name("푸우")
+                    .build());
+                Artist 푸 = artistRepository.save(ArtistFixture.builder()
+                    .name("푸")
+                    .build());
 
-                stageArtistRepository.save(new StageArtist(부산_공연.getId(), 푸우.getId()));
-                stageArtistRepository.save(new StageArtist(부산_공연.getId(), 푸.getId()));
+                stageArtistRepository.save(StageArtistFixture.builder(부산_공연.getId(), 푸우.getId()).build());
+                stageArtistRepository.save(StageArtistFixture.builder(부산_공연.getId(), 푸.getId()).build());
 
-                stageArtistRepository.save(new StageArtist(서울_공연.getId(), 푸.getId()));
+                stageArtistRepository.save(StageArtistFixture.builder(서울_공연.getId(), 푸.getId()).build());
 
                 // when
                 List<FestivalSearchV1Response> actual = festivalSearchV1QueryService.search("푸");
@@ -214,13 +271,19 @@ class FestivalSearchV1QueryServiceTest extends ApplicationIntegrationTest {
             @Test
             void 해당하는_키워드의_아티스트가_없으면_빈_리스트를_반환한다() {
                 // given
-                Artist 푸우 = artistRepository.save(new Artist("푸우", "image.jpg"));
-                Artist 푸푸푸푸 = artistRepository.save(new Artist("푸푸푸푸", "image.jpg"));
-                Artist 글렌 = artistRepository.save(new Artist("글렌", "image.jpg"));
+                Artist 푸우 = artistRepository.save(ArtistFixture.builder()
+                    .name("푸우")
+                    .build());
+                Artist 푸푸푸푸 = artistRepository.save(ArtistFixture.builder()
+                    .name("푸푸푸푸")
+                    .build());
+                Artist 글렌 = artistRepository.save(ArtistFixture.builder()
+                    .name("글렌")
+                    .build());
 
-                stageArtistRepository.save(new StageArtist(부산_공연.getId(), 푸우.getId()));
-                stageArtistRepository.save(new StageArtist(부산_공연.getId(), 푸푸푸푸.getId()));
-                stageArtistRepository.save(new StageArtist(부산_공연.getId(), 글렌.getId()));
+                stageArtistRepository.save(StageArtistFixture.builder(부산_공연.getId(), 푸우.getId()).build());
+                stageArtistRepository.save(StageArtistFixture.builder(부산_공연.getId(), 푸푸푸푸.getId()).build());
+                stageArtistRepository.save(StageArtistFixture.builder(부산_공연.getId(), 글렌.getId()).build());
 
                 // when
                 List<FestivalSearchV1Response> actual = festivalSearchV1QueryService.search("푸");
@@ -232,7 +295,9 @@ class FestivalSearchV1QueryServiceTest extends ApplicationIntegrationTest {
             @Test
             void 아티스트가_공연에_참여하고_있지_않으면_빈_리스트를_반환한다() {
                 // given
-                Artist 우푸우 = artistRepository.save(new Artist("우푸우", "image.jpg"));
+                artistRepository.save(ArtistFixture.builder()
+                    .name("우푸우")
+                    .build());
 
                 // when
                 List<FestivalSearchV1Response> actual = festivalSearchV1QueryService.search("우푸");

--- a/backend/src/test/java/com/festago/festival/application/integration/query/FestivalSearchV1QueryServiceTest.java
+++ b/backend/src/test/java/com/festago/festival/application/integration/query/FestivalSearchV1QueryServiceTest.java
@@ -1,4 +1,4 @@
-package com.festago.festival.application.integration;
+package com.festago.festival.application.integration.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;

--- a/backend/src/test/java/com/festago/festival/application/integration/query/FestivalV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/festival/application/integration/query/FestivalV1QueryServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.festago.festival.application.integration;
+package com.festago.festival.application.integration.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;

--- a/backend/src/test/java/com/festago/festival/application/integration/query/PopularFestivalV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/festival/application/integration/query/PopularFestivalV1QueryServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.festago.festival.application.integration;
+package com.festago.festival.application.integration.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed #814 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

festival 패키지 내에 Fixture를 사용하도록 변경했습니다.
또한 기존 패키지를 변경했는데 기존 내역은 다음과 같습니다.
```
├── FestivalQueryInfoArtistRenewServiceTest.java
├── QueryDslSchoolSearchRecentFestivalV1QueryServiceIntegrationTest.java
├── command
│   ├── FestivalCreateServiceTest.java
│   ├── FestivalDeleteServiceTest.java
│   └── FestivalUpdateServiceTest.java
└── integration
    ├── FestivalDetailV1QueryServiceIntegrationTest.java
    ├── FestivalSearchV1QueryServiceTest.java
    ├── FestivalV1QueryServiceIntegrationTest.java
    └── PopularFestivalV1QueryServiceIntegrationTest.java

```

command 패키지 내부에도 다 integration 테스트여서 다음과 같이 변경했습니다.
```bash
├── FestivalQueryInfoArtistRenewServiceTest.java
├── QueryDslSchoolSearchRecentFestivalV1QueryServiceIntegrationTest.java
└── integration
    ├── command
    │   ├── FestivalCreateServiceTest.java
    │   ├── FestivalDeleteServiceTest.java
    │   └── FestivalUpdateServiceTest.java
    └── query
        ├── FestivalDetailV1QueryServiceIntegrationTest.java
        ├── FestivalSearchV1QueryServiceTest.java
        ├── FestivalV1QueryServiceIntegrationTest.java
        └── PopularFestivalV1QueryServiceIntegrationTest.java

```