### PR TITLE
[BE] feat: 소셜미디어 CRUD 기능 추가 (#802)

### DIFF
--- a/backend/src/main/java/com/festago/admin/application/AdminSocialMediaV1QueryService.java
+++ b/backend/src/main/java/com/festago/admin/application/AdminSocialMediaV1QueryService.java
@@ -1,0 +1,28 @@
+package com.festago.admin.application;
+
+import com.festago.admin.dto.socialmedia.AdminSocialMediaV1Response;
+import com.festago.admin.repository.AdminSocialMediaV1QueryDslRepository;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
+import com.festago.socialmedia.domain.OwnerType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminSocialMediaV1QueryService {
+
+    private final AdminSocialMediaV1QueryDslRepository adminSocialMediaV1QueryDslRepository;
+
+    public AdminSocialMediaV1Response findById(Long socialMediaId) {
+        return adminSocialMediaV1QueryDslRepository.findById(socialMediaId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.SOCIAL_MEDIA_NOT_FOUND));
+    }
+
+    public List<AdminSocialMediaV1Response> findByOwnerIdAndOwnerType(Long ownerId, OwnerType ownerType) {
+        return adminSocialMediaV1QueryDslRepository.findByOwnerIdAndOwnerType(ownerId, ownerType);
+    }
+}

--- a/backend/src/main/java/com/festago/admin/dto/socialmedia/AdminSocialMediaV1Response.java
+++ b/backend/src/main/java/com/festago/admin/dto/socialmedia/AdminSocialMediaV1Response.java
@@ -1,10 +1,13 @@
 package com.festago.admin.dto.socialmedia;
 
