### PR TITLE
[BE] feat: AdminStageV1Controller에 공연 단건 조회 기능 추가 (#855)

### DIFF
--- a/backend/src/main/java/com/festago/admin/application/AdminStageV1QueryService.java
+++ b/backend/src/main/java/com/festago/admin/application/AdminStageV1QueryService.java
@@ -2,6 +2,8 @@ package com.festago.admin.application;
 
 import com.festago.admin.dto.stage.AdminStageV1Response;
 import com.festago.admin.repository.AdminStageV1QueryDslRepository;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,5 +18,10 @@ public class AdminStageV1QueryService {
 
     public List<AdminStageV1Response> findAllByFestivalId(Long festivalId) {
         return adminStageV1QueryDslRepository.findAllByFestivalId(festivalId);
+    }
+
+    public AdminStageV1Response findById(Long stageId) {
+        return adminStageV1QueryDslRepository.findById(stageId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.STAGE_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/com/festago/admin/presentation/v1/AdminStageV1Controller.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/AdminStageV1Controller.java
@@ -30,7 +30,7 @@ public class AdminStageV1Controller {
 
     @GetMapping("/{stageId}")
     public ResponseEntity<AdminStageV1Response> findById(
-        @PathVariable  Long stageId
+        @PathVariable Long stageId
     ) {
         return ResponseEntity.ok()
             .body(adminStageV1QueryService.findById(stageId));

--- a/backend/src/main/java/com/festago/admin/presentation/v1/AdminStageV1Controller.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/AdminStageV1Controller.java
@@ -1,5 +1,7 @@
 package com.festago.admin.presentation.v1;
 
+import com.festago.admin.application.AdminStageV1QueryService;
+import com.festago.admin.dto.stage.AdminStageV1Response;
 import com.festago.admin.dto.stage.StageV1CreateRequest;
 import com.festago.admin.dto.stage.StageV1UpdateRequest;
 import com.festago.stage.application.command.StageCommandFacadeService;
@@ -9,6 +11,7 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,6 +26,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminStageV1Controller {
 
     private final StageCommandFacadeService stageCommandFacadeService;
+    private final AdminStageV1QueryService adminStageV1QueryService;
+
+    @GetMapping("/{stageId}")
+    public ResponseEntity<AdminStageV1Response> findStageById(
+        @PathVariable  Long stageId
+    ) {
+        return ResponseEntity.ok()
+            .body(adminStageV1QueryService.findById(stageId));
+    }
 
     @PostMapping
     public ResponseEntity<Void> createStage(

--- a/backend/src/main/java/com/festago/admin/presentation/v1/AdminStageV1Controller.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/AdminStageV1Controller.java
@@ -29,7 +29,7 @@ public class AdminStageV1Controller {
     private final AdminStageV1QueryService adminStageV1QueryService;
 
     @GetMapping("/{stageId}")
-    public ResponseEntity<AdminStageV1Response> findStageById(
+    public ResponseEntity<AdminStageV1Response> findById(
         @PathVariable  Long stageId
     ) {
         return ResponseEntity.ok()

--- a/backend/src/main/java/com/festago/admin/repository/AdminStageV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/admin/repository/AdminStageV1QueryDslRepository.java
@@ -12,6 +12,7 @@ import com.festago.admin.dto.stage.QAdminStageV1Response;
 import com.festago.common.querydsl.QueryDslRepositorySupport;
 import com.festago.stage.domain.Stage;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -42,5 +43,31 @@ public class AdminStageV1QueryDslRepository extends QueryDslRepositorySupport {
                     )
                 )
             );
+    }
+
+    public Optional<AdminStageV1Response> findById(Long stageId) {
+        List<AdminStageV1Response> response = selectFrom(stage)
+            .leftJoin(stageArtist).on(stageArtist.stageId.eq(stageId))
+            .leftJoin(artist).on(artist.id.eq(stageArtist.artistId))
+            .where(stage.id.eq(stageId))
+            .transform(
+                groupBy(stage.id).list(
+                    new QAdminStageV1Response(
+                        stage.id,
+                        stage.startTime,
+                        stage.ticketOpenTime,
+                        list(new QAdminStageArtistV1Response(
+                            artist.id,
+                            artist.name
+                        )),
+                        stage.createdAt,
+                        stage.updatedAt
+                    )
+                )
+            );
+        if (response.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(response.get(0));
     }
 }

--- a/backend/src/test/java/com/festago/admin/application/integration/AdminStageV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/admin/application/integration/AdminStageV1QueryServiceIntegrationTest.java
@@ -2,12 +2,16 @@ package com.festago.admin.application.integration;
 
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.festago.admin.application.AdminStageV1QueryService;
 import com.festago.admin.dto.stage.AdminStageArtistV1Response;
 import com.festago.admin.dto.stage.AdminStageV1Response;
+import com.festago.artist.domain.Artist;
 import com.festago.artist.repository.ArtistRepository;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
 import com.festago.festival.domain.Festival;
 import com.festago.festival.repository.FestivalRepository;
 import com.festago.school.repository.SchoolRepository;
@@ -55,116 +59,187 @@ class AdminStageV1QueryServiceIntegrationTest extends ApplicationIntegrationTest
     LocalDate _2077년_6월_16일 = LocalDate.parse("2077-06-16");
     LocalDate _2077년_6월_17일 = LocalDate.parse("2077-07-17");
 
-    @Test
-    void 존재하지_않는_축제의_식별자로_조회하면_빈_리스트가_반환된다() {
-        // when
-        var actual = adminStageV1QueryService.findAllByFestivalId(4885L);
-
-        // then
-        assertThat(actual).isEmpty();
-    }
-
     @Nested
-    class 축제에_공연이_없으면 {
-
-        Long 축제_식별자;
-
-        @BeforeEach
-        void setUp() {
-            var 학교 = schoolRepository.save(SchoolFixture.builder().build());
-            축제_식별자 = festivalRepository.save(FestivalFixture.builder()
-                .startDate(_2077년_6월_15일)
-                .endDate(_2077년_6월_15일)
-                .school(학교)
-                .build()).getId();
-        }
+    class findAllByFestivalId {
 
         @Test
-        void 빈_리스트가_반환된다() {
+        void 존재하지_않는_축제의_식별자로_조회하면_빈_리스트가_반환된다() {
             // when
-            var actual = adminStageV1QueryService.findAllByFestivalId(축제_식별자);
+            var actual = adminStageV1QueryService.findAllByFestivalId(4885L);
 
             // then
             assertThat(actual).isEmpty();
         }
+
+        @Nested
+        class 축제에_공연이_없으면 {
+
+            Long 축제_식별자;
+
+            @BeforeEach
+            void setUp() {
+                var 학교 = schoolRepository.save(SchoolFixture.builder().build());
+                축제_식별자 = festivalRepository.save(FestivalFixture.builder()
+                    .startDate(_2077년_6월_15일)
+                    .endDate(_2077년_6월_15일)
+                    .school(학교)
+                    .build()).getId();
+            }
+
+            @Test
+            void 빈_리스트가_반환된다() {
+                // when
+                var actual = adminStageV1QueryService.findAllByFestivalId(축제_식별자);
+
+                // then
+                assertThat(actual).isEmpty();
+            }
+        }
+
+        /**
+         * 6월 15일 ~ 6월 17일까지 진행되는 축제<p> 6월 15일 공연, 6월 16일 공연이 있다.<p>
+         * <p>
+         * 6월 15일 공연에는 아티스트A, 아티스트B가 참여한다.<p> 6월 16일 공연에는 아티스트C가 참여한다.
+         */
+        @Nested
+        class 특정_축제의_공연_목록과_참여하는_아티스트를_조회할_수_있어야_한다 {
+
+            Long 아티스트A_식별자;
+            Long 아티스트B_식별자;
+            Long 아티스트C_식별자;
+            Festival 축제;
+            Long _6월_15일_공연_식별자;
+            Long _6월_16일_공연_식별자;
+
+            @BeforeEach
+            void setUp() {
+                아티스트A_식별자 = createArtist("아티스트A").getId();
+                아티스트B_식별자 = createArtist("아티스트B").getId();
+                아티스트C_식별자 = createArtist("아티스트C").getId();
+                var 학교 = schoolRepository.save(SchoolFixture.builder().build());
+                축제 = festivalRepository.save(FestivalFixture.builder()
+                    .startDate(_2077년_6월_15일)
+                    .endDate(_2077년_6월_17일)
+                    .school(학교)
+                    .build());
+                _6월_15일_공연_식별자 = createStage(축제, _2077년_6월_15일, List.of(아티스트A_식별자, 아티스트B_식별자)).getId();
+                _6월_16일_공연_식별자 = createStage(축제, _2077년_6월_16일, List.of(아티스트C_식별자)).getId();
+            }
+
+            @Test
+            void 공연의_시작_순서대로_정렬된다() {
+                // when
+                var actual = adminStageV1QueryService.findAllByFestivalId(축제.getId());
+
+                // then
+                assertThat(actual)
+                    .map(AdminStageV1Response::id)
+                    .containsExactly(_6월_15일_공연_식별자, _6월_16일_공연_식별자);
+            }
+
+            @Test
+            void 해당_일자의_공연에_참여하는_아티스트_목록을_조회할_수_있다() {
+                // when
+                var stageIdToArtists = adminStageV1QueryService.findAllByFestivalId(축제.getId()).stream()
+                    .collect(toMap(AdminStageV1Response::id, AdminStageV1Response::artists));
+
+                // then
+                assertSoftly(softly -> {
+                    softly.assertThat(stageIdToArtists.get(_6월_15일_공연_식별자))
+                        .map(AdminStageArtistV1Response::id)
+                        .containsExactlyInAnyOrder(아티스트A_식별자, 아티스트B_식별자);
+
+                    softly.assertThat(stageIdToArtists.get(_6월_16일_공연_식별자))
+                        .map(AdminStageArtistV1Response::id)
+                        .containsExactlyInAnyOrder(아티스트C_식별자);
+                });
+            }
+        }
     }
 
-    /**
-     * 6월 15일 ~ 6월 17일까지 진행되는 축제<p> 6월 15일 공연, 6월 16일 공연이 있다.<p>
-     * <p>
-     * 6월 15일 공연에는 아티스트A, 아티스트B가 참여한다.<p> 6월 16일 공연에는 아티스트C가 참여한다.
-     */
+    private Artist createArtist(String artistName) {
+        return artistRepository.save(ArtistFixture.builder()
+            .name(artistName)
+            .build()
+        );
+    }
+
+    private Stage createStage(Festival festival, LocalDate localDate, List<Long> artistIds) {
+        var 공연 = stageRepository.save(StageFixture.builder()
+            .festival(festival)
+            .startTime(localDate.atTime(18, 0))
+            .build()
+        );
+        for (Long artistId : artistIds) {
+            stageArtistRepository.save(StageArtistFixture.builder(공연.getId(), artistId).build());
+        }
+        return 공연;
+    }
+
     @Nested
-    class 특정_축제의_공연_목록과_참여하는_아티스트를_조회할_수_있어야_한다 {
+    class findById {
 
-        Long 아티스트A_식별자;
-        Long 아티스트B_식별자;
-        Long 아티스트C_식별자;
-        Festival 축제;
-        Long _6월_15일_공연_식별자;
-        Long _6월_16일_공연_식별자;
+        @Nested
+        class 식별자에_해당하는_공연이_없으면 {
 
-        @BeforeEach
-        void setUp() {
-            아티스트A_식별자 = createArtist("아티스트A");
-            아티스트B_식별자 = createArtist("아티스트B");
-            아티스트C_식별자 = createArtist("아티스트C");
-            var 학교 = schoolRepository.save(SchoolFixture.builder().build());
-            축제 = festivalRepository.save(FestivalFixture.builder()
-                .startDate(_2077년_6월_15일)
-                .endDate(_2077년_6월_17일)
-                .school(학교)
-                .build());
-            _6월_15일_공연_식별자 = createStage(축제, _2077년_6월_15일, List.of(아티스트A_식별자, 아티스트B_식별자)).getId();
-            _6월_16일_공연_식별자 = createStage(축제, _2077년_6월_16일, List.of(아티스트C_식별자)).getId();
-        }
-
-        private Long createArtist(String artistName) {
-            return artistRepository.save(ArtistFixture.builder()
-                .name(artistName)
-                .build()
-            ).getId();
-        }
-
-        private Stage createStage(Festival festival, LocalDate localDate, List<Long> artistIds) {
-            var 공연 = stageRepository.save(StageFixture.builder()
-                .festival(festival)
-                .startTime(localDate.atTime(18, 0))
-                .build()
-            );
-            for (Long artistId : artistIds) {
-                stageArtistRepository.save(StageArtistFixture.builder(공연.getId(), artistId).build());
+            @Test
+            void 예외가_발생한다() {
+                // when & then
+                assertThatThrownBy(() -> adminStageV1QueryService.findById(4885L))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage(ErrorCode.STAGE_NOT_FOUND.getMessage());
             }
-            return 공연;
         }
 
-        @Test
-        void 공연의_시작_순서대로_정렬된다() {
-            // when
-            var actual = adminStageV1QueryService.findAllByFestivalId(축제.getId());
+        @Nested
+        class 식별자에_해당하는_공연이_있으면 {
 
-            // then
-            assertThat(actual)
-                .map(AdminStageV1Response::id)
-                .containsExactly(_6월_15일_공연_식별자, _6월_16일_공연_식별자);
-        }
+            Artist 아티스트A;
+            Artist 아티스트B;
+            Artist 아티스트C;
+            Stage 공연;
 
-        @Test
-        void 해당_일자의_공연에_참여하는_아티스트_목록을_조회할_수_있다() {
-            // when
-            var stageIdToArtists = adminStageV1QueryService.findAllByFestivalId(축제.getId()).stream()
-                .collect(toMap(AdminStageV1Response::id, AdminStageV1Response::artists));
+            @BeforeEach
+            void setUp() {
+                var 학교 = schoolRepository.save(SchoolFixture.builder().build());
+                var 축제 = festivalRepository.save(FestivalFixture.builder()
+                    .startDate(_2077년_6월_15일)
+                    .endDate(_2077년_6월_15일)
+                    .school(학교)
+                    .build()
+                );
+                아티스트A = createArtist("아티스트A");
+                아티스트B = createArtist("아티스트B");
+                아티스트C = createArtist("아티스트C");
+                공연 = createStage(
+                    축제,
+                    _2077년_6월_15일,
+                    List.of(아티스트A.getId(), 아티스트B.getId(), 아티스트C.getId())
+                );
+            }
 
-            // then
-            assertSoftly(softly -> {
-                softly.assertThat(stageIdToArtists.get(_6월_15일_공연_식별자))
-                    .map(AdminStageArtistV1Response::id)
-                    .containsExactlyInAnyOrder(아티스트A_식별자, 아티스트B_식별자);
+            @Test
+            void 공연의_정보가_정확하게_조회되어야_한다() {
+                // when
+                var actual = adminStageV1QueryService.findById(공연.getId());
 
-                softly.assertThat(stageIdToArtists.get(_6월_16일_공연_식별자))
-                    .map(AdminStageArtistV1Response::id)
-                    .containsExactlyInAnyOrder(아티스트C_식별자);
-            });
+                assertSoftly(softly -> {
+                    softly.assertThat(actual.id()).isEqualTo(공연.getId());
+                    softly.assertThat(actual.startDateTime()).isEqualTo(공연.getStartTime());
+                    softly.assertThat(actual.ticketOpenTime()).isEqualTo(공연.getTicketOpenTime());
+                });
+            }
+
+            @Test
+            void 공연의_아티스트_목록이_조회되어야_한다() {
+                // when
+                var actual = adminStageV1QueryService.findById(공연.getId());
+
+                // then
+                assertThat(actual.artists())
+                    .map(AdminStageArtistV1Response::name)
+                    .containsExactlyInAnyOrder(아티스트A.getName(), 아티스트B.getName(), 아티스트C.getName());
+            }
         }
     }
 }

--- a/backend/src/test/java/com/festago/admin/application/integration/AdminStageV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/admin/application/integration/AdminStageV1QueryServiceIntegrationTest.java
@@ -102,7 +102,7 @@ class AdminStageV1QueryServiceIntegrationTest extends ApplicationIntegrationTest
          * 6월 15일 공연에는 아티스트A, 아티스트B가 참여한다.<p> 6월 16일 공연에는 아티스트C가 참여한다.
          */
         @Nested
-        class 특정_축제의_공연_목록과_참여하는_아티스트를_조회할_수_있어야_한다 {
+        class 축제에_공연이_있으면 {
 
             Long 아티스트A_식별자;
             Long 아티스트B_식별자;

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminStageV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminStageV1ControllerTest.java
@@ -3,6 +3,7 @@ package com.festago.admin.presentation.v1;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -46,6 +47,44 @@ class AdminStageV1ControllerTest {
     StageCommandFacadeService stageCommandFacadeService;
 
     @Nested
+    class 공연_단건_조회 {
+
+        final String uri = "/admin/api/v1/stages/{stageId}";
+
+        @Nested
+        @DisplayName("GET " + uri)
+        class 올바른_주소로 {
+
+            Long stageId = 1L;
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                mockMvc.perform(get(uri, stageId)
+                        .cookie(TOKEN_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri, 1))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(get(uri, 1)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
+
+    @Nested
     class 공연_생성 {
 
         final String uri = "/admin/api/v1/stages";
@@ -58,7 +97,8 @@ class AdminStageV1ControllerTest {
             LocalDateTime startTime = LocalDateTime.parse("2077-06-30T18:00:00");
             LocalDateTime ticketOpenTime = LocalDateTime.parse("2077-06-23T00:00:00");
             List<Long> artistIds = List.of(1L, 2L, 3L);
-            StageV1CreateRequest request = new StageV1CreateRequest(festivalId, startTime, ticketOpenTime, artistIds);
+            StageV1CreateRequest request = new StageV1CreateRequest(festivalId, startTime, ticketOpenTime,
+                artistIds);
 
             @Test
             @WithMockAuth(role = Role.ADMIN)
@@ -172,4 +212,5 @@ class AdminStageV1ControllerTest {
             }
         }
     }
+
 }

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminStageV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminStageV1ControllerTest.java
@@ -108,7 +108,7 @@ class AdminStageV1ControllerTest {
                     .willReturn(1L);
 
                 // when & then
-                mockMvc.perform(post(uri, 1)
+                mockMvc.perform(post(uri)
                         .cookie(TOKEN_COOKIE)
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON))
@@ -119,7 +119,7 @@ class AdminStageV1ControllerTest {
             @Test
             void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
                 // when & then
-                mockMvc.perform(post(uri, 1))
+                mockMvc.perform(post(uri))
                     .andExpect(status().isUnauthorized());
             }
 
@@ -127,7 +127,7 @@ class AdminStageV1ControllerTest {
             @WithMockAuth(role = Role.MEMBER)
             void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
                 // when & then
-                mockMvc.perform(post(uri, 1)
+                mockMvc.perform(post(uri)
                         .cookie(TOKEN_COOKIE))
                     .andExpect(status().isNotFound());
             }
@@ -152,7 +152,7 @@ class AdminStageV1ControllerTest {
             @WithMockAuth(role = Role.ADMIN)
             void 요청을_보내면_200_응답이_반환된다() throws Exception {
                 // when & then
-                mockMvc.perform(patch(uri, 1, 1)
+                mockMvc.perform(patch(uri, 1)
                         .cookie(TOKEN_COOKIE)
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON))
@@ -162,7 +162,7 @@ class AdminStageV1ControllerTest {
             @Test
             void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
                 // when & then
-                mockMvc.perform(patch(uri, 1, 1))
+                mockMvc.perform(patch(uri, 1))
                     .andExpect(status().isUnauthorized());
             }
 
@@ -170,7 +170,7 @@ class AdminStageV1ControllerTest {
             @WithMockAuth(role = Role.MEMBER)
             void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
                 // when & then
-                mockMvc.perform(patch(uri, 1, 1)
+                mockMvc.perform(patch(uri, 1)
                         .cookie(TOKEN_COOKIE))
                     .andExpect(status().isNotFound());
             }
@@ -190,7 +190,7 @@ class AdminStageV1ControllerTest {
             @WithMockAuth(role = Role.ADMIN)
             void 요청을_보내면_204_응답이_반환된다() throws Exception {
                 // when & then
-                mockMvc.perform(delete(uri, 1, 1)
+                mockMvc.perform(delete(uri, 1)
                         .cookie(TOKEN_COOKIE))
                     .andExpect(status().isNoContent());
             }
@@ -198,7 +198,7 @@ class AdminStageV1ControllerTest {
             @Test
             void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
                 // when & then
-                mockMvc.perform(delete(uri, 1, 1))
+                mockMvc.perform(delete(uri, 1))
                     .andExpect(status().isUnauthorized());
             }
 
@@ -206,7 +206,7 @@ class AdminStageV1ControllerTest {
             @WithMockAuth(role = Role.MEMBER)
             void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
                 // when & then
-                mockMvc.perform(delete(uri, 1, 1)
+                mockMvc.perform(delete(uri, 1)
                         .cookie(TOKEN_COOKIE))
                     .andExpect(status().isNotFound());
             }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #855

## ✨ PR 세부 내용

이슈 내용 그대로 `AdminStageV1Controller`에 공연의 식별자로 공연을 조회하는 기능을 추가했습니다.

`AdminStageV1QueryServiceIntegrationTest`에서 각 메서드 별 `@Nested`로 묶은 것 빼고는 크게 볼게 없을거라 생각되네요.

그 외 메서드 명을 어떻게 통일해야 하나 거슬리긴 하는데... 사소한 부분이니 나중에 운영 단계에서 리팩터링하면 좋을 것 같습니다.