### PR TITLE
feat: Mock 축제 데이터 추가하는 관리자 API 추가 (#907)

### DIFF
--- a/backend/src/main/java/com/festago/admin/presentation/v1/AdminMockDataV1Controller.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/AdminMockDataV1Controller.java
@@ -1,0 +1,26 @@
+package com.festago.admin.presentation.v1;
+
+import com.festago.mock.application.MockDataService;
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile({"!prod"})
+@RestController
+@RequestMapping("/admin/api/v1/mock-data")
+@RequiredArgsConstructor
+@Hidden
+public class AdminMockDataV1Controller {
+
+    private final MockDataService mockDataService;
+
+    @PostMapping("/festivals")
+    public ResponseEntity<Void> generateMockFestivals() {
+        mockDataService.makeMockFestivals();
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminMockDataV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminMockDataV1ControllerTest.java
@@ -1,0 +1,73 @@
+package com.festago.admin.presentation.v1;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.auth.domain.Role;
+import com.festago.mock.application.MockDataService;
+import com.festago.support.CustomWebMvcTest;
+import com.festago.support.WithMockAuth;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class AdminMockDataV1ControllerTest {
+
+    private static final Cookie TOKEN_COOKIE = new Cookie("token", "token");
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    MockDataService mockDataService;
+
+    @Nested
+    class Mock_축제_생성 {
+
+        final String uri = "/admin/api/v1/mock-data/festivals";
+
+        @Nested
+        @DisplayName("POST " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri)
+                        .cookie(TOKEN_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #907

## ✨ PR 세부 내용

Mock 축제 데이터를 활성화하는 관리자 API를 추가했습니다.

기능은 단순히 `MockDataService`의 `makeMockFestivals()` 메서드를 호출하는게 끝 입니다.

운영 환경에서 해당 API가 노출되면 의도치 않은 결과가 생길 수 있으므로 Controller에는 `@Profile({"!prod"})` 어노테이션을 추가했습니다.