+import com.festago.socialmedia.domain.OwnerType;
 import com.festago.socialmedia.domain.SocialMediaType;
 import com.querydsl.core.annotations.QueryProjection;
 
 public record AdminSocialMediaV1Response(
     Long id,
+    Long ownerId,
+    OwnerType ownerType,
     SocialMediaType socialMediaType,
     String name,
     String logoUrl,

--- a/backend/src/main/java/com/festago/admin/dto/socialmedia/AdminSocialMediaV1Response.java
+++ b/backend/src/main/java/com/festago/admin/dto/socialmedia/AdminSocialMediaV1Response.java
@@ -1,0 +1,17 @@
+package com.festago.admin.dto.socialmedia;
+
+import com.festago.socialmedia.domain.SocialMediaType;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record AdminSocialMediaV1Response(
+    Long id,
+    SocialMediaType socialMediaType,
+    String name,
+    String logoUrl,
+    String url
+) {
+
+    @QueryProjection
+    public AdminSocialMediaV1Response {
+    }
+}

--- a/backend/src/main/java/com/festago/admin/dto/socialmedia/SocialMediaCreateV1Request.java
+++ b/backend/src/main/java/com/festago/admin/dto/socialmedia/SocialMediaCreateV1Request.java
@@ -1,0 +1,36 @@
+package com.festago.admin.dto.socialmedia;
+
+import com.festago.socialmedia.domain.OwnerType;
+import com.festago.socialmedia.domain.SocialMediaType;
+import com.festago.socialmedia.dto.command.SocialMediaCreateCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record SocialMediaCreateV1Request(
+    @NotNull
+    Long ownerId,
+    @NotNull
+    OwnerType ownerType,
+    @NotNull
+    SocialMediaType socialMediaType,
+    @NotBlank
+    String name,
+    @NotBlank
+    String logoUrl,
+    @NotBlank
+    String url
+) {
+
+    public SocialMediaCreateCommand toCommand() {
+        return new SocialMediaCreateCommand(
+            ownerId,
+            ownerType,
+            socialMediaType,
+            name,
+            logoUrl,
+            url
+        );
+    }
+}

--- a/backend/src/main/java/com/festago/admin/dto/socialmedia/SocialMediaUpdateV1Request.java
+++ b/backend/src/main/java/com/festago/admin/dto/socialmedia/SocialMediaUpdateV1Request.java
@@ -1,0 +1,24 @@
+package com.festago.admin.dto.socialmedia;
+
+import com.festago.socialmedia.dto.command.SocialMediaUpdateCommand;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record SocialMediaUpdateV1Request(
+    @NotBlank
+    String name,
+    @NotBlank
+    String logoUrl,
+    @NotBlank
+    String url
+) {
+
+    public SocialMediaUpdateCommand toCommand() {
+        return new SocialMediaUpdateCommand(
+            name,
+            logoUrl,
+            url
+        );
+    }
+}

--- a/backend/src/main/java/com/festago/admin/presentation/v1/AdminSocialMediaV1Controller.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/AdminSocialMediaV1Controller.java
@@ -1,18 +1,24 @@
 package com.festago.admin.presentation.v1;
 
+import com.festago.admin.application.AdminSocialMediaV1QueryService;
+import com.festago.admin.dto.socialmedia.AdminSocialMediaV1Response;
 import com.festago.admin.dto.socialmedia.SocialMediaCreateV1Request;
 import com.festago.admin.dto.socialmedia.SocialMediaUpdateV1Request;
 import com.festago.socialmedia.application.SocialMediaCommandService;
+import com.festago.socialmedia.domain.OwnerType;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,6 +28,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminSocialMediaV1Controller {
 
     private final SocialMediaCommandService socialMediaCommandService;
+    private final AdminSocialMediaV1QueryService adminSocialMediaV1QueryService;
+
+    @GetMapping
+    public ResponseEntity<List<AdminSocialMediaV1Response>> findByOwnerIdAndOwnerType(
+        @RequestParam Long ownerId,
+        @RequestParam OwnerType ownerType
+    ) {
+        return ResponseEntity.ok()
+            .body(adminSocialMediaV1QueryService.findByOwnerIdAndOwnerType(ownerId, ownerType));
+    }
+
+    @GetMapping("/{socialMediaId}")
+    public ResponseEntity<AdminSocialMediaV1Response> findById(
+        @PathVariable Long socialMediaId
+    ) {
+        return ResponseEntity.ok()
+            .body(adminSocialMediaV1QueryService.findById(socialMediaId));
+    }
 
     @PostMapping
     public ResponseEntity<Void> createSocialMedia(

--- a/backend/src/main/java/com/festago/admin/presentation/v1/AdminSocialMediaV1Controller.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/AdminSocialMediaV1Controller.java
@@ -1,0 +1,52 @@
+package com.festago.admin.presentation.v1;
+
+import com.festago.admin.dto.socialmedia.SocialMediaCreateV1Request;
+import com.festago.admin.dto.socialmedia.SocialMediaUpdateV1Request;
+import com.festago.socialmedia.application.SocialMediaCommandService;
+import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/api/v1/socialmedias")
+@RequiredArgsConstructor
+@Hidden
+public class AdminSocialMediaV1Controller {
+
+    private final SocialMediaCommandService socialMediaCommandService;
+
+    @PostMapping
+    public ResponseEntity<Void> createSocialMedia(
+        @RequestBody @Valid SocialMediaCreateV1Request request
+    ) {
+        socialMediaCommandService.createSocialMedia(request.toCommand());
+        return ResponseEntity.ok()
+            .build();
+    }
+
+    @PatchMapping("/{socialMediaId}")
+    public ResponseEntity<Void> updateSocialMedia(
+        @PathVariable Long socialMediaId,
+        @RequestBody @Valid SocialMediaUpdateV1Request request
+    ) {
+        socialMediaCommandService.updateSocialMedia(socialMediaId, request.toCommand());
+        return ResponseEntity.ok()
+            .build();
+    }
+
+    @DeleteMapping("/{socialMediaId}")
+    public ResponseEntity<Void> deleteSocialMedia(
+        @PathVariable Long socialMediaId
+    ) {
+        socialMediaCommandService.deleteSocialMedia(socialMediaId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/festago/admin/repository/AdminSocialMediaV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/admin/repository/AdminSocialMediaV1QueryDslRepository.java
@@ -21,6 +21,8 @@ public class AdminSocialMediaV1QueryDslRepository extends QueryDslRepositorySupp
     public Optional<AdminSocialMediaV1Response> findById(Long socialMediaId) {
         return fetchOne(query -> query.select(new QAdminSocialMediaV1Response(
                     socialMedia.id,
+                    socialMedia.ownerId,
+                    socialMedia.ownerType,
                     socialMedia.mediaType,
                     socialMedia.name,
                     socialMedia.logoUrl,
@@ -35,6 +37,8 @@ public class AdminSocialMediaV1QueryDslRepository extends QueryDslRepositorySupp
     public List<AdminSocialMediaV1Response> findByOwnerIdAndOwnerType(Long ownerId, OwnerType ownerType) {
         return select(new QAdminSocialMediaV1Response(
             socialMedia.id,
+            socialMedia.ownerId,
+            socialMedia.ownerType,
             socialMedia.mediaType,
             socialMedia.name,
             socialMedia.logoUrl,

--- a/backend/src/main/java/com/festago/admin/repository/AdminSocialMediaV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/admin/repository/AdminSocialMediaV1QueryDslRepository.java
@@ -1,0 +1,47 @@
+package com.festago.admin.repository;
+
+import static com.festago.socialmedia.domain.QSocialMedia.socialMedia;
+
+import com.festago.admin.dto.socialmedia.AdminSocialMediaV1Response;
+import com.festago.admin.dto.socialmedia.QAdminSocialMediaV1Response;
+import com.festago.common.querydsl.QueryDslRepositorySupport;
+import com.festago.socialmedia.domain.OwnerType;
+import com.festago.socialmedia.domain.SocialMedia;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class AdminSocialMediaV1QueryDslRepository extends QueryDslRepositorySupport {
+
+    public AdminSocialMediaV1QueryDslRepository() {
+        super(SocialMedia.class);
+    }
+
+    public Optional<AdminSocialMediaV1Response> findById(Long socialMediaId) {
+        return fetchOne(query -> query.select(new QAdminSocialMediaV1Response(
+                    socialMedia.id,
+                    socialMedia.mediaType,
+                    socialMedia.name,
+                    socialMedia.logoUrl,
+                    socialMedia.url
+                ))
+                .from(socialMedia)
+                .where(socialMedia.id.eq(socialMediaId))
+        );
+    }
+
+    // SocialMedia의 도메인 특성 상 SocialMediaType 개수만큼 row 생성이 제한되기에 limit을 사용하지 않음
+    public List<AdminSocialMediaV1Response> findByOwnerIdAndOwnerType(Long ownerId, OwnerType ownerType) {
+        return select(new QAdminSocialMediaV1Response(
+            socialMedia.id,
+            socialMedia.mediaType,
+            socialMedia.name,
+            socialMedia.logoUrl,
+            socialMedia.url
+        ))
+            .from(socialMedia)
+            .where(socialMedia.ownerId.eq(ownerId).and(socialMedia.ownerType.eq(ownerType)))
+            .fetch();
+    }
+}

--- a/backend/src/main/java/com/festago/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/festago/common/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     BOOKMARK_LIMIT_EXCEEDED("최대 북마크 갯수를 초과했습니다"),
     BROAD_SEARCH_KEYWORD("더 자세한 검색어로 입력해야합니다."),
     INVALID_KEYWORD("유효하지 않은 키워드 입니다."),
+    DUPLICATE_SOCIAL_MEDIA("이미 존재하는 소셜미디어 입니다."),
 
     // 401
     EXPIRED_AUTH_TOKEN("만료된 로그인 토큰입니다."),

--- a/backend/src/main/java/com/festago/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/festago/common/exception/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode {
     TICKET_NOT_FOUND("존재하지 않는 티켓입니다."),
     SCHOOL_NOT_FOUND("존재하지 않는 학교입니다."),
     ARTIST_NOT_FOUND("존재하지 않는 아티스트입니다."),
+    SOCIAL_MEDIA_NOT_FOUND("존재하지 않는 소셜미디어입니다."),
 
     // 429
     TOO_FREQUENT_REQUESTS("너무 잦은 요청입니다. 잠시 후 다시 시도해주세요."),

--- a/backend/src/main/java/com/festago/socialmedia/application/SocialMediaCommandService.java
+++ b/backend/src/main/java/com/festago/socialmedia/application/SocialMediaCommandService.java
@@ -9,6 +9,7 @@ import com.festago.socialmedia.domain.OwnerType;
 import com.festago.socialmedia.domain.SocialMedia;
 import com.festago.socialmedia.domain.SocialMediaType;
 import com.festago.socialmedia.dto.command.SocialMediaCreateCommand;
+import com.festago.socialmedia.dto.command.SocialMediaUpdateCommand;
 import com.festago.socialmedia.repository.SocialMediaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -43,5 +44,12 @@ public class SocialMediaCommandService {
         if (ownerType == OwnerType.SCHOOL && !schoolRepository.existsById(ownerId)) {
             throw new NotFoundException(ErrorCode.SCHOOL_NOT_FOUND);
         }
+    }
+
+    public void updateSocialMedia(Long socialMediaId, SocialMediaUpdateCommand command) {
+        SocialMedia socialMedia = socialMediaRepository.getOrThrow(socialMediaId);
+        socialMedia.changeName(command.name());
+        socialMedia.changeLogoUrl(command.logoUrl());
+        socialMedia.changeUrl(command.url());
     }
 }

--- a/backend/src/main/java/com/festago/socialmedia/application/SocialMediaCommandService.java
+++ b/backend/src/main/java/com/festago/socialmedia/application/SocialMediaCommandService.java
@@ -52,4 +52,8 @@ public class SocialMediaCommandService {
         socialMedia.changeLogoUrl(command.logoUrl());
         socialMedia.changeUrl(command.url());
     }
+
+    public void deleteSocialMedia(Long socialMediaId) {
+        socialMediaRepository.deleteById(socialMediaId);
+    }
 }

--- a/backend/src/main/java/com/festago/socialmedia/application/SocialMediaCommandService.java
+++ b/backend/src/main/java/com/festago/socialmedia/application/SocialMediaCommandService.java
@@ -25,12 +25,12 @@ public class SocialMediaCommandService {
     private final ArtistRepository artistRepository;
 
     public Long createSocialMedia(SocialMediaCreateCommand command) {
-        validate(command);
+        validateCreate(command);
         SocialMedia socialMedia = socialMediaRepository.save(command.toEntity());
         return socialMedia.getId();
     }
 
-    private void validate(SocialMediaCreateCommand command) {
+    private void validateCreate(SocialMediaCreateCommand command) {
         Long ownerId = command.ownerId();
         OwnerType ownerType = command.ownerType();
         SocialMediaType socialMediaType = command.socialMediaType();

--- a/backend/src/main/java/com/festago/socialmedia/application/SocialMediaCommandService.java
+++ b/backend/src/main/java/com/festago/socialmedia/application/SocialMediaCommandService.java
@@ -1,0 +1,47 @@
+package com.festago.socialmedia.application;
+
+import com.festago.artist.repository.ArtistRepository;
+import com.festago.common.exception.BadRequestException;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
+import com.festago.school.repository.SchoolRepository;
+import com.festago.socialmedia.domain.OwnerType;
+import com.festago.socialmedia.domain.SocialMedia;
+import com.festago.socialmedia.domain.SocialMediaType;
+import com.festago.socialmedia.dto.command.SocialMediaCreateCommand;
+import com.festago.socialmedia.repository.SocialMediaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SocialMediaCommandService {
+
+    private final SocialMediaRepository socialMediaRepository;
+    private final SchoolRepository schoolRepository;
+    private final ArtistRepository artistRepository;
+
+    public Long createSocialMedia(SocialMediaCreateCommand command) {
+        validate(command);
+        SocialMedia socialMedia = socialMediaRepository.save(command.toEntity());
+        return socialMedia.getId();
+    }
+
+    private void validate(SocialMediaCreateCommand command) {
+        Long ownerId = command.ownerId();
+        OwnerType ownerType = command.ownerType();
+        SocialMediaType socialMediaType = command.socialMediaType();
+        if (socialMediaRepository.existsByOwnerIdAndOwnerTypeAndMediaType(ownerId, ownerType, socialMediaType)) {
+            throw new BadRequestException(ErrorCode.DUPLICATE_SOCIAL_MEDIA);
+        }
+        // TODO 추상적인 에러 코드가 필요할지? ex) ErrorCode.SOCIAL_MEDIA_OWNER_NOT_FOUND
+        if (ownerType == OwnerType.ARTIST && !artistRepository.existsById(ownerId)) {
+            throw new NotFoundException(ErrorCode.ARTIST_NOT_FOUND);
+        }
+        if (ownerType == OwnerType.SCHOOL && !schoolRepository.existsById(ownerId)) {
+            throw new NotFoundException(ErrorCode.SCHOOL_NOT_FOUND);
+        }
+    }
+}

--- a/backend/src/main/java/com/festago/socialmedia/domain/OwnerType.java
+++ b/backend/src/main/java/com/festago/socialmedia/domain/OwnerType.java
@@ -1,7 +1,6 @@
 package com.festago.socialmedia.domain;
 
 public enum OwnerType {
-
     ARTIST,
     SCHOOL,
     ;

--- a/backend/src/main/java/com/festago/socialmedia/domain/SocialMedia.java
+++ b/backend/src/main/java/com/festago/socialmedia/domain/SocialMedia.java
@@ -64,6 +64,18 @@ public class SocialMedia extends BaseTimeEntity {
         this(null, ownerId, ownerType, mediaType, name, logoUrl, url);
     }
 
+    public void changeName(String name) {
+        this.name = name;
+    }
+
+    public void changeUrl(String url) {
+        this.url = url;
+    }
+
+    public void changeLogoUrl(String logoUrl) {
+        this.logoUrl = logoUrl;
+    }
+
     public Long getId() {
         return id;
     }

--- a/backend/src/main/java/com/festago/socialmedia/dto/command/SocialMediaCreateCommand.java
+++ b/backend/src/main/java/com/festago/socialmedia/dto/command/SocialMediaCreateCommand.java
@@ -1,0 +1,26 @@
+package com.festago.socialmedia.dto.command;
+
+import com.festago.socialmedia.domain.OwnerType;
+import com.festago.socialmedia.domain.SocialMedia;
+import com.festago.socialmedia.domain.SocialMediaType;
+
+public record SocialMediaCreateCommand(
+    Long ownerId,
+    OwnerType ownerType,
+    SocialMediaType socialMediaType,
+    String name,
+    String logoUrl,
+    String url
+) {
+
+    public SocialMedia toEntity() {
+        return new SocialMedia(
+            ownerId,
+            ownerType,
+            socialMediaType,
+            name,
+            logoUrl,
+            url
+        );
+    }
+}

--- a/backend/src/main/java/com/festago/socialmedia/dto/command/SocialMediaUpdateCommand.java
+++ b/backend/src/main/java/com/festago/socialmedia/dto/command/SocialMediaUpdateCommand.java
@@ -1,0 +1,9 @@
+package com.festago.socialmedia.dto.command;
+
+public record SocialMediaUpdateCommand(
+    String name,
+    String url,
+    String logoUrl
+) {
+
+}

--- a/backend/src/main/java/com/festago/socialmedia/repository/SocialMediaRepository.java
+++ b/backend/src/main/java/com/festago/socialmedia/repository/SocialMediaRepository.java
@@ -1,13 +1,23 @@
 package com.festago.socialmedia.repository;
 
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
 import com.festago.socialmedia.domain.OwnerType;
 import com.festago.socialmedia.domain.SocialMedia;
 import com.festago.socialmedia.domain.SocialMediaType;
+import java.util.Optional;
 import org.springframework.data.repository.Repository;
 
 public interface SocialMediaRepository extends Repository<SocialMedia, Long> {
 
+    default SocialMedia getOrThrow(Long id) {
+        return findById(id).orElseThrow(() -> new NotFoundException(ErrorCode.SOCIAL_MEDIA_NOT_FOUND));
+    }
+
     SocialMedia save(SocialMedia socialMedia);
 
+    Optional<SocialMedia> findById(Long id);
+
     boolean existsByOwnerIdAndOwnerTypeAndMediaType(Long ownerId, OwnerType ownerType, SocialMediaType mediaType);
+
 }

--- a/backend/src/main/java/com/festago/socialmedia/repository/SocialMediaRepository.java
+++ b/backend/src/main/java/com/festago/socialmedia/repository/SocialMediaRepository.java
@@ -20,4 +20,5 @@ public interface SocialMediaRepository extends Repository<SocialMedia, Long> {
 
     boolean existsByOwnerIdAndOwnerTypeAndMediaType(Long ownerId, OwnerType ownerType, SocialMediaType mediaType);
 
+    void deleteById(Long socialMediaId);
 }

--- a/backend/src/main/java/com/festago/socialmedia/repository/SocialMediaRepository.java
+++ b/backend/src/main/java/com/festago/socialmedia/repository/SocialMediaRepository.java
@@ -1,9 +1,13 @@
 package com.festago.socialmedia.repository;
 
+import com.festago.socialmedia.domain.OwnerType;
 import com.festago.socialmedia.domain.SocialMedia;
+import com.festago.socialmedia.domain.SocialMediaType;
 import org.springframework.data.repository.Repository;
 
 public interface SocialMediaRepository extends Repository<SocialMedia, Long> {
 
     SocialMedia save(SocialMedia socialMedia);
+
+    boolean existsByOwnerIdAndOwnerTypeAndMediaType(Long ownerId, OwnerType ownerType, SocialMediaType mediaType);
 }

--- a/backend/src/test/java/com/festago/admin/application/integration/AdminSocialMediaV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/admin/application/integration/AdminSocialMediaV1QueryServiceIntegrationTest.java
@@ -1,0 +1,88 @@
+package com.festago.admin.application.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.festago.admin.application.AdminSocialMediaV1QueryService;
+import com.festago.admin.dto.socialmedia.AdminSocialMediaV1Response;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
+import com.festago.socialmedia.domain.OwnerType;
+import com.festago.socialmedia.domain.SocialMedia;
+import com.festago.socialmedia.domain.SocialMediaType;
+import com.festago.socialmedia.repository.SocialMediaRepository;
+import com.festago.support.ApplicationIntegrationTest;
+import com.festago.support.fixture.SocialMediaFixture;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class AdminSocialMediaV1QueryServiceIntegrationTest extends ApplicationIntegrationTest {
+
+    @Autowired
+    AdminSocialMediaV1QueryService adminSocialMediaV1QueryService;
+
+    @Autowired
+    SocialMediaRepository socialMediaRepository;
+
+    @Nested
+    class findById {
+
+        @Test
+        void 소셜미디어_식별자로_조회할_수_있다() {
+            // given
+            Long 테코대학교_식별자 = 1L;
+            Long 소셜미디어_식별자 = socialMediaRepository.save(SocialMediaFixture.builder()
+                .ownerId(테코대학교_식별자)
+                .ownerType(OwnerType.SCHOOL)
+                .name("테코대학교 소셜미디어")
+                .build()).getId();
+
+            // when
+            var actual = adminSocialMediaV1QueryService.findById(소셜미디어_식별자);
+
+            // then
+            assertThat(actual.name()).isEqualTo("테코대학교 소셜미디어");
+        }
+
+        @Test
+        void 식별자에_대한_소셜미디어가_존재하지_않으면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> adminSocialMediaV1QueryService.findById(4885L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.SOCIAL_MEDIA_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    class findByOwnerIdAndOwnerType {
+
+        @Test
+        void ownerId와_ownerType으로_해당하는_소셜미디어를_모두_조회할_수_있다() {
+            // given
+            Long 테코대학교_식별자 = 1L;
+            var expect = Stream.of(SocialMediaType.INSTAGRAM, SocialMediaType.X, SocialMediaType.YOUTUBE)
+                .map(mediaType -> socialMediaRepository.save(SocialMediaFixture.builder()
+                    .ownerId(테코대학교_식별자)
+                    .ownerType(OwnerType.SCHOOL)
+                    .mediaType(mediaType)
+                    .build())
+                )
+                .map(SocialMedia::getId)
+                .toList();
+
+            // when
+            var actual = adminSocialMediaV1QueryService.findByOwnerIdAndOwnerType(테코대학교_식별자, OwnerType.SCHOOL);
+
+            // then
+            assertThat(actual)
+                .map(AdminSocialMediaV1Response::id)
+                .containsExactlyInAnyOrderElementsOf(expect);
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminSocialMediaV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminSocialMediaV1ControllerTest.java
@@ -1,0 +1,180 @@
+package com.festago.admin.presentation.v1;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.admin.dto.socialmedia.SocialMediaCreateV1Request;
+import com.festago.admin.dto.socialmedia.SocialMediaUpdateV1Request;
+import com.festago.auth.domain.Role;
+import com.festago.socialmedia.application.SocialMediaCommandService;
+import com.festago.socialmedia.domain.OwnerType;
+import com.festago.socialmedia.domain.SocialMediaType;
+import com.festago.socialmedia.dto.command.SocialMediaCreateCommand;
+import com.festago.support.CustomWebMvcTest;
+import com.festago.support.WithMockAuth;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class AdminSocialMediaV1ControllerTest {
+
+    private static final Cookie TOKEN_COOKIE = new Cookie("token", "token");
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    SocialMediaCommandService socialMediaCommandService;
+
+    @Nested
+    class 소셜미디어_생성 {
+
+        final String uri = "/admin/api/v1/socialmedias";
+
+        @Nested
+        @DisplayName("POST " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                // given
+                Long socialMediaId = 1L;
+                var request = SocialMediaCreateV1Request.builder()
+                    .ownerId(1L)
+                    .ownerType(OwnerType.SCHOOL)
+                    .socialMediaType(SocialMediaType.INSTAGRAM)
+                    .url("https://instagram.com/tecodaehak")
+                    .logoUrl("https://image.com/logo.png")
+                    .name("테코대학교 총학생회 인스타그램")
+                    .build();
+                given(socialMediaCommandService.createSocialMedia(any(SocialMediaCreateCommand.class)))
+                    .willReturn(socialMediaId);
+
+                // when & then
+                mockMvc.perform(post(uri)
+                        .cookie(TOKEN_COOKIE)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
+
+    @Nested
+    class 소셜미디어_수정 {
+
+        final String uri = "/admin/api/v1/socialmedias/{socialMediaId}";
+        Long socialMediaId = 1L;
+
+        @Nested
+        @DisplayName("PATCH " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                // given
+                var request = SocialMediaUpdateV1Request.builder()
+                    .url("https://instagram.com/tecodaehak")
+                    .logoUrl("https://image.com/logo.png")
+                    .name("테코대학교 총학생회 인스타그램")
+                    .build();
+
+                // when & then
+                mockMvc.perform(patch(uri, socialMediaId)
+                        .cookie(TOKEN_COOKIE)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(patch(uri, socialMediaId))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(patch(uri, socialMediaId)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
+
+    @Nested
+    class 소셜미디어_삭제 {
+
+        final String uri = "/admin/api/v1/socialmedias/{socialMediaId}";
+        Long socialMediaId = 1L;
+
+        @Nested
+        @DisplayName("DELETE " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_204_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(delete(uri, socialMediaId)
+                        .cookie(TOKEN_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNoContent());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(delete(uri, socialMediaId))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(delete(uri, socialMediaId)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminSocialMediaV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminSocialMediaV1ControllerTest.java
@@ -1,13 +1,17 @@
 package com.festago.admin.presentation.v1;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.admin.application.AdminSocialMediaV1QueryService;
+import com.festago.admin.dto.socialmedia.AdminSocialMediaV1Response;
 import com.festago.admin.dto.socialmedia.SocialMediaCreateV1Request;
 import com.festago.admin.dto.socialmedia.SocialMediaUpdateV1Request;
 import com.festago.auth.domain.Role;
@@ -18,6 +22,7 @@ import com.festago.socialmedia.dto.command.SocialMediaCreateCommand;
 import com.festago.support.CustomWebMvcTest;
 import com.festago.support.WithMockAuth;
 import jakarta.servlet.http.Cookie;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -42,6 +47,108 @@ class AdminSocialMediaV1ControllerTest {
 
     @Autowired
     SocialMediaCommandService socialMediaCommandService;
+
+    @Autowired
+    AdminSocialMediaV1QueryService adminSocialMediaV1QueryService;
+
+    @Nested
+    class 소셜미디어_단건_조회 {
+
+        final String uri = "/admin/api/v1/socialmedias/{socialMediaId}";
+        Long socialMediaId = 1L;
+
+        @Nested
+        @DisplayName("GET " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                // given
+                given(adminSocialMediaV1QueryService.findById(anyLong()))
+                    .willReturn(new AdminSocialMediaV1Response(
+                        1L,
+                        SocialMediaType.INSTAGRAM,
+                        "테코대학교 총학생회 인스타그램",
+                        "https://image.com/logo.png",
+                        "htps://instagram.com/tecodaehak"
+                    ));
+
+                // when & then
+                mockMvc.perform(get(uri, socialMediaId)
+                        .cookie(TOKEN_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri, socialMediaId))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri, socialMediaId)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
+
+    @Nested
+    class 소셜미디어_목록_조회 {
+
+        final String uri = "/admin/api/v1/socialmedias";
+
+        @Nested
+        @DisplayName("GET " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                // given
+                given(adminSocialMediaV1QueryService.findByOwnerIdAndOwnerType(anyLong(), any(OwnerType.class)))
+                    .willReturn(List.of(
+                        new AdminSocialMediaV1Response(
+                            1L,
+                            SocialMediaType.INSTAGRAM,
+                            "테코대학교 총학생회 인스타그램",
+                            "https://image.com/logo.png",
+                            "htps://instagram.com/tecodaehak"
+                        )
+                    ));
+
+                // when & then
+                mockMvc.perform(get(uri)
+                        .param("ownerId", "1")
+                        .param("ownerType", "SCHOOL")
+                        .cookie(TOKEN_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
 
     @Nested
     class 소셜미디어_생성 {

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminSocialMediaV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminSocialMediaV1ControllerTest.java
@@ -65,9 +65,12 @@ class AdminSocialMediaV1ControllerTest {
             @WithMockAuth(role = Role.ADMIN)
             void 요청을_보내면_200_응답이_반환된다() throws Exception {
                 // given
+                Long ownerId = 1L;
                 given(adminSocialMediaV1QueryService.findById(anyLong()))
                     .willReturn(new AdminSocialMediaV1Response(
-                        1L,
+                        socialMediaId,
+                        ownerId,
+                        OwnerType.SCHOOL,
                         SocialMediaType.INSTAGRAM,
                         "테코대학교 총학생회 인스타그램",
                         "https://image.com/logo.png",
@@ -112,10 +115,14 @@ class AdminSocialMediaV1ControllerTest {
             @WithMockAuth(role = Role.ADMIN)
             void 요청을_보내면_200_응답이_반환된다() throws Exception {
                 // given
+                Long socialMediaId = 1L;
+                Long ownerId = 1L;
                 given(adminSocialMediaV1QueryService.findByOwnerIdAndOwnerType(anyLong(), any(OwnerType.class)))
                     .willReturn(List.of(
                         new AdminSocialMediaV1Response(
-                            1L,
+                            socialMediaId,
+                            ownerId,
+                            OwnerType.SCHOOL,
                             SocialMediaType.INSTAGRAM,
                             "테코대학교 총학생회 인스타그램",
                             "https://image.com/logo.png",

--- a/backend/src/test/java/com/festago/socialmedia/application/SocialMediaCommandServiceTest.java
+++ b/backend/src/test/java/com/festago/socialmedia/application/SocialMediaCommandServiceTest.java
@@ -1,0 +1,121 @@
+package com.festago.socialmedia.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.festago.artist.repository.ArtistRepository;
+import com.festago.artist.repository.MemoryArtistRepository;
+import com.festago.common.exception.BadRequestException;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
+import com.festago.school.domain.School;
+import com.festago.school.repository.MemorySchoolRepository;
+import com.festago.school.repository.SchoolRepository;
+import com.festago.socialmedia.domain.OwnerType;
+import com.festago.socialmedia.domain.SocialMedia;
+import com.festago.socialmedia.domain.SocialMediaType;
+import com.festago.socialmedia.dto.command.SocialMediaCreateCommand;
+import com.festago.socialmedia.repository.MemorySocialMediaRepository;
+import com.festago.socialmedia.repository.SocialMediaRepository;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.SocialMediaFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class SocialMediaCommandServiceTest {
+
+    SocialMediaCommandService socialMediaCommandService;
+
+    SocialMediaRepository socialMediaRepository;
+
+    SchoolRepository schoolRepository;
+
+    ArtistRepository artistRepository;
+
+    @BeforeEach
+    void setUp() {
+        socialMediaRepository = new MemorySocialMediaRepository();
+        schoolRepository = new MemorySchoolRepository();
+        artistRepository = new MemoryArtistRepository();
+        socialMediaCommandService = new SocialMediaCommandService(
+            socialMediaRepository,
+            schoolRepository,
+            artistRepository
+        );
+    }
+
+    @Nested
+    class createSocialMedia {
+
+        @Test
+        void 중복된_소셜미디어가_있으면_예외() {
+            // given
+            School 테코대학교 = schoolRepository.save(SchoolFixture.builder().name("테코대학교").build());
+
+            SocialMedia socialMedia = socialMediaRepository.save(SocialMediaFixture.builder()
+                .ownerId(테코대학교.getId())
+                .ownerType(OwnerType.SCHOOL)
+                .mediaType(SocialMediaType.INSTAGRAM)
+                .build());
+
+            // when & then
+            var command = new SocialMediaCreateCommand(
+                socialMedia.getOwnerId(),
+                socialMedia.getOwnerType(),
+                socialMedia.getMediaType(),
+                socialMedia.getName(),
+                socialMedia.getLogoUrl(),
+                socialMedia.getUrl()
+            );
+            assertThatThrownBy(() -> socialMediaCommandService.createSocialMedia(command))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.DUPLICATE_SOCIAL_MEDIA.getMessage());
+        }
+
+        // TODO 다른 Owner에 대한 테스트를 어떻게 작성할지? ex) MethodSource
+        @Test
+        void 추가하려는_소셜미디어의_owner가_존재하지_않으면_예외() {
+            // when & then
+            var command = new SocialMediaCreateCommand(
+                4885L,
+                OwnerType.SCHOOL,
+                SocialMediaType.INSTAGRAM,
+                "테코대학교 인스타그램",
+                "https://image.com/logo.png",
+                "https://instagram.com/tecodaehak"
+            );
+            assertThatThrownBy(() -> socialMediaCommandService.createSocialMedia(command))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.SCHOOL_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 성공하면_소셜미디어가_저장된다() {
+            // given
+            School 테코대학교 = schoolRepository.save(SchoolFixture.builder().name("테코대학교").build());
+
+            // when
+            var command = new SocialMediaCreateCommand(
+                테코대학교.getId(),
+                OwnerType.SCHOOL,
+                SocialMediaType.INSTAGRAM,
+                "테코대학교 인스타그램",
+                "https://image.com/logo.png",
+                "https://instagram.com/tecodaehak"
+            );
+            socialMediaCommandService.createSocialMedia(command);
+
+            // then
+            assertThat(socialMediaRepository.existsByOwnerIdAndOwnerTypeAndMediaType(
+                테코대학교.getId(),
+                OwnerType.SCHOOL,
+                SocialMediaType.INSTAGRAM
+            )).isTrue();
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/socialmedia/application/SocialMediaCommandServiceTest.java
+++ b/backend/src/test/java/com/festago/socialmedia/application/SocialMediaCommandServiceTest.java
@@ -3,6 +3,7 @@ package com.festago.socialmedia.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.festago.artist.repository.ArtistRepository;
 import com.festago.artist.repository.MemoryArtistRepository;
@@ -159,6 +160,34 @@ class SocialMediaCommandServiceTest {
                 softly.assertThat(actual.getUrl()).isEqualTo(command.url());
                 softly.assertThat(actual.getLogoUrl()).isEqualTo(command.logoUrl());
             });
+        }
+    }
+
+    @Nested
+    class deleteSocialMedia {
+
+        @Test
+        void 삭제하려는_소셜미디어가_존재하지_않아도_예외가_발생하지_않는다() {
+            // when & then
+            assertDoesNotThrow(() -> socialMediaCommandService.deleteSocialMedia(4885L));
+        }
+
+        @Test
+        void 소셜미디어의_식별자로_삭제할_수_있다() {
+            // given
+            School 테코대학교 = schoolRepository.save(SchoolFixture.builder().name("테코대학교").build());
+
+            SocialMedia socialMedia = socialMediaRepository.save(SocialMediaFixture.builder()
+                .ownerId(테코대학교.getId())
+                .ownerType(OwnerType.SCHOOL)
+                .mediaType(SocialMediaType.INSTAGRAM)
+                .build());
+
+            // when
+            socialMediaCommandService.deleteSocialMedia(socialMedia.getId());
+
+            // then
+            assertThat(socialMediaRepository.findById(socialMedia.getId())).isEmpty();
         }
     }
 }

--- a/backend/src/test/java/com/festago/socialmedia/application/SocialMediaCommandServiceTest.java
+++ b/backend/src/test/java/com/festago/socialmedia/application/SocialMediaCommandServiceTest.java
@@ -110,14 +110,10 @@ class SocialMediaCommandServiceTest {
                 "https://image.com/logo.png",
                 "https://instagram.com/tecodaehak"
             );
-            socialMediaCommandService.createSocialMedia(command);
+            Long socialMediaId = socialMediaCommandService.createSocialMedia(command);
 
             // then
-            assertThat(socialMediaRepository.existsByOwnerIdAndOwnerTypeAndMediaType(
-                테코대학교.getId(),
-                OwnerType.SCHOOL,
-                SocialMediaType.INSTAGRAM
-            )).isTrue();
+            assertThat(socialMediaRepository.findById(socialMediaId)).isPresent();
         }
     }
 

--- a/backend/src/test/java/com/festago/socialmedia/repository/MemorySocialMediaRepository.java
+++ b/backend/src/test/java/com/festago/socialmedia/repository/MemorySocialMediaRepository.java
@@ -3,35 +3,11 @@ package com.festago.socialmedia.repository;
 import com.festago.socialmedia.domain.OwnerType;
 import com.festago.socialmedia.domain.SocialMedia;
 import com.festago.socialmedia.domain.SocialMediaType;
-import java.lang.reflect.Field;
-import java.util.HashMap;
-import java.util.Map;
+import com.festago.support.AbstractMemoryRepository;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicLong;
-import lombok.SneakyThrows;
 
-// TODO #841 이슈 해결되면 반영할 것
-public class MemorySocialMediaRepository implements SocialMediaRepository {
-
-    private final Map<Long, SocialMedia> memory = new HashMap<>();
-    private final AtomicLong autoIncrement = new AtomicLong();
-
-    @Override
-    @SneakyThrows
-    public SocialMedia save(SocialMedia socialMedia) {
-        Field idField = socialMedia.getClass()
-            .getDeclaredField("id");
-        idField.setAccessible(true);
-        idField.set(socialMedia, autoIncrement.incrementAndGet());
-        memory.put(socialMedia.getId(), socialMedia);
-        return socialMedia;
-    }
-
-    @Override
-    public Optional<SocialMedia> findById(Long id) {
-        return Optional.ofNullable(memory.get(id));
-    }
+public class MemorySocialMediaRepository extends AbstractMemoryRepository<SocialMedia> implements
+    SocialMediaRepository {
 
     @Override
     public boolean existsByOwnerIdAndOwnerTypeAndMediaType(
@@ -43,10 +19,5 @@ public class MemorySocialMediaRepository implements SocialMediaRepository {
             .filter(it -> Objects.equals(it.getOwnerId(), ownerId))
             .filter(it -> it.getOwnerType() == ownerType)
             .anyMatch(it -> it.getMediaType() == mediaType);
-    }
-
-    @Override
-    public void deleteById(Long socialMediaId) {
-        memory.remove(socialMediaId);
     }
 }

--- a/backend/src/test/java/com/festago/socialmedia/repository/MemorySocialMediaRepository.java
+++ b/backend/src/test/java/com/festago/socialmedia/repository/MemorySocialMediaRepository.java
@@ -44,4 +44,9 @@ public class MemorySocialMediaRepository implements SocialMediaRepository {
             .filter(it -> it.getOwnerType() == ownerType)
             .anyMatch(it -> it.getMediaType() == mediaType);
     }
+
+    @Override
+    public void deleteById(Long socialMediaId) {
+        memory.remove(socialMediaId);
+    }
 }

--- a/backend/src/test/java/com/festago/socialmedia/repository/MemorySocialMediaRepository.java
+++ b/backend/src/test/java/com/festago/socialmedia/repository/MemorySocialMediaRepository.java
@@ -1,0 +1,41 @@
+package com.festago.socialmedia.repository;
+
+import com.festago.socialmedia.domain.OwnerType;
+import com.festago.socialmedia.domain.SocialMedia;
+import com.festago.socialmedia.domain.SocialMediaType;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.SneakyThrows;
+
+// TODO #841 이슈 해결되면 반영할 것
+public class MemorySocialMediaRepository implements SocialMediaRepository {
+
+    private final Map<Long, SocialMedia> memory = new HashMap<>();
+    private final AtomicLong autoIncrement = new AtomicLong();
+
+    @Override
+    @SneakyThrows
+    public SocialMedia save(SocialMedia socialMedia) {
+        Field idField = socialMedia.getClass()
+            .getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(socialMedia, autoIncrement.incrementAndGet());
+        memory.put(socialMedia.getId(), socialMedia);
+        return socialMedia;
+    }
+
+    @Override
+    public boolean existsByOwnerIdAndOwnerTypeAndMediaType(
+        Long ownerId,
+        OwnerType ownerType,
+        SocialMediaType mediaType
+    ) {
+        return memory.values().stream()
+            .filter(it -> Objects.equals(it.getOwnerId(), ownerId))
+            .filter(it -> it.getOwnerType() == ownerType)
+            .anyMatch(it -> it.getMediaType() == mediaType);
+    }
+}

--- a/backend/src/test/java/com/festago/socialmedia/repository/MemorySocialMediaRepository.java
+++ b/backend/src/test/java/com/festago/socialmedia/repository/MemorySocialMediaRepository.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.SneakyThrows;
 
@@ -25,6 +26,11 @@ public class MemorySocialMediaRepository implements SocialMediaRepository {
         idField.set(socialMedia, autoIncrement.incrementAndGet());
         memory.put(socialMedia.getId(), socialMedia);
         return socialMedia;
+    }
+
+    @Override
+    public Optional<SocialMedia> findById(Long id) {
+        return Optional.ofNullable(memory.get(id));
     }
 
     @Override


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #802

## ✨ PR 세부 내용

관련 이슈처럼 소셜미디어 CRUD 기능을 추가했습니다.

이슈에서는 CUD 기능만 추가하기로 되어 있지만, 관리자 페이지에 빠르게 기능 구현이 필요하고, 구현의 어려움이 없으므로 해당 PR에서 작업하였습니다.

소셜미디어의 추가와 수정에 문자열의 길이에 대한 검증 로직이 없는데, 관리자 기능이라 추가하지는 않았습니다.
(추후 500 에러가 발생하는 것을 보고 추가하면 될 것 같네요)

소셜미디어 조회 API는 2개인데, 그중 식별자를 통한 단건 조회 기능은 수정 기능에서 사용할 목적으로 만들었습니다. (상세 조회)

목록 조회는 `ownerId`, `ownerType`에 해당하는 소셜미디어를 모두 조회해 오는데, 따로 limit을 두지는 않았습니다.

이유는 `ownerId`와 `ownerType`의 조합에서 생성할 수 있는 소셜미디어의 최대 개수는 `socialMediaType` 개수와 동일하기에, 너무 많은 row로 인해 발생하는 성능 이슈가 없습니다. 

`SocialMediaType.values().length`를 limit 절에 사용한다면 나름 성능 최적화가 가능할 것 같네요. 다만 모든 socialMediaType을 만드는 경우가 없을 것 같아 현실성은 떨어져 보입니다. 😂

또한 `SocialMediaCommandService`의 TODO 주석에서 남겨두었지만, 추상화된 예외가 필요할지 얘기하고 싶습니다.

더 객체 지향적인 방법으로 풀어나간다면 SocialMediaCreateValidator 인터페이스를 만들어서 어떻게 할 것 같은데...

현재 소셜미디어의 owner는 School과 Artist 2개뿐이고, 여기서 더 추가될 것 같지는 않아서 그저 오버 엔지니어링이 될 것 같네요. 😂

그 외, 메서드 이름이 적절한지 봐주시면 감사하겠습니다!