### PR TITLE
[BE] Spring Actuator, Prometheus 의존성 추가 (#873)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.springframework.boot:spring-boot-starter-mail")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${swaggerVersion}")
 
     // Spring Security
@@ -79,6 +80,9 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok")
     testCompileOnly("org.projectlombok:lombok")
     testAnnotationProcessor("org.projectlombok:lombok")
+
+    // Micrometer
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 }
 
 tasks.test {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #873

## ✨ PR 세부 내용

Spring Actuator, Prometheus 의존성을 추가했습니다.

세부 설정은 `application.yml`에 정의해야 하므로, 의존성 추가 외에 작업은 없습니다.

Actuator로 열린 엔드포인트는 서브모듈 참고하시면 될 것 같습니다!