### PR TITLE
[AN/USER] feat: 애니메이션 수정 축제 로딩 개선(#876)

### DIFF
--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/FestivalListFragment.kt
@@ -83,8 +83,8 @@ class FestivalListFragment : Fragment() {
             binding.srlFestivalList.isRefreshing = false
         }
         binding.srlFestivalList.setDistanceToTriggerSync(400)
-        binding.ivSearch.setOnClickListener { // 임시 연결
-            showSchoolDetail()
+        binding.ivSearch.setOnClickListener {
+            showSearch()
         }
         binding.ivAlarm.setOnClickListener {
             showNotificationList()
@@ -206,7 +206,7 @@ class FestivalListFragment : Fragment() {
         },
     )
 
-    private fun showSchoolDetail() {
+    private fun showSearch() {
         findNavController().navigate(actionFestivalListFragmentToSearchFragment())
     }
 

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/festival/FestivalListMoreItemViewHolder.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/festival/FestivalListMoreItemViewHolder.kt
@@ -9,6 +9,7 @@ class FestivalListMoreItemViewHolder(val binding: ItemFestivalListMoreItemBindin
     FestivalListViewHolder(binding) {
 
     fun bind(festivalMoreItemUiState: FestivalMoreItemUiState) {
+        festivalMoreItemUiState.requestMoreItem()
     }
 
     companion object {

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/uistate/FestivalMoreItemUiState.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/uistate/FestivalMoreItemUiState.kt
@@ -1,3 +1,3 @@
 package com.festago.festago.presentation.ui.home.festivallist.uistate
 
-object FestivalMoreItemUiState
+class FestivalMoreItemUiState(val requestMoreItem: () -> Unit)

--- a/android/festago/presentation/src/main/res/anim/fade_in.xml
+++ b/android/festago/presentation/src/main/res/anim/fade_in.xml
@@ -1,0 +1,6 @@
+<!-- res/anim/fade_in.xml -->
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_longAnimTime"
+    android:fromAlpha="0"
+    android:interpolator="@android:anim/decelerate_interpolator"
+    android:toAlpha="1" />

--- a/android/festago/presentation/src/main/res/anim/fade_out.xml
+++ b/android/festago/presentation/src/main/res/anim/fade_out.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_longAnimTime"
+    android:fromAlpha="1"
+    android:interpolator="@android:anim/decelerate_interpolator"
+    android:toAlpha="0" />

--- a/android/festago/presentation/src/main/res/anim/no_anim.xml
+++ b/android/festago/presentation/src/main/res/anim/no_anim.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_longAnimTime"
+    android:fromAlpha="1"
+    android:interpolator="@android:anim/decelerate_interpolator"
+    android:toAlpha="1" />

--- a/android/festago/presentation/src/main/res/anim/slide_in.xml
+++ b/android/festago/presentation/src/main/res/anim/slide_in.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:anim/decelerate_interpolator">
+    <alpha
+        android:duration="@android:integer/config_longAnimTime"
+        android:fromAlpha="0"
+        android:toAlpha="1" />
+    <translate
+        android:duration="@android:integer/config_longAnimTime"
+        android:fromXDelta="100%"
+        android:toXDelta="0%" />
+</set>

--- a/android/festago/presentation/src/main/res/anim/slide_out.xml
+++ b/android/festago/presentation/src/main/res/anim/slide_out.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:anim/decelerate_interpolator">
+    <alpha
+        android:duration="@android:integer/config_longAnimTime"
+        android:fromAlpha="1"
+        android:toAlpha="0" />
+    <translate
+        android:duration="@android:integer/config_longAnimTime"
+        android:fromXDelta="0%"
+        android:toXDelta="100%" />
+</set>

--- a/android/festago/presentation/src/main/res/layout/fragment_search.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_search.xml
@@ -81,6 +81,7 @@
             app:tabIndicatorColor="@color/contents_gray_07"
             app:tabIndicatorFullWidth="false"
             app:tabIndicatorHeight="2dp"
+            app:tabRippleColor="@color/contents_gray_04"
             app:tabSelectedTextColor="@color/contents_gray_07"
             app:tabTextAppearance="@style/H4Bold16Lh20"
             app:tabTextColor="@color/contents_gray_05" />

--- a/android/festago/presentation/src/main/res/layout/item_artist_detail_festival.xml
+++ b/android/festago/presentation/src/main/res/layout/item_artist_detail_festival.xml
@@ -79,8 +79,8 @@
             android:maxLines="1"
             android:text="@{item.name}"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/ivFestivalImage"
-            app:layout_constraintTop_toTopOf="@+id/ivFestivalImage"
+            app:layout_constraintStart_toEndOf="@id/ivFestivalImage"
+            app:layout_constraintTop_toTopOf="@id/ivFestivalImage"
             tools:text="중앙대학교 청진난만 중앙대학교 천진난만" />
 
         <TextView
@@ -89,8 +89,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@{@string/festival_list_tv_date_range_format(item.startDate.format(DateTimeFormatter.ofPattern(@string/festival_list_tv_date_format)),item.endDate.format(DateTimeFormatter.ofPattern(@string/festival_list_tv_date_format)))}"
-            app:layout_constraintStart_toStartOf="@+id/tvFestivalName"
-            app:layout_constraintTop_toBottomOf="@+id/tvFestivalName"
+            app:layout_constraintStart_toStartOf="@id/tvFestivalName"
+            app:layout_constraintTop_toBottomOf="@id/tvFestivalName"
             tools:text="21.10.10 ~ 21.10.12" />
 
         <androidx.recyclerview.widget.RecyclerView

--- a/android/festago/presentation/src/main/res/layout/item_festival_list_popular.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_list_popular.xml
@@ -101,7 +101,8 @@
             app:tabGravity="center"
             app:tabIndicatorHeight="0dp"
             app:tabPaddingEnd="8dp"
-            app:tabPaddingStart="8dp" />
+            app:tabPaddingStart="8dp"
+            app:tabRippleColor="@null" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/festago/presentation/src/main/res/layout/item_festival_list_tab.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_list_tab.xml
@@ -26,6 +26,7 @@
             app:tabIndicatorColor="@color/contents_gray_07"
             app:tabIndicatorFullWidth="false"
             app:tabIndicatorHeight="2dp"
+            app:tabRippleColor="@color/contents_gray_04"
             app:tabSelectedTextColor="@color/contents_gray_07"
             app:tabTextAppearance="@style/H1Bold20Lh20"
             app:tabTextColor="@color/contents_gray_04">

--- a/android/festago/presentation/src/main/res/navigation/festival_list.xml
+++ b/android/festago/presentation/src/main/res/navigation/festival_list.xml
@@ -13,23 +13,31 @@
         <action
             android:id="@+id/action_festivalListFragment_to_schoolDetailFragment"
             app:destination="@id/schoolDetailFragment"
-            app:enterAnim="@android:anim/slide_in_left"
-            app:popExitAnim="@android:anim/slide_out_right" />
+            app:enterAnim="@anim/slide_in"
+            app:exitAnim="@anim/no_anim"
+            app:popEnterAnim="@anim/no_anim"
+            app:popExitAnim="@anim/slide_out" />
         <action
             android:id="@+id/action_festivalListFragment_to_artistDetailFragment"
             app:destination="@id/artistDetailFragment"
-            app:enterAnim="@android:anim/slide_in_left"
-            app:popExitAnim="@android:anim/slide_out_right" />
+            app:enterAnim="@anim/slide_in"
+            app:exitAnim="@anim/no_anim"
+            app:popEnterAnim="@anim/no_anim"
+            app:popExitAnim="@anim/slide_out" />
         <action
             android:id="@+id/action_festivalListFragment_to_festivalDetailFragment"
             app:destination="@id/festivalDetailFragment"
-            app:enterAnim="@android:anim/slide_in_left"
-            app:popExitAnim="@android:anim/slide_out_right" />
+            app:enterAnim="@anim/slide_in"
+            app:exitAnim="@anim/no_anim"
+            app:popEnterAnim="@anim/no_anim"
+            app:popExitAnim="@anim/slide_out" />
         <action
             android:id="@+id/action_festivalListFragment_to_searchFragment"
             app:destination="@id/searchFragment"
-            app:enterAnim="@android:anim/slide_in_left"
-            app:popExitAnim="@android:anim/slide_out_right" />
+            app:enterAnim="@anim/fade_in"
+            app:exitAnim="@anim/fade_out"
+            app:popEnterAnim="@anim/fade_in"
+            app:popExitAnim="@anim/fade_out" />
     </fragment>
     <fragment
         android:id="@+id/artistDetailFragment"
@@ -42,20 +50,24 @@
         <action
             android:id="@+id/action_artistDetailFragment_to_schoolDetailFragment"
             app:destination="@id/schoolDetailFragment"
-            app:enterAnim="@android:anim/slide_in_left"
-            app:popExitAnim="@android:anim/slide_out_right" />
+            app:enterAnim="@anim/slide_in"
+            app:exitAnim="@anim/no_anim"
+            app:popEnterAnim="@anim/no_anim"
+            app:popExitAnim="@anim/slide_out" />
         <action
             android:id="@+id/action_artistDetailFragment_self"
             app:destination="@id/artistDetailFragment"
-            app:enterAnim="@android:anim/slide_in_left"
-            app:popExitAnim="@android:anim/slide_out_right"
-            app:popUpToSaveState="true"
-            app:restoreState="true" />
+            app:enterAnim="@anim/slide_in"
+            app:exitAnim="@anim/no_anim"
+            app:popEnterAnim="@anim/no_anim"
+            app:popExitAnim="@anim/slide_out" />
         <action
             android:id="@+id/action_artistDetailFragment_to_festivalDetailFragment"
             app:destination="@id/festivalDetailFragment"
-            app:enterAnim="@android:anim/slide_in_left"
-            app:popExitAnim="@android:anim/slide_out_right" />
+            app:enterAnim="@anim/slide_in"
+            app:exitAnim="@anim/no_anim"
+            app:popEnterAnim="@anim/no_anim"
+            app:popExitAnim="@anim/slide_out" />
     </fragment>
     <fragment
         android:id="@+id/schoolDetailFragment"
@@ -65,16 +77,20 @@
         <action
             android:id="@+id/action_schoolDetailFragment_to_artistDetailFragment"
             app:destination="@id/artistDetailFragment"
-            app:enterAnim="@android:anim/slide_in_left"
-            app:popExitAnim="@android:anim/slide_out_right" />
+            app:enterAnim="@anim/slide_in"
+            app:exitAnim="@anim/no_anim"
+            app:popEnterAnim="@anim/no_anim"
+            app:popExitAnim="@anim/slide_out" />
         <argument
             android:name="schoolId"
             app:argType="long" />
         <action
             android:id="@+id/action_schoolDetailFragment_to_festivalDetailFragment"
             app:destination="@id/festivalDetailFragment"
-            app:enterAnim="@android:anim/slide_in_left"
-            app:popExitAnim="@android:anim/slide_out_right" />
+            app:enterAnim="@anim/slide_in"
+            app:exitAnim="@anim/no_anim"
+            app:popEnterAnim="@anim/no_anim"
+            app:popExitAnim="@anim/slide_out" />
 
     </fragment>
     <fragment
@@ -88,8 +104,10 @@
         <action
             android:id="@+id/action_festivalDetailFragment_to_artistDetailFragment"
             app:destination="@id/artistDetailFragment"
-            app:enterAnim="@android:anim/slide_in_left"
-            app:popExitAnim="@android:anim/slide_out_right" />
+            app:enterAnim="@anim/slide_in"
+            app:exitAnim="@anim/no_anim"
+            app:popEnterAnim="@anim/no_anim"
+            app:popExitAnim="@anim/slide_out" />
     </fragment>
     <fragment
         android:id="@+id/searchFragment"
@@ -99,18 +117,24 @@
         <action
             android:id="@+id/action_searchFragment_to_schoolDetailFragment"
             app:destination="@id/schoolDetailFragment"
-            app:enterAnim="@android:anim/slide_in_left"
-            app:popExitAnim="@android:anim/slide_out_right" />
+            app:enterAnim="@anim/slide_in"
+            app:exitAnim="@anim/no_anim"
+            app:popEnterAnim="@anim/no_anim"
+            app:popExitAnim="@anim/slide_out" />
         <action
             android:id="@+id/action_searchFragment_to_artistDetailFragment"
             app:destination="@id/artistDetailFragment"
-            app:enterAnim="@android:anim/slide_in_left"
-            app:popExitAnim="@android:anim/slide_out_right" />
+            app:enterAnim="@anim/slide_in"
+            app:exitAnim="@anim/no_anim"
+            app:popEnterAnim="@anim/no_anim"
+            app:popExitAnim="@anim/slide_out" />
         <action
             android:id="@+id/action_searchFragment_to_festivalDetailFragment"
             app:destination="@id/festivalDetailFragment"
-            app:enterAnim="@android:anim/slide_in_left"
-            app:popExitAnim="@android:anim/slide_out_right" />
+            app:enterAnim="@anim/slide_in"
+            app:exitAnim="@anim/no_anim"
+            app:popEnterAnim="@anim/no_anim"
+            app:popExitAnim="@anim/slide_out" />
     </fragment>
 
 </navigation>


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #876 

## ✨ PR 세부 내용

## 커스텀 애니메이션 적용

- slide_in : 오른쪽에서 왼쪽으로 슬라이드로 등장하면서 서서히 나타난다
- slide_out : 왼쪽에서 오른쪽으로 슬라이드 되면서 서서히 사라진다.
- no_anim : 그대로 유지한다. (설정을 안해주니깐 빈 화면이 되어버려서 추가했습니다.)
- fade_in : 서서히 나타난다.
- fade_out: 서서히 사라진다.

상세화면으로 들어가는 것들은 모두 slide 를 사용했습니다.
검색 화면은 fade 로 들어갑니다.

## 페이징 방식 변경
1. 기존 방식
  스크롤 이벤트가 발생했을 때 리사이클러뷰 바닥에 도달하면 요청
  바닥에 도달해야지만 재요청하기 때문에 문제 발생
2. FestivalMoreItemUiState (Progress Bar View) 의 바인드 이용
  바인드되는 시점에 람다 함수를 실행. 바인드는 실제로 보이기 이전에 발생하기 때문에 보다 자연스러운 스크롤이 가능.
  물론 겁나 빨리 스크롤하면 끊김.

