### PR TITLE
[BE] feat: 커서 기반 페이징 처리 시 last 여부를 설정하는 로직을 공통으로 처리 (#885)

### DIFF
--- a/backend/src/main/java/com/festago/common/querydsl/QueryDslHelper.java
+++ b/backend/src/main/java/com/festago/common/querydsl/QueryDslHelper.java
@@ -1,5 +1,6 @@
 package com.festago.common.querydsl;
 
+import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.Expression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -9,6 +10,8 @@ import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Component;
 
@@ -16,10 +19,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class QueryDslHelper {
 
+    private static final int NEXT_PAGE_OFFSET = 1;
     private final JPAQueryFactory queryFactory;
 
     public <T> JPAQuery<T> select(Expression<T> expr) {
         return queryFactory.select(expr);
+    }
+
+    public <T> JPAQuery<T> selectFrom(EntityPath<T> expr) {
+        return queryFactory.selectFrom(expr);
     }
 
     public <T> Optional<T> fetchOne(Function<JPAQueryFactory, JPAQuery<T>> queryFunction) {
@@ -35,5 +43,23 @@ public class QueryDslHelper {
         List<T> content = contentQueryFunction.apply(queryFactory).fetch();
         JPAQuery<Long> countQuery = countQueryFunction.apply(queryFactory);
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    public <T> Slice<T> applySlice(
+        Pageable pageable,
+        Function<JPAQueryFactory, JPAQuery<T>> contentQueryFunction
+    ) {
+        List<T> content = contentQueryFunction.apply(queryFactory)
+            .limit(pageable.getPageSize() + (long) NEXT_PAGE_OFFSET)
+            .fetch();
+        if (content.size() > pageable.getPageSize()) {
+            removeTemporaryContent(content);
+            return new SliceImpl<>(content, pageable, true);
+        }
+        return new SliceImpl<>(content, pageable, false);
+    }
+
+    private <T> void removeTemporaryContent(List<T> content) {
+        content.remove(content.size() - NEXT_PAGE_OFFSET);
     }
 }

--- a/backend/src/main/java/com/festago/festival/repository/FestivalSearchCondition.java
+++ b/backend/src/main/java/com/festago/festival/repository/FestivalSearchCondition.java
@@ -9,7 +9,7 @@ public record FestivalSearchCondition(
     SchoolRegion region,
     LocalDate lastStartDate,
     Long lastFestivalId,
-    Pageable page,
+    Pageable pageable,
     LocalDate currentTime
 ) {
 

--- a/backend/src/main/java/com/festago/festival/repository/FestivalV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/festival/repository/FestivalV1QueryDslRepository.java
@@ -4,7 +4,8 @@ import static com.festago.festival.domain.QFestival.festival;
 import static com.festago.festival.domain.QFestivalQueryInfo.festivalQueryInfo;
 import static com.festago.school.domain.QSchool.school;
 
-import com.festago.common.querydsl.QueryDslHelper;
+import com.festago.common.querydsl.QueryDslRepositorySupport;
+import com.festago.festival.domain.Festival;
 import com.festago.festival.dto.FestivalV1Response;
 import com.festago.festival.dto.QFestivalV1Response;
 import com.festago.festival.dto.QSchoolV1Response;
@@ -12,21 +13,21 @@ import com.festago.school.domain.SchoolRegion;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import java.time.LocalDate;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@RequiredArgsConstructor
-public class FestivalV1QueryDslRepository {
+public class FestivalV1QueryDslRepository extends QueryDslRepositorySupport {
 
-    private final QueryDslHelper queryDslHelper;
+    public FestivalV1QueryDslRepository() {
+        super(Festival.class);
+    }
 
     public Slice<FestivalV1Response> findBy(FestivalSearchCondition searchCondition) {
         FestivalFilter filter = searchCondition.filter();
         Pageable pageable = searchCondition.pageable();
-        return queryDslHelper.applySlice(
+        return applySlice(
             pageable,
             query -> query.select(new QFestivalV1Response(
                     festival.id,

--- a/backend/src/main/java/com/festago/festival/repository/FestivalV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/festival/repository/FestivalV1QueryDslRepository.java
@@ -4,59 +4,49 @@ import static com.festago.festival.domain.QFestival.festival;
 import static com.festago.festival.domain.QFestivalQueryInfo.festivalQueryInfo;
 import static com.festago.school.domain.QSchool.school;
 
-import com.festago.common.querydsl.QueryDslRepositorySupport;
-import com.festago.festival.domain.Festival;
+import com.festago.common.querydsl.QueryDslHelper;
 import com.festago.festival.dto.FestivalV1Response;
 import com.festago.festival.dto.QFestivalV1Response;
 import com.festago.festival.dto.QSchoolV1Response;
 import com.festago.school.domain.SchoolRegion;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQuery;
 import java.time.LocalDate;
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class FestivalV1QueryDslRepository extends QueryDslRepositorySupport {
+@RequiredArgsConstructor
+public class FestivalV1QueryDslRepository {
 
-    private static final long NEXT_PAGE_TEMPORARY_COUNT = 1;
-
-    public FestivalV1QueryDslRepository() {
-        super(Festival.class);
-    }
+    private final QueryDslHelper queryDslHelper;
 
     public Slice<FestivalV1Response> findBy(FestivalSearchCondition searchCondition) {
         FestivalFilter filter = searchCondition.filter();
-        Pageable page = searchCondition.page();
-        List<FestivalV1Response> content = getSelectQuery()
-            .where(dynamicWhere(filter, searchCondition.currentTime(), searchCondition.lastFestivalId(),
-                searchCondition.lastStartDate(), searchCondition.region()))
-            .orderBy(dynamicOrderBy(filter))
-            .limit(page.getPageSize() + NEXT_PAGE_TEMPORARY_COUNT)
-            .fetch();
-        return getResponse(content, page);
-    }
-
-    private JPAQuery<FestivalV1Response> getSelectQuery() {
-        return select(new QFestivalV1Response(
-            festival.id,
-            festival.name,
-            festival.festivalDuration.startDate,
-            festival.festivalDuration.endDate,
-            festival.posterImageUrl,
-            new QSchoolV1Response(
-                school.id,
-                school.name
-            ),
-            festivalQueryInfo.artistInfo)
-        )
-            .from(festival)
-            .innerJoin(school).on(school.id.eq(festival.school.id))
-            .innerJoin(festivalQueryInfo).on(festivalQueryInfo.festivalId.eq(festival.id));
+        Pageable pageable = searchCondition.pageable();
+        return queryDslHelper.applySlice(
+            pageable,
+            query -> query.select(new QFestivalV1Response(
+                    festival.id,
+                    festival.name,
+                    festival.festivalDuration.startDate,
+                    festival.festivalDuration.endDate,
+                    festival.posterImageUrl,
+                    new QSchoolV1Response(
+                        school.id,
+                        school.name
+                    ),
+                    festivalQueryInfo.artistInfo
+                ))
+                .from(festival)
+                .innerJoin(school).on(school.id.eq(festival.school.id))
+                .innerJoin(festivalQueryInfo).on(festivalQueryInfo.festivalId.eq(festival.id))
+                .where(dynamicWhere(filter, searchCondition.currentTime(), searchCondition.lastFestivalId(),
+                    searchCondition.lastStartDate(), searchCondition.region()))
+                .orderBy(dynamicOrderBy(filter))
+        );
     }
 
     private BooleanExpression dynamicWhere(
@@ -134,21 +124,5 @@ public class FestivalV1QueryDslRepository extends QueryDslRepositorySupport {
             case PROGRESS -> new OrderSpecifier[]{festival.festivalDuration.startDate.desc(), festival.id.asc()};
             case END -> new OrderSpecifier[]{festival.festivalDuration.endDate.desc()};
         };
-    }
-
-    private Slice<FestivalV1Response> getResponse(List<FestivalV1Response> content, Pageable page) {
-        if (hasContentNextPage(content, page)) {
-            removeTemporaryContent(content);
-            return new SliceImpl<>(content, page, true);
-        }
-        return new SliceImpl<>(content, page, false);
-    }
-
-    private boolean hasContentNextPage(List<FestivalV1Response> content, Pageable page) {
-        return content.size() > page.getPageSize();
-    }
-
-    private void removeTemporaryContent(List<FestivalV1Response> content) {
-        content.remove(content.size() - 1);
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #885

## ✨ PR 세부 내용

기존 중복으로 처리되던 커서 기반 페이징 로직을 공통으로 처리하도록 했습니다.

문제는 QueryDSL을 편하게 사용하기 위해 만든 Support 클래스가 2개 있다는 점인데, 둘 중 하나를 선택해야 할 것 같습니다.

`QueryDslRepositorySupport`는 상속을 해야 사용 가능하며, 부모 생성자를 호출하고 `Class<T>` 타입의 변수를 넣어줘야 합니다.

`QueryDslHelper`는 빈으로 주입 받으며, 딱히 뭘 하지 않아도 됩니다.

이것만 보면, 상속보다 조합을 사용하고, 굳이 번거로운 일을 하지 않아도 되는 `QueryDslHelper`를 사용하는게 좋아 보이지만, `QueryDslRepositorySupport`은 나름대로 장점이 있습니다.

바로 `QueryDslRepositorySupport`의 `applyPagination` 메서드는 `Pageable`의 `Sort` 객체에 따라 자동으로 정렬이 가능하도록 해줍니다.
(해당 내용은 #749 PR 참조하시면 될 것 같습니다.)

우선 비교를 위해 각 클래스를 사용한 버전을 만들어 뒀습니다.

보시고 어떤게 좋아보이는지 리뷰 남겨주시면 해당 클래스를 사용한 버전으로 리팩터링 하면 될 것 같네요!
