### PR TITLE
[BE] fix: 학교의 축제 목록을 조회할 때 last 여부가 반대로 반환되는 버그를 수정 (#883)

### DIFF
--- a/backend/src/main/java/com/festago/school/repository/v1/SchoolV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/school/repository/v1/SchoolV1QueryDslRepository.java
@@ -124,12 +124,12 @@ public class SchoolV1QueryDslRepository extends QueryDslRepositorySupport {
         Pageable pageable,
         List<SchoolFestivalV1Response> content
     ) {
-        boolean hasNext = true;
+        boolean hasNext = false;
         if (content.size() > pageable.getPageSize()) {
             content.remove(content.size() - 1);
-            hasNext = false;
+            hasNext = true;
         }
 
-        return new SliceImpl(content, pageable, hasNext);
+        return new SliceImpl<>(content, pageable, hasNext);
     }
 }

--- a/backend/src/test/java/com/festago/school/application/integration/SchoolV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/school/application/integration/SchoolV1QueryServiceIntegrationTest.java
@@ -256,11 +256,11 @@ class SchoolV1QueryServiceIntegrationTest extends ApplicationIntegrationTest {
                 searchCondition);
 
             // then
-            assertThat(actual.hasNext()).isFalse();
+            assertThat(actual.hasNext()).isTrue();
         }
 
         @Test
-        void 다음_페이지가_존재하지않는다() {
+        void 다음_페이지가_존재하지_않는다() {
             // given
             saveFestival(today, today.plusDays(1));
             var searchCondition = new SchoolFestivalV1SearchCondition(null, null, false, Pageable.ofSize(1));
@@ -270,7 +270,7 @@ class SchoolV1QueryServiceIntegrationTest extends ApplicationIntegrationTest {
                 school.getId(), today, searchCondition);
 
             // then
-            assertThat(actual.hasNext()).isTrue();
+            assertThat(actual.hasNext()).isFalse();
         }
 
         private Festival saveFestival(LocalDate startDate, LocalDate endDate) {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #883

## ✨ PR 세부 내용

학교의 축제 목록을 조회할 때, `last` 여부가 반대로 발생하는 버그를 수정했습니다.

원인은 `SchoolV1QueryDslRepository`에서 `createResponse()` 메서드의 `hasNext` 변수를 세팅하는 로직이 반대로 되어 있더군요. 😂

테스트 코드에서 또한 잘못된 assertion으로 인해 검증할 수 없었습니다.

이러한 버그가 발생한 근본적 원인은 `last` 여부를 설정하는 로직이 중복되어 있기 때문이라고 생각합니다.

지금은 단순히 버그를 수정했지만, 근본적인 문제를 수정하려면 last 여부를 판단하는 로직을 공통으로 사용하도록 해야할 것 같네요.

클라이언트에 영향이 가는 문제이기 때문에 바로 머지하겠습니다!