### PR TITLE
[BE] fix: 공연 삭제 메서드 순서 변경하여 외래키 제약 에러 수정 (#857)

### DIFF
--- a/backend/src/main/java/com/festago/stage/application/command/StageDeleteService.java
+++ b/backend/src/main/java/com/festago/stage/application/command/StageDeleteService.java
@@ -19,8 +19,8 @@ public class StageDeleteService {
 
     public void deleteStage(Long stageId) {
         stageRepository.findByIdWithFetch(stageId).ifPresent(stage -> {
-            stageRepository.deleteById(stageId);
             stageArtistRepository.deleteByStageId(stageId);
+            stageRepository.deleteById(stageId);
             eventPublisher.publishEvent(new StageDeletedEvent(stage));
         });
     }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #857 

## ✨ PR 세부 내용

이슈 내용과 같이 공연을 삭제할 때 발생하는 외래키 제약 조건으로 발생하는 에러를 수정했습니다.

큰 변경은 없으나, 외래키 제약으로 인한 문제가 계속 발생하면 외래키 제약을 없애는 것도 좋을 것 같네요.