### PR TITLE
feat: jjwtVersion 0.12.5 업그레이드 (#905)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -25,7 +25,7 @@ configurations.all {
 
 val swaggerVersion = "2.0.2"
 val restAssuredVersion = "5.3.0"
-val jjwtVersion = "0.11.5"
+val jjwtVersion = "0.12.5"
 val logbackSlackAppenderVersion = "1.4.0"
 val cucumberVersion = "7.13.0"
 val firebaseVersion = "8.1.0"

--- a/backend/src/main/java/com/festago/auth/infrastructure/JwtAuthTokenExtractor.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/JwtAuthTokenExtractor.java
@@ -29,9 +29,9 @@ public class JwtAuthTokenExtractor implements AuthTokenExtractor {
 
     public JwtAuthTokenExtractor(String secretKey, Clock clock) {
         SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
-        this.jwtParser = Jwts.parserBuilder()
-            .setClock(() -> Date.from(clock.instant()))
-            .setSigningKey(key)
+        this.jwtParser = Jwts.parser()
+            .clock(() -> Date.from(clock.instant()))
+            .verifyWith(key)
             .build();
     }
 
@@ -45,8 +45,8 @@ public class JwtAuthTokenExtractor implements AuthTokenExtractor {
 
     private Claims getClaims(String code) {
         try {
-            return jwtParser.parseClaimsJws(code)
-                .getBody();
+            return jwtParser.parseSignedClaims(code)
+                .getPayload();
         } catch (ExpiredJwtException e) {
             throw new UnauthorizedException(ErrorCode.EXPIRED_AUTH_TOKEN);
         } catch (SignatureException | IllegalArgumentException | MalformedJwtException | UnsupportedJwtException e) {

--- a/backend/src/main/java/com/festago/auth/infrastructure/JwtAuthTokenProvider.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/JwtAuthTokenProvider.java
@@ -4,7 +4,6 @@ import com.festago.auth.application.AuthTokenProvider;
 import com.festago.auth.domain.AuthPayload;
 import com.festago.auth.dto.v1.TokenResponse;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
@@ -36,9 +35,9 @@ public class JwtAuthTokenProvider implements AuthTokenProvider {
         String accessToken = Jwts.builder()
             .claim(MEMBER_ID_KEY, authPayload.getMemberId())
             .claim(ROLE_ID_KEY, authPayload.getRole())
-            .setIssuedAt(Date.from(now))
-            .setExpiration(Date.from(expiredAt))
-            .signWith(key, SignatureAlgorithm.HS256)
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(expiredAt))
+            .signWith(key)
             .compact();
         return new TokenResponse(accessToken, LocalDateTime.ofInstant(expiredAt, clock.getZone()));
     }

--- a/backend/src/main/java/com/festago/entry/infrastructure/JwtEntryCodeExtractor.java
+++ b/backend/src/main/java/com/festago/entry/infrastructure/JwtEntryCodeExtractor.java
@@ -27,8 +27,8 @@ public class JwtEntryCodeExtractor implements EntryCodeExtractor {
 
     public JwtEntryCodeExtractor(String secretKey) {
         SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
-        this.jwtParser = Jwts.parserBuilder()
-            .setSigningKey(key)
+        this.jwtParser = Jwts.parser()
+            .verifyWith(key)
             .build();
     }
 
@@ -43,8 +43,8 @@ public class JwtEntryCodeExtractor implements EntryCodeExtractor {
 
     private Claims getClaims(String code) {
         try {
-            return jwtParser.parseClaimsJws(code)
-                .getBody();
+            return jwtParser.parseSignedClaims(code)
+                .getPayload();
         } catch (ExpiredJwtException e) {
             throw new BadRequestException(ErrorCode.EXPIRED_ENTRY_CODE);
         } catch (SignatureException | IllegalArgumentException | MalformedJwtException | UnsupportedJwtException e) {

--- a/backend/src/main/java/com/festago/entry/infrastructure/JwtEntryCodeProvider.java
+++ b/backend/src/main/java/com/festago/entry/infrastructure/JwtEntryCodeProvider.java
@@ -4,7 +4,6 @@ import com.festago.common.exception.UnexpectedException;
 import com.festago.entry.application.EntryCodeProvider;
 import com.festago.entry.domain.EntryCodePayload;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -28,8 +27,8 @@ public class JwtEntryCodeProvider implements EntryCodeProvider {
         return Jwts.builder()
             .claim(MEMBER_TICKET_ID_KEY, entryCodePayload.getMemberTicketId())
             .claim(ENTRY_STATE_KEY, entryCodePayload.getEntryState().getIndex())
-            .setExpiration(expiredAt)
-            .signWith(key, SignatureAlgorithm.HS256)
+            .expiration(expiredAt)
+            .signWith(key)
             .compact();
     }
 

--- a/backend/src/test/java/com/festago/auth/infrastructure/JwtAuthTokenExtractorTest.java
+++ b/backend/src/test/java/com/festago/auth/infrastructure/JwtAuthTokenExtractorTest.java
@@ -9,7 +9,6 @@ import com.festago.auth.domain.Role;
 import com.festago.common.exception.UnauthorizedException;
 import com.festago.common.exception.UnexpectedException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -47,8 +46,8 @@ class JwtAuthTokenExtractorTest {
         //given
         String token = Jwts.builder()
             .claim(MEMBER_ID_KEY, 1L)
-            .setExpiration(new Date(new Date().getTime() - 1000))
-            .signWith(KEY, SignatureAlgorithm.HS256)
+            .expiration(new Date(new Date().getTime() - 1000))
+            .signWith(KEY)
             .compact();
 
         // when & then
@@ -64,8 +63,8 @@ class JwtAuthTokenExtractorTest {
 
         String token = Jwts.builder()
             .claim(MEMBER_ID_KEY, 1L)
-            .setExpiration(new Date(new Date().getTime() + 10000))
-            .signWith(otherKey, SignatureAlgorithm.HS256)
+            .expiration(new Date(new Date().getTime() + 10000))
+            .signWith(otherKey)
             .compact();
 
         // when & then
@@ -79,8 +78,8 @@ class JwtAuthTokenExtractorTest {
         // given
         String token = Jwts.builder()
             .claim(MEMBER_ID_KEY, 1)
-            .setExpiration(new Date(new Date().getTime() + 10000))
-            .signWith(KEY, SignatureAlgorithm.HS256)
+            .expiration(new Date(new Date().getTime() + 10000))
+            .signWith(KEY)
             .compact();
 
         // when & then
@@ -104,8 +103,8 @@ class JwtAuthTokenExtractorTest {
         String token = Jwts.builder()
             .claim(MEMBER_ID_KEY, memberId)
             .claim(ROLE_ID_KEY, Role.MEMBER)
-            .setExpiration(new Date(new Date().getTime() + 10000))
-            .signWith(KEY, SignatureAlgorithm.HS256)
+            .expiration(new Date(new Date().getTime() + 10000))
+            .signWith(KEY)
             .compact();
 
         // when

--- a/backend/src/test/java/com/festago/auth/infrastructure/JwtAuthTokenProviderTest.java
+++ b/backend/src/test/java/com/festago/auth/infrastructure/JwtAuthTokenProviderTest.java
@@ -23,7 +23,7 @@ class JwtAuthTokenProviderTest {
     void 토큰_생성_성공() {
         // given
         AuthPayload authPayload = new AuthPayload(1L, Role.MEMBER);
-        JwtParser parser = Jwts.parserBuilder()
+        JwtParser parser = Jwts.parser()
             .setSigningKey(SECRET_KEY.getBytes())
             .build();
 

--- a/backend/src/test/java/com/festago/entry/infrastructure/JwtEntryCodeProviderTest.java
+++ b/backend/src/test/java/com/festago/entry/infrastructure/JwtEntryCodeProviderTest.java
@@ -52,11 +52,11 @@ class JwtEntryCodeProviderTest {
         String code = entryCodeProvider.provide(entryCodePayload, expiredAt);
 
         // then
-        Claims claims = Jwts.parserBuilder()
+        Claims claims = Jwts.parser()
             .setSigningKey(SECRET_KEY.getBytes())
             .build()
-            .parseClaimsJws(code)
-            .getBody();
+            .parseSignedClaims(code)
+            .getPayload();
 
         Long actualMemberTicketId = claims.get("ticketId", Long.class);
         Date actualExpiredAt = claims.getExpiration();


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #905

## ✨ PR 세부 내용

이슈에 작성한 것 처럼 jjwtVersion을 0.11.5에서 0.12.5로 업그레이드 했습니다.

기존 `Jwts.parserBuilder()` 메서드가 deprecate 처리되어 `Jwts.parser()` 사용으로 변경되었고, 다른 메서드 또한 변경되었습니다.

테스트 확인 결과 작동에는 이상 없는 것을 확인했습니다!