### PR TITLE
[BE] OAuth2 설정에 native app key 설정 추가 및 id 토큰 유효성 검사 수정 (#916)

### DIFF
--- a/backend/src/main/java/com/festago/auth/infrastructure/KakaoOAuth2AccessTokenClient.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/KakaoOAuth2AccessTokenClient.java
@@ -21,7 +21,7 @@ public class KakaoOAuth2AccessTokenClient {
 
     public KakaoOAuth2AccessTokenClient(
         @Value("${festago.oauth2.kakao.grant-type}") String grantType,
-        @Value("${festago.oauth2.kakao.client-id}") String clientId,
+        @Value("${festago.oauth2.kakao.rest-api-key}") String clientId,
         @Value("${festago.oauth2.kakao.redirect-uri}") String redirectUri,
         @Value("${festago.oauth2.kakao.client-secret}") String clientSecret,
         RestTemplateBuilder restTemplateBuilder

--- a/backend/src/main/java/com/festago/auth/infrastructure/KakaoOpenIdUserInfoProvider.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/KakaoOpenIdUserInfoProvider.java
@@ -4,10 +4,13 @@ import com.festago.auth.domain.OpenIdNonceValidator;
 import com.festago.auth.domain.OpenIdUserInfoProvider;
 import com.festago.auth.domain.SocialType;
 import com.festago.auth.domain.UserInfo;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.UnauthorizedException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import java.time.Clock;
 import java.util.Date;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -19,18 +22,20 @@ public class KakaoOpenIdUserInfoProvider implements OpenIdUserInfoProvider {
     private static final String ISSUER = "https://kauth.kakao.com";
     private final OpenIdNonceValidator openIdNonceValidator;
     private final OpenIdIdTokenParser idTokenParser;
+    private final Set<String> appKeys;
 
     public KakaoOpenIdUserInfoProvider(
-        @Value("${festago.oauth2.kakao.client-id}") String clientId,
+        @Value("${festago.oauth2.kakao.rest-api-key}") String restApiKey,
+        @Value("${festago.oauth2.kakao.native-app-key}") String nativeAppKey,
         KakaoOpenIdPublicKeyLocator kakaoOpenIdPublicKeyLocator,
         OpenIdNonceValidator openIdNonceValidator,
         Clock clock
     ) {
+        this.appKeys = Set.of(restApiKey, nativeAppKey);
         this.openIdNonceValidator = openIdNonceValidator;
         this.idTokenParser = new OpenIdIdTokenParser(Jwts.parser()
             .keyLocator(kakaoOpenIdPublicKeyLocator)
             .requireIssuer(ISSUER)
-            .requireAudience(clientId)
             .clock(() -> Date.from(clock.instant()))
             .build());
     }
@@ -39,11 +44,22 @@ public class KakaoOpenIdUserInfoProvider implements OpenIdUserInfoProvider {
     public UserInfo provide(String idToken) {
         Claims payload = idTokenParser.parse(idToken);
         openIdNonceValidator.validate(payload.get("nonce", String.class), payload.getExpiration());
+        validateAudience(payload.getAudience());
         return UserInfo.builder()
             .socialType(SocialType.KAKAO)
             .socialId(payload.getSubject())
             .nickname(payload.get("nickname", String.class))
             .profileImage(payload.get("picture", String.class))
             .build();
+    }
+
+    private void validateAudience(Set<String> audiences) {
+        for (String audience : audiences) {
+            if (appKeys.contains(audience)) {
+                return;
+            }
+        }
+        log.info("허용되지 않는 id 토큰의 audience 값이 요청되었습니다. audiences={}", audiences);
+        throw new UnauthorizedException(ErrorCode.OPEN_ID_INVALID_TOKEN);
     }
 }

--- a/backend/src/main/java/com/festago/auth/infrastructure/OpenIdIdTokenParser.java
+++ b/backend/src/main/java/com/festago/auth/infrastructure/OpenIdIdTokenParser.java
@@ -1,0 +1,28 @@
+package com.festago.auth.infrastructure;
+
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.UnauthorizedException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OpenIdIdTokenParser {
+
+    private final JwtParser jwtParser;
+
+    public Claims parse(String idToken) {
+        try {
+            return jwtParser.parseSignedClaims(idToken).getPayload();
+        } catch (JwtException | IllegalArgumentException e) {
+            log.info("OpenID Token 파싱에서 예외가 발생했습니다. message={}", e.getMessage());
+            throw new UnauthorizedException(ErrorCode.OPEN_ID_INVALID_TOKEN);
+        } catch (Exception e) {
+            log.error("JWT 토큰 파싱 중에 문제가 발생했습니다.", e);
+            throw e;
+        }
+    }
+}

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -23,6 +23,7 @@ festago:
   oauth2:
     kakao:
       grant-type: grant-type
-      client-id: client-id
+      rest-api-key: rest-api-key
+      native-app-key: native-app-key
       redirect-uri: redirect-uri
       client-secret: client-secret


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #916

## ✨ PR 세부 내용

이슈에서 얘기한 것 처럼, 앱 환경에서 id 토큰의 `aud` 값이 REST API 키와 달라 검증이 되지 않는 문제를 수정했습니다.

다른 환경의 토큰 `aud` 값이 native app, REST API 키 둘 중 하나라도 일치하면 유효성 검사를 통과한 것이라 판단하였습니다.

그 외 JWT 토큰을 파싱할 때 로직이 다른 서비스 구현체(Apple)가 생기면 중복이 발생할 것 같아, 미리 분리해두었습니다.

클라이언트에서 빠르게 반영해야 하므로 우선 바로 머지 처리 하도록 하겠습니다!