### PR TITLE
[BE] feat: OpenID Connect 방식의 인증 기능 추가 (#909)

### DIFF
--- a/backend/src/main/java/com/festago/auth/config/AuthConfig.java
+++ b/backend/src/main/java/com/festago/auth/config/AuthConfig.java
@@ -35,7 +35,7 @@ public class AuthConfig {
     }
 
     @Bean
-    public OpenIdClients oAuth2OpenIdClients(List<OpenIdClient> openIdClients) {
+    public OpenIdClients openIdClients(List<OpenIdClient> openIdClients) {
         return OpenIdClients.builder()
             .addAll(openIdClients)
             .build();

--- a/backend/src/main/java/com/festago/auth/config/AuthConfig.java
+++ b/backend/src/main/java/com/festago/auth/config/AuthConfig.java
@@ -4,6 +4,8 @@ import com.festago.auth.application.AuthTokenExtractor;
 import com.festago.auth.application.AuthTokenProvider;
 import com.festago.auth.application.OAuth2Client;
 import com.festago.auth.application.OAuth2Clients;
+import com.festago.auth.domain.OpenIdClient;
+import com.festago.auth.domain.OpenIdClients;
 import com.festago.auth.infrastructure.JwtAuthTokenExtractor;
 import com.festago.auth.infrastructure.JwtAuthTokenProvider;
 import java.time.Clock;
@@ -29,6 +31,13 @@ public class AuthConfig {
     public OAuth2Clients oAuth2Clients(List<OAuth2Client> oAuth2Clients) {
         return OAuth2Clients.builder()
             .addAll(oAuth2Clients)
+            .build();
+    }
+
+    @Bean
+    public OpenIdClients oAuth2OpenIdClients(List<OpenIdClient> openIdClients) {
+        return OpenIdClients.builder()
+            .addAll(openIdClients)
             .build();
     }
 

--- a/backend/src/main/java/com/festago/auth/domain/OpenIdClient.java
+++ b/backend/src/main/java/com/festago/auth/domain/OpenIdClient.java
@@ -1,0 +1,8 @@
+package com.festago.auth.domain;
+
+public interface OpenIdClient {
+
+    UserInfo getUserInfo(String idToken);
+
+    SocialType getSocialType();
+}

--- a/backend/src/main/java/com/festago/auth/domain/OpenIdClients.java
+++ b/backend/src/main/java/com/festago/auth/domain/OpenIdClients.java
@@ -1,0 +1,58 @@
+package com.festago.auth.domain;
+
+import com.festago.common.exception.BadRequestException;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.UnexpectedException;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class OpenIdClients {
+
+    private final Map<SocialType, OpenIdClient> openIdClientMap;
+
+    private OpenIdClients(Map<SocialType, OpenIdClient> openIdClientMap) {
+        this.openIdClientMap = openIdClientMap;
+    }
+
+    public static OpenIdClientsBuilder builder() {
+        return new OpenIdClientsBuilder();
+    }
+
+    public OpenIdClient getClient(SocialType socialType) {
+        return Optional.ofNullable(openIdClientMap.get(socialType))
+            .orElseThrow(() -> new BadRequestException(ErrorCode.OPEN_ID_NOT_SUPPORTED_SOCIAL_TYPE));
+    }
+
+    public static class OpenIdClientsBuilder {
+
+        private final Map<SocialType, OpenIdClient> openIdClientMap = new EnumMap<>(SocialType.class);
+
+        private OpenIdClientsBuilder() {
+        }
+
+        public OpenIdClientsBuilder addAll(List<OpenIdClient> openIdClients) {
+            for (OpenIdClient openIdClient : openIdClients) {
+                add(openIdClient);
+            }
+            return this;
+        }
+
+        public OpenIdClientsBuilder add(OpenIdClient openIdClient) {
+            SocialType socialType = openIdClient.getSocialType();
+            if (openIdClientMap.containsKey(socialType)) {
+                log.error("OpenID 제공자는 중복될 수 없습니다.");
+                throw new UnexpectedException("중복된 OpenID 제공자 입니다.");
+            }
+            openIdClientMap.put(socialType, openIdClient);
+            return this;
+        }
+
+        public OpenIdClients build() {
+            return new OpenIdClients(openIdClientMap);
+        }
+    }
+}

--- a/backend/src/main/java/com/festago/auth/domain/OpenIdNonceValidator.java
+++ b/backend/src/main/java/com/festago/auth/domain/OpenIdNonceValidator.java
@@ -1,0 +1,12 @@
+package com.festago.auth.domain;
+
+import java.util.Date;
+
+/**
+ * nonce을 기록하고, 기록된 nonce의 TTL은 expiredAt 이후로 삭제되게 한다. <br/> nonce 값이 이미 기록된 nonce 값이면 주어지면 사용자의 토큰이 도난 당한 것으로 판단하여 예외를
+ * 던져야한다.<br/>
+ */
+public interface OpenIdNonceValidator {
+
+    void validate(String nonce, Date expiredAt);
+}

--- a/backend/src/main/java/com/festago/auth/domain/OpenIdUserInfoProvider.java
+++ b/backend/src/main/java/com/festago/auth/domain/OpenIdUserInfoProvider.java
@@ -1,0 +1,6 @@
+package com.festago.auth.domain;
+
+public interface OpenIdUserInfoProvider {
+
+    UserInfo provide(String idToken);
+}

--- a/backend/src/main/java/com/festago/auth/domain/UserInfo.java
+++ b/backend/src/main/java/com/festago/auth/domain/UserInfo.java
@@ -1,7 +1,9 @@
 package com.festago.auth.domain;
 
 import com.festago.member.domain.Member;
+import lombok.Builder;
 
+@Builder
 public record UserInfo(
     String socialId,
     SocialType socialType,

--- a/backend/src/main/java/com/festago/auth/dto/KakaoUserInfo.java
+++ b/backend/src/main/java/com/festago/auth/dto/KakaoUserInfo.java
@@ -10,12 +10,12 @@ public record KakaoUserInfo(
 ) {
 
     public UserInfo toUserInfo() {
-        return new UserInfo(
-            id,
-            SocialType.KAKAO,
-            kakaoAccount.profile.nickname,
-            kakaoAccount.profile.thumbnailImageUrl
-        );
+        return UserInfo.builder()
+            .socialId(id)
+            .socialType(SocialType.KAKAO)
+            .nickname(kakaoAccount.profile.nickname)
+            .profileImage(kakaoAccount.profile.thumbnailImageUrl)
+            .build();
     }
 
     public record KakaoAccount(

--- a/backend/src/main/java/com/festago/auth/dto/v1/OpenIdLoginV1Request.java
+++ b/backend/src/main/java/com/festago/auth/dto/v1/OpenIdLoginV1Request.java
@@ -1,0 +1,12 @@
+package com.festago.auth.dto.v1;
+
+import com.festago.auth.domain.SocialType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record OpenIdLoginV1Request(
+    @NotNull SocialType socialType,
+    @NotBlank String idToken
+) {
+
+}

--- a/backend/src/main/java/com/festago/auth/infrastructure/CachedOpenIdKeyProvider.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/CachedOpenIdKeyProvider.java
@@ -1,0 +1,63 @@
+package com.festago.auth.infrastructure;
+
+import com.festago.common.exception.UnexpectedException;
+import io.jsonwebtoken.security.JwkSet;
+import jakarta.annotation.Nullable;
+import java.security.Key;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CachedOpenIdKeyProvider {
+
+    private final Map<String, Key> cache = new HashMap<>();
+    private final ReentrantLock lock = new ReentrantLock();
+
+    /**
+     * OpenId Key를 캐싱하여 반환하는 클래스 <br/> OpenID Id Token 헤더의 kid 값을 key로 가지도록 구현 <br/> Id Token을 검증할 때, 매번 공개키 목록을 조회하면
+     * 요청이 차단될 수 있으므로 캐싱하는 과정이 필요. <br/> 따라서 kid에 대한 Key를 찾을 수 없으면, fallback을 통해 캐시를 업데이트함 <br/> 이때, 동시에 여러 요청이 들어오면 동시성
+     * 문제가 발생할 수 있으므로 ReentrantLock을 사용하여 상호 배제 구현 <br/> 데드락을 방지하기 위해 ReentrantLock.tryLock() 메서드를 사용하였음 <br/> 또한 반드시
+     * fallback에서 Timeout에 대한 예외 발생을 구현 해야함<br/> 존재하지 않는 kid로 계속 요청 시 fallback이 계속 호출되므로 공격 가능성이 있음. <br/>
+     *
+     * @param kid      캐시의 Key로 사용될 OpenId Id Token 헤더의 kid 값
+     * @param fallback 캐시 미스 발생 시 캐시에 Key를 등록할 JwkSet을 반환하는 함수
+     * @return 캐시 Hit의 경우 Key 반환, 캐시 Miss에서 fallback으로 반환된 JwkSet에 Key가 없으면 null 반환
+     */
+    @Nullable
+    public Key provide(String kid, Supplier<JwkSet> fallback) {
+        Key key = cache.get(kid);
+        if (key != null) {
+            return key;
+        }
+        log.info("kid에 대한 OpenId Key를 찾지 못해 Key 목록 조회를 시도합니다. kid={}", kid);
+        try {
+            if (lock.tryLock(5, TimeUnit.SECONDS)) {
+                try {
+                    key = cache.get(kid);
+                    if (key != null) {
+                        return key;
+                    }
+                    JwkSet jwkSet = fallback.get();
+                    jwkSet.forEach(jwk -> cache.put(jwk.getId(), jwk.toKey()));
+                    key = cache.get(kid);
+                    if (key == null) {
+                        log.warn("OpenId kid에 대한 Key를 찾을 수 없습니다. kid={}", kid);
+                    }
+                    return key;
+                } finally {
+                    lock.unlock();
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("스레드가 인터럽트 되었습니다.", e);
+        }
+        throw new UnexpectedException("OpenId Key를 가져오는 중, 락 대기로 인해 Key를 획득하지 못했습니다. kid=" + kid);
+    }
+}

--- a/backend/src/main/java/com/festago/auth/infrastructure/FestagoOpenIdClient.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/FestagoOpenIdClient.java
@@ -1,0 +1,39 @@
+package com.festago.auth.infrastructure;
+
+import com.festago.auth.domain.OpenIdClient;
+import com.festago.auth.domain.SocialType;
+import com.festago.auth.domain.UserInfo;
+import com.festago.common.exception.BadRequestException;
+import com.festago.common.exception.ErrorCode;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("!prod")
+public class FestagoOpenIdClient implements OpenIdClient {
+
+    private static final String PROFILE_IMAGE = "https://placehold.co/150x150";
+
+    private final Map<String, Supplier<UserInfo>> userInfoMap = new HashMap<>();
+
+    public FestagoOpenIdClient() {
+        userInfoMap.put("1", () -> new UserInfo("1", getSocialType(), "member1", PROFILE_IMAGE));
+        userInfoMap.put("2", () -> new UserInfo("2", getSocialType(), "member2", PROFILE_IMAGE));
+        userInfoMap.put("3", () -> new UserInfo("3", getSocialType(), "member3", PROFILE_IMAGE));
+    }
+
+    @Override
+    public UserInfo getUserInfo(String idToken) {
+        return userInfoMap.getOrDefault(idToken, () -> {
+            throw new BadRequestException(ErrorCode.OPEN_ID_INVALID_TOKEN);
+        }).get();
+    }
+
+    @Override
+    public SocialType getSocialType() {
+        return SocialType.FESTAGO;
+    }
+}

--- a/backend/src/main/java/com/festago/auth/infrastructure/KakaoOpenIdClient.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/KakaoOpenIdClient.java
@@ -1,0 +1,24 @@
+package com.festago.auth.infrastructure;
+
+import com.festago.auth.domain.OpenIdClient;
+import com.festago.auth.domain.SocialType;
+import com.festago.auth.domain.UserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOpenIdClient implements OpenIdClient {
+
+    private final KakaoOpenIdUserInfoProvider kakaoIdTokenUserInfoProvider;
+
+    @Override
+    public UserInfo getUserInfo(String idToken) {
+        return kakaoIdTokenUserInfoProvider.provide(idToken);
+    }
+
+    @Override
+    public SocialType getSocialType() {
+        return SocialType.KAKAO;
+    }
+}

--- a/backend/src/main/java/com/festago/auth/infrastructure/KakaoOpenIdJwksClient.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/KakaoOpenIdJwksClient.java
@@ -1,0 +1,45 @@
+package com.festago.auth.infrastructure;
+
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.InternalServerException;
+import io.jsonwebtoken.io.Parser;
+import io.jsonwebtoken.security.JwkSet;
+import io.jsonwebtoken.security.Jwks;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+public class KakaoOpenIdJwksClient {
+
+    private final RestTemplate restTemplate;
+    private final Parser<JwkSet> parser;
+
+    public KakaoOpenIdJwksClient(
+        RestTemplateBuilder restTemplateBuilder
+    ) {
+        this.restTemplate = restTemplateBuilder
+            .errorHandler(new KakaoOpenIdJwksErrorHandler())
+            .setConnectTimeout(Duration.ofSeconds(2))
+            .setReadTimeout(Duration.ofSeconds(3))
+            .build();
+        this.parser = Jwks.setParser()
+            .build();
+    }
+
+    // 너무 많은 요청이 오면 차단될 수 있음
+    public JwkSet requestGetJwks() {
+        try {
+            String jsonKeys = restTemplate.getForObject("https://kauth.kakao.com/.well-known/jwks.json", String.class);
+            log.info("카카오 JWKS 공개키 목록을 조회했습니다.");
+            return parser.parse(jsonKeys);
+        } catch (ResourceAccessException e) {
+            log.warn("카카오 JWKS 서버가 응답하지 않습니다.");
+            throw new InternalServerException(ErrorCode.OPEN_ID_PROVIDER_NOT_RESPONSE);
+        }
+    }
+}

--- a/backend/src/main/java/com/festago/auth/infrastructure/KakaoOpenIdJwksErrorHandler.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/KakaoOpenIdJwksErrorHandler.java
@@ -1,0 +1,24 @@
+package com.festago.auth.infrastructure;
+
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.InternalServerException;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+
+@Slf4j
+public class KakaoOpenIdJwksErrorHandler extends DefaultResponseErrorHandler {
+
+    @Override
+    public void handleError(ClientHttpResponse response) throws IOException {
+        HttpStatusCode statusCode = response.getStatusCode();
+        if (statusCode.isError()) {
+            log.warn("카카오 JWKS 서버에서 {} 상태코드가 반환되었습니다.", statusCode.value());
+            throw new InternalServerException(ErrorCode.OPEN_ID_PROVIDER_NOT_RESPONSE);
+        }
+        log.error("카카오 JWKS 서버에서 알 수 없는 에러가 발생했습니다.");
+        throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/backend/src/main/java/com/festago/auth/infrastructure/KakaoOpenIdPublicKeyLocator.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/KakaoOpenIdPublicKeyLocator.java
@@ -1,0 +1,26 @@
+package com.festago.auth.infrastructure;
+
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.UnauthorizedException;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Locator;
+import java.security.Key;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOpenIdPublicKeyLocator implements Locator<Key> {
+
+    private final KakaoOpenIdJwksClient kakaoOpenIdJwksClient;
+    private final CachedOpenIdKeyProvider cachedOpenIdKeyProvider;
+
+    @Override
+    public Key locate(Header header) {
+        String kid = (String) header.get("kid");
+        if (kid == null) {
+            throw new UnauthorizedException(ErrorCode.OPEN_ID_INVALID_TOKEN);
+        }
+        return cachedOpenIdKeyProvider.provide(kid, kakaoOpenIdJwksClient::requestGetJwks);
+    }
+}

--- a/backend/src/main/java/com/festago/auth/infrastructure/KakaoOpenIdUserInfoProvider.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/KakaoOpenIdUserInfoProvider.java
@@ -1,0 +1,65 @@
+package com.festago.auth.infrastructure;
+
+import com.festago.auth.domain.OpenIdNonceValidator;
+import com.festago.auth.domain.OpenIdUserInfoProvider;
+import com.festago.auth.domain.SocialType;
+import com.festago.auth.domain.UserInfo;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.UnauthorizedException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import java.time.Clock;
+import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class KakaoOpenIdUserInfoProvider implements OpenIdUserInfoProvider {
+
+    private static final String ISSUER = "https://kauth.kakao.com";
+    private final OpenIdNonceValidator openIdNonceValidator;
+    private final JwtParser jwtParser;
+
+    public KakaoOpenIdUserInfoProvider(
+        @Value("${festago.oauth2.kakao.client-id}") String clientId,
+        KakaoOpenIdPublicKeyLocator kakaoOpenIdPublicKeyLocator,
+        OpenIdNonceValidator openIdNonceValidator,
+        Clock clock
+    ) {
+        this.openIdNonceValidator = openIdNonceValidator;
+        this.jwtParser = Jwts.parser()
+            .keyLocator(kakaoOpenIdPublicKeyLocator)
+            .requireIssuer(ISSUER)
+            .requireAudience(clientId)
+            .clock(() -> Date.from(clock.instant()))
+            .build();
+    }
+
+    @Override
+    public UserInfo provide(String idToken) {
+        Claims payload = getPayload(idToken);
+        openIdNonceValidator.validate(payload.get("nonce", String.class), payload.getExpiration());
+        return UserInfo.builder()
+            .socialType(SocialType.KAKAO)
+            .socialId(payload.getSubject())
+            .nickname(payload.get("nickname", String.class))
+            .profileImage(payload.get("picture", String.class))
+            .build();
+    }
+
+    private Claims getPayload(String idToken) {
+        try {
+            return jwtParser.parseSignedClaims(idToken)
+                .getPayload();
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new UnauthorizedException(ErrorCode.OPEN_ID_INVALID_TOKEN);
+        } catch (Exception e) {
+            log.error("JWT 토큰 파싱 중에 문제가 발생했습니다.", e);
+            throw e;
+        }
+    }
+}

--- a/backend/src/main/java/com/festago/auth/infrastructure/NoopOpenIdNonceValidator.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/NoopOpenIdNonceValidator.java
@@ -1,0 +1,17 @@
+package com.festago.auth.infrastructure;
+
+import com.festago.auth.domain.OpenIdNonceValidator;
+import java.util.Date;
+import org.springframework.stereotype.Component;
+
+/**
+ * 2024-04-29 기준 nonce 값 검증 구현에 시간이 소요되므로, nonce 검증을 사용하지 않음.<br/> nonce 검증 기능을 추가하면 해당 클래스 삭제할 것<br/>
+ */
+@Component
+public class NoopOpenIdNonceValidator implements OpenIdNonceValidator {
+
+    @Override
+    public void validate(String nonce, Date expiredAt) {
+        // noop
+    }
+}

--- a/backend/src/main/java/com/festago/auth/presentation/v1/MemberAuthV1Controller.java
+++ b/backend/src/main/java/com/festago/auth/presentation/v1/MemberAuthV1Controller.java
@@ -7,6 +7,7 @@ import com.festago.auth.domain.SocialType;
 import com.festago.auth.dto.v1.LoginV1Response;
 import com.festago.auth.dto.v1.LogoutV1Request;
 import com.festago.auth.dto.v1.OAuth2LoginV1Request;
+import com.festago.auth.dto.v1.OpenIdLoginV1Request;
 import com.festago.auth.dto.v1.RefreshTokenV1Request;
 import com.festago.auth.dto.v1.TokenRefreshV1Response;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -50,6 +51,15 @@ public class MemberAuthV1Controller {
     ) {
         return ResponseEntity.ok()
             .body(memberAuthFacadeService.oAuth2Login(socialType, code));
+    }
+
+    @PostMapping("/login/open-id")
+    @Operation(description = "OpenID Id Token을 받아 로그인/회원가입을 한다.", summary = "OpenID Id Token 로그인")
+    public ResponseEntity<LoginV1Response> openIdLogin(
+        @Valid @RequestBody OpenIdLoginV1Request request
+    ) {
+        return ResponseEntity.ok()
+            .body(memberAuthFacadeService.openIdLogin(request.socialType(), request.idToken()));
     }
 
     @MemberAuth

--- a/backend/src/main/java/com/festago/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/festago/common/exception/ErrorCode.java
@@ -43,6 +43,8 @@ public enum ErrorCode {
     INVALID_KEYWORD("유효하지 않은 키워드 입니다."),
     DUPLICATE_SOCIAL_MEDIA("이미 존재하는 소셜미디어 입니다."),
     OAUTH2_INVALID_CODE("잘못된 OAuth2 Code 입니다."),
+    OPEN_ID_NOT_SUPPORTED_SOCIAL_TYPE("해당 OpenId 제공자는 지원되지 않습니다."),
+    OPEN_ID_INVALID_TOKEN("잘못된 OpenID 토큰입니다."),
 
     // 401
     EXPIRED_AUTH_TOKEN("만료된 로그인 토큰입니다."),
@@ -77,7 +79,8 @@ public enum ErrorCode {
     FOR_TEST_ERROR("테스트용 에러입니다."),
     FAIL_SEND_FCM_MESSAGE("FCM Message 전송에 실패했습니다."),
     TICKET_SEQUENCE_DATA_ERROR("입장 순서 값의 데이터 정합성에 문제가 발생했습니다."),
-    OAUTH2_INVALID_REQUEST("알 수 없는 OAuth2 에러가 발생했습니다.")
+    OAUTH2_INVALID_REQUEST("알 수 없는 OAuth2 에러가 발생했습니다."),
+    OPEN_ID_PROVIDER_NOT_RESPONSE("OpenID 제공자 서버에 문제가 발생했습니다."),
     ;
 
     private final String message;

--- a/backend/src/test/java/com/festago/auth/infrastructure/CachedOpenIdKeyProviderTest.java
+++ b/backend/src/test/java/com/festago/auth/infrastructure/CachedOpenIdKeyProviderTest.java
@@ -1,0 +1,111 @@
+package com.festago.auth.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+
+import io.jsonwebtoken.security.JwkSet;
+import io.jsonwebtoken.security.Jwks;
+import java.security.Key;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class CachedOpenIdKeyProviderTest {
+
+    CachedOpenIdKeyProvider cachedOpenIdKeyProvider;
+
+    String jwksJson = """
+        {
+            "keys": [
+                {
+                    "kid": "1",
+                    "kty": "RSA",
+                    "alg": "RS256",
+                    "use": "sig",
+                    "n": "q8zZ0b_MNaLd6Ny8wd4cjFomilLfFIZcmhNSc1ttx_oQdJJZt5CDHB8WWwPGBUDUyY8AmfglS9Y1qA0_fxxs-ZUWdt45jSbUxghKNYgEwSutfM5sROh3srm5TiLW4YfOvKytGW1r9TQEdLe98ork8-rNRYPybRI3SKoqpci1m1QOcvUg4xEYRvbZIWku24DNMSeheytKUz6Ni4kKOVkzfGN11rUj1IrlRR-LNA9V9ZYmeoywy3k066rD5TaZHor5bM5gIzt1B4FmUuFITpXKGQZS5Hn_Ck8Bgc8kLWGAU8TzmOzLeROosqKE0eZJ4ESLMImTb2XSEZuN1wFyL0VtJw",
+                    "e": "AQAB"
+                }
+            ]
+        }
+        """;
+
+    @BeforeEach
+    void setUp() {
+        cachedOpenIdKeyProvider = new CachedOpenIdKeyProvider();
+    }
+
+    @Test
+    void kid에_대한_JWK_키가_있으면_null이_아니다() {
+        // given
+        JwkSet jwtSet = Jwks.setParser()
+            .build()
+            .parse(jwksJson);
+
+        // when
+        Key actual = cachedOpenIdKeyProvider.provide("1", () -> jwtSet);
+
+        // then
+        assertThat(actual).isNotNull();
+    }
+
+    @Test
+    void kid에_대한_JWK_키가_없으면_null이다() {
+        // given
+        JwkSet jwtSet = Jwks.setParser()
+            .build()
+            .parse(jwksJson);
+
+        // when
+        Key actual = cachedOpenIdKeyProvider.provide("2", () -> jwtSet);
+
+        // then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void kid에_대한_JWK_키가_캐싱되어야_한다() {
+        // given
+        JwkSet jwtSet = Jwks.setParser()
+            .build()
+            .parse(jwksJson);
+        Supplier<JwkSet> jwkSetSupplier = mock(Supplier.class);
+        given(jwkSetSupplier.get())
+            .willReturn(jwtSet);
+        cachedOpenIdKeyProvider.provide("1", jwkSetSupplier);
+
+        // when
+        cachedOpenIdKeyProvider.provide("1", jwkSetSupplier);
+
+        // then
+        verify(jwkSetSupplier, times(1)).get();
+    }
+
+    @Test
+    void 동시에_요청이_와도_캐시에_값을_갱신하는_로직은_한_번만_호출된다() {
+        // given
+        JwkSet jwtSet = Jwks.setParser()
+            .build()
+            .parse(jwksJson);
+        Supplier<JwkSet> jwkSetSupplier = mock(Supplier.class);
+        given(jwkSetSupplier.get())
+            .willReturn(jwtSet);
+
+        // when
+        var futures = IntStream.rangeClosed(1, 10)
+            .mapToObj(i -> CompletableFuture.runAsync(() -> cachedOpenIdKeyProvider.provide("1", jwkSetSupplier)))
+            .toList();
+        futures.forEach(CompletableFuture::join);
+
+        // then
+        verify(jwkSetSupplier, times(1)).get();
+    }
+}

--- a/backend/src/test/java/com/festago/auth/infrastructure/KakaoOpenIdJwksClientTest.java
+++ b/backend/src/test/java/com/festago/auth/infrastructure/KakaoOpenIdJwksClientTest.java
@@ -1,0 +1,101 @@
+package com.festago.auth.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.InternalServerException;
+import io.jsonwebtoken.Identifiable;
+import io.jsonwebtoken.security.JwkSet;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@RestClientTest(KakaoOpenIdJwksClient.class)
+class KakaoOpenIdJwksClientTest {
+
+    private static final String URL = "https://kauth.kakao.com/.well-known/jwks.json";
+
+    @Autowired
+    KakaoOpenIdJwksClient kakaoOpenIdJwksClient;
+
+    @Autowired
+    MockRestServiceServer mockServer;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void 상태코드가_4xx이면_InternalServer_예외() {
+        // given
+        mockServer.expect(requestTo(URL))
+            .andRespond(MockRestResponseCreators.withBadRequest()
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // when & then
+        assertThatThrownBy(() -> kakaoOpenIdJwksClient.requestGetJwks())
+            .isInstanceOf(InternalServerException.class)
+            .hasMessage(ErrorCode.OPEN_ID_PROVIDER_NOT_RESPONSE.getMessage());
+    }
+
+    @Test
+    void 상태코드가_5xx이면_InternalServer_예외() {
+        // given
+        mockServer.expect(requestTo(URL))
+            .andRespond(MockRestResponseCreators.withServerError()
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // when & then
+        assertThatThrownBy(() -> kakaoOpenIdJwksClient.requestGetJwks())
+            .isInstanceOf(InternalServerException.class)
+            .hasMessage(ErrorCode.OPEN_ID_PROVIDER_NOT_RESPONSE.getMessage());
+    }
+
+    @Test
+    void 성공() {
+        // given
+        String jwksJson = """
+            {
+                "keys": [
+                    {
+                        "kid": "3f96980381e451efad0d2ddd30e3d3",
+                        "kty": "RSA",
+                        "alg": "RS256",
+                        "use": "sig",
+                        "n": "q8zZ0b_MNaLd6Ny8wd4cjFomilLfFIZcmhNSc1ttx_oQdJJZt5CDHB8WWwPGBUDUyY8AmfglS9Y1qA0_fxxs-ZUWdt45jSbUxghKNYgEwSutfM5sROh3srm5TiLW4YfOvKytGW1r9TQEdLe98ork8-rNRYPybRI3SKoqpci1m1QOcvUg4xEYRvbZIWku24DNMSeheytKUz6Ni4kKOVkzfGN11rUj1IrlRR-LNA9V9ZYmeoywy3k066rD5TaZHor5bM5gIzt1B4FmUuFITpXKGQZS5Hn_Ck8Bgc8kLWGAU8TzmOzLeROosqKE0eZJ4ESLMImTb2XSEZuN1wFyL0VtJw",
+                        "e": "AQAB"
+                    },
+                    {
+                        "kid": "9f252dadd5f233f93d2fa528d12fea",
+                        "kty": "RSA",
+                        "alg": "RS256",
+                        "use": "sig",
+                        "n": "qGWf6RVzV2pM8YqJ6by5exoixIlTvdXDfYj2v7E6xkoYmesAjp_1IYL7rzhpUYqIkWX0P4wOwAsg-Ud8PcMHggfwUNPOcqgSk1hAIHr63zSlG8xatQb17q9LrWny2HWkUVEU30PxxHsLcuzmfhbRx8kOrNfJEirIuqSyWF_OBHeEgBgYjydd_c8vPo7IiH-pijZn4ZouPsEg7wtdIX3-0ZcXXDbFkaDaqClfqmVCLNBhg3DKYDQOoyWXrpFKUXUFuk2FTCqWaQJ0GniO4p_ppkYIf4zhlwUYfXZEhm8cBo6H2EgukntDbTgnoha8kNunTPekxWTDhE5wGAt6YpT4Yw",
+                        "e": "AQAB"
+                    }
+                ]
+            }
+            """;
+        mockServer.expect(requestTo(URL))
+            .andRespond(MockRestResponseCreators.withSuccess()
+                .body(jwksJson)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // when
+        JwkSet actual = kakaoOpenIdJwksClient.requestGetJwks();
+
+        // then
+        assertThat(actual.getKeys())
+            .map(Identifiable::getId)
+            .containsExactlyInAnyOrder("3f96980381e451efad0d2ddd30e3d3", "9f252dadd5f233f93d2fa528d12fea");
+    }
+}

--- a/backend/src/test/java/com/festago/auth/infrastructure/KakaoOpenIdUserInfoProviderTest.java
+++ b/backend/src/test/java/com/festago/auth/infrastructure/KakaoOpenIdUserInfoProviderTest.java
@@ -1,0 +1,166 @@
+package com.festago.auth.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.spy;
+
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.UnauthorizedException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class KakaoOpenIdUserInfoProviderTest {
+
+    KakaoOpenIdUserInfoProvider kakaoOpenIdUserInfoProvider;
+
+    KakaoOpenIdPublicKeyLocator keyLocator;
+
+    Clock clock;
+
+    Key key = Keys.hmacShaKeyFor("key".repeat(15).getBytes(StandardCharsets.UTF_8));
+
+    @BeforeEach
+    void setUp() {
+        keyLocator = mock();
+        clock = spy(Clock.systemDefaultZone());
+        kakaoOpenIdUserInfoProvider = new KakaoOpenIdUserInfoProvider(
+            "client-id",
+            keyLocator,
+            new NoopOpenIdNonceValidator(),
+            clock
+        );
+    }
+
+    @Test
+    void audience가_올바르지_않으면_예외() {
+        // given
+        given(keyLocator.locate(any()))
+            .willReturn(key);
+        String idToken = Jwts.builder()
+            .audience().add("wrong")
+            .and()
+            .issuer("https://kauth.kakao.com")
+            .signWith(key)
+            .expiration(Date.from(clock.instant().plus(1, ChronoUnit.DAYS)))
+            .compact();
+
+        // when & then
+        assertThatThrownBy(() -> kakaoOpenIdUserInfoProvider.provide(idToken))
+            .isInstanceOf(UnauthorizedException.class)
+            .hasMessage(ErrorCode.OPEN_ID_INVALID_TOKEN.getMessage());
+    }
+
+    @Test
+    void issuer가_올바르지_않으면_예외() {
+        // given
+        given(keyLocator.locate(any()))
+            .willReturn(key);
+        String idToken = Jwts.builder()
+            .audience().add("client-id")
+            .and()
+            .issuer("wrong")
+            .signWith(key)
+            .expiration(Date.from(clock.instant().plus(1, ChronoUnit.DAYS)))
+            .compact();
+
+        // when & then
+        assertThatThrownBy(() -> kakaoOpenIdUserInfoProvider.provide(idToken))
+            .isInstanceOf(UnauthorizedException.class)
+            .hasMessage(ErrorCode.OPEN_ID_INVALID_TOKEN.getMessage());
+    }
+
+    @Test
+    void 토큰이_만료되면_예외() {
+        // given
+        given(keyLocator.locate(any()))
+            .willReturn(key);
+        Date yesterday = Date.from(clock.instant().minus(1, ChronoUnit.DAYS));
+        String idToken = Jwts.builder()
+            .audience().add("client-id")
+            .and()
+            .issuer("https://kauth.kakao.com")
+            .signWith(key)
+            .expiration(yesterday)
+            .compact();
+
+        // when & then
+        assertThatThrownBy(() -> kakaoOpenIdUserInfoProvider.provide(idToken))
+            .isInstanceOf(UnauthorizedException.class)
+            .hasMessage(ErrorCode.OPEN_ID_INVALID_TOKEN.getMessage());
+    }
+
+    @Test
+    void 토큰에_서명된_키가_파싱할때_키와_일치하지_않으면_예외() {
+        // given
+        Key otherKey = Keys.hmacShaKeyFor("otherKey".repeat(10).getBytes(StandardCharsets.UTF_8));
+        given(keyLocator.locate(any()))
+            .willReturn(otherKey);
+        String idToken = Jwts.builder()
+            .audience().add("client-id")
+            .and()
+            .issuer("https://kauth.kakao.com")
+            .signWith(key)
+            .expiration(Date.from(clock.instant().plus(1, ChronoUnit.DAYS)))
+            .compact();
+
+        // when & then
+        assertThatThrownBy(() -> kakaoOpenIdUserInfoProvider.provide(idToken))
+            .isInstanceOf(UnauthorizedException.class)
+            .hasMessage(ErrorCode.OPEN_ID_INVALID_TOKEN.getMessage());
+    }
+
+    @Test
+    void 파싱할때_키가_null이면_예외() {
+        // given
+        given(keyLocator.locate(any()))
+            .willReturn(null);
+        String idToken = Jwts.builder()
+            .audience().add("client-id")
+            .and()
+            .issuer("https://kauth.kakao.com")
+            .signWith(key)
+            .expiration(Date.from(clock.instant().plus(1, ChronoUnit.DAYS)))
+            .compact();
+
+        // when & then
+        assertThatThrownBy(() -> kakaoOpenIdUserInfoProvider.provide(idToken))
+            .isInstanceOf(UnauthorizedException.class)
+            .hasMessage(ErrorCode.OPEN_ID_INVALID_TOKEN.getMessage());
+    }
+
+    @Test
+    void audience_issuer가_올바르면_성공() {
+        // given
+        String socialId = "12345";
+        given(keyLocator.locate(any()))
+            .willReturn(key);
+        String idToken = Jwts.builder()
+            .audience().add("client-id")
+            .and()
+            .issuer("https://kauth.kakao.com")
+            .signWith(key)
+            .subject(socialId)
+            .expiration(Date.from(clock.instant().plus(1, ChronoUnit.DAYS)))
+            .compact();
+
+        // when
+        var expect = kakaoOpenIdUserInfoProvider.provide(idToken);
+
+        // then
+        assertThat(expect.socialId()).isEqualTo(socialId);
+    }
+}

--- a/backend/src/test/java/com/festago/auth/presentation/v1/MemberAuthV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/auth/presentation/v1/MemberAuthV1ControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.festago.auth.domain.SocialType;
 import com.festago.auth.dto.v1.OAuth2LoginV1Request;
+import com.festago.auth.dto.v1.OpenIdLoginV1Request;
 import com.festago.auth.dto.v1.RefreshTokenV1Request;
 import com.festago.support.CustomWebMvcTest;
 import com.festago.support.WithMockAuth;
@@ -73,6 +74,29 @@ class MemberAuthV1ControllerTest {
                 // when & then
                 mockMvc.perform(get(uri, "festago")
                         .queryParam("code", code)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+        }
+    }
+
+    @Nested
+    class OpenId_회원_로그인 {
+
+        final String uri = "/api/v1/auth/login/open-id";
+
+        @Nested
+        @DisplayName("POST " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            void 요청을_보내면_200_응답과_로그인_응답이_반환된다() throws Exception {
+                // given
+                var request = new OpenIdLoginV1Request(SocialType.FESTAGO, "token");
+
+                // when & then
+                mockMvc.perform(post(uri)
+                        .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk());
             }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #909 

## ✨ PR 세부 내용

OpenID Connect 방식의 인증 기능을 추가했습니다.

사용자는 OAuth2로 인증을 수행하고, `accessToken`을 서버로 보내지 않고 `idToken`을 서버로 보냅니다.

`idToken`은 JWT 토큰 형식으로, 모든 정보가 노출되어 있는데, 이걸로 어떻게 신원을 검사하냐면, OAuth2 서버에서 비밀키로 서명된 JWT 토큰을  OAuth2 서버에 공개키를 요청하여, 서버에서 해당 공개키로 IdToken이 수정되지 않은 토큰임을 검사합니다.

따라서 악의적으로 토큰을 수정해서 보내더라도, 서버에서 해당 토큰이 수정되었는지 판단할 수 있으므로 보안에 문제가 없습니다!

카카오에서 제공하는 OpenID 유효성 검증 절차는 다음과 같습니다.

---

1. ID 토큰의 영역 구분자인 온점(.)을 기준으로 헤더, 페이로드, 서명을 분리
2. 페이로드를 Base64 방식으로 디코딩
3. 페이로드의 iss 값이 https://kauth.kakao.com와 일치하는지 확인
4. 페이로드의 aud 값이 서비스 앱 키와 일치하는지 확인
5. 페이로드의 exp 값이 현재 UNIX 타임스탬프(Timestamp)보다 큰 값인지 확인(ID 토큰이 만료되지 않았는지 확인)
6. 페이로드의 nonce 값이 카카오 로그인 요청 시 전달한 값과 일치하는지 확인
7. 서명 검증


서명 검증은 다음 순서로 진행합니다.
1. 헤더를 Base64 방식으로 디코딩
2. [OIDC: 공개키 목록 조회하기](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#oidc-find-public-key)를 통해 카카오 인증 서버가 서명 시 사용하는 공개키 목록 조회
3. 공개키 목록에서 헤더의 kid에 해당하는 공개키 값 확인
  3.1 공개키는 일정 기간 캐싱(Caching)하여 사용할 것을 권장하며, 지나치게 빈번한 요청 시 요청이 차단될 수 있으므로 유의
5. JWT 서명 검증을 지원하는 라이브러리를 사용해 공개키로 서명 검증
  5.1 참고: [OpenID Foundation](https://openid.net/developers/jwt/), [jwt.io](https://jwt.io/libraries)
  5.2 라이브러리를 사용하지 않고 직접 서명 검증 구현 시, [RFC7515](https://datatracker.ietf.org/doc/html/rfc7515) 규격에 따라 서명 검증 과정 진행 가능

---

여기서 3, 4, 5, 6, 서명 검증 과정은 `KakaoOpenIdUserInfoProvider`에 구현되어 있으니 참고하시면 될 것 같습니다.
(6 과정은 시간 상의 이유로 생략했습니다. 추후 구현이 필요합니다)

서명 검증을 진행할 때, 공개키 목록을 매번 조회하면 요청이 차단될 수 있으므로 `CachedOpenIdKeyProvider`를 통해 캐싱을 하였습니다.
라이브러리 캐시를 사용한 것이 아닌, 직접 캐시를 구현하여 동시성 문제를 처리하는 코드가 포함되어 있으므로 약간 지저분 합니다. 😂
`ConcurrentHashMap`을 사용하는 방법도 있는데, `computeIfAbsent`의 2번째 매개변수인 매핑 함수에 현재 상태를 변경하면 안 된다는 규칙이 있어서, 직접 동시성 문제를 처리할 수 밖에 없었네요. 😂