### PR TITLE
[BE] fix: ArtistBookmarkInfoV1Response에 아티스트 식별자 추가 (#869)

### DIFF
--- a/backend/src/main/java/com/festago/bookmark/application/ArtistBookmarkV1QueryService.java
+++ b/backend/src/main/java/com/festago/bookmark/application/ArtistBookmarkV1QueryService.java
@@ -14,7 +14,7 @@ public class ArtistBookmarkV1QueryService {
 
     private final ArtistBookmarkV1QueryDslRepository artistBookmarkV1QueryDslRepository;
 
-    public List<ArtistBookmarkV1Response> findArtistBookmarksByMemberId(Long memberid){
-        return artistBookmarkV1QueryDslRepository.findByMemberId(memberid);
+    public List<ArtistBookmarkV1Response> findArtistBookmarksByMemberId(Long memberId){
+        return artistBookmarkV1QueryDslRepository.findByMemberId(memberId);
     }
 }

--- a/backend/src/main/java/com/festago/bookmark/dto/v1/ArtistBookmarkInfoV1Response.java
+++ b/backend/src/main/java/com/festago/bookmark/dto/v1/ArtistBookmarkInfoV1Response.java
@@ -3,6 +3,7 @@ package com.festago.bookmark.dto.v1;
 import com.querydsl.core.annotations.QueryProjection;
 
 public record ArtistBookmarkInfoV1Response(
+    Long id,
     String name,
     String profileImageUrl
 ) {

--- a/backend/src/main/java/com/festago/bookmark/repository/v1/ArtistBookmarkV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/bookmark/repository/v1/ArtistBookmarkV1QueryDslRepository.java
@@ -23,6 +23,7 @@ public class ArtistBookmarkV1QueryDslRepository extends QueryDslRepositorySuppor
         return select(
             new QArtistBookmarkV1Response(
                 new QArtistBookmarkInfoV1Response(
+                    artist.id,
                     artist.name,
                     artist.profileImage
                 ),


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #869

## ✨ PR 세부 내용

`ArtistBookmarkInfoV1Response`에 누락된 아티스트 식별자를 추가했습니다.

수정되어야 클라이언트에서 북마크 기능을 구현 가능하기 때문에 바로 머지하도록 하겠습니다!
