### PR TITLE
[BE] fix: 아티스트 목록 스웨거 문서에서 정확하게 표시되도록 변경 (#920)

### DIFF
--- a/backend/src/main/java/com/festago/artist/dto/ArtistFestivalDetailV1Response.java
+++ b/backend/src/main/java/com/festago/artist/dto/ArtistFestivalDetailV1Response.java
@@ -1,7 +1,10 @@
 package com.festago.artist.dto;
 
 import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.festago.artist.infrastructure.JsonArtistsSerializer;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
 public record ArtistFestivalDetailV1Response(
@@ -10,7 +13,9 @@ public record ArtistFestivalDetailV1Response(
     LocalDate startDate,
     LocalDate endDate,
     String posterImageUrl,
-    @JsonRawValue String artists
+    @JsonRawValue
+    @ArraySchema(schema = @Schema(implementation = JsonArtistsSerializer.ArtistQueryModel.class))
+    String artists
 ) {
 
     @QueryProjection

--- a/backend/src/main/java/com/festago/artist/infrastructure/JsonArtistsSerializer.java
+++ b/backend/src/main/java/com/festago/artist/infrastructure/JsonArtistsSerializer.java
@@ -33,7 +33,7 @@ public class JsonArtistsSerializer implements ArtistsSerializer {
     /**
      * 쿼리에서 사용되는 모델이므로, 필드를 추가해도 필드명은 변경되면 절대로 안 됨!!!
      */
-    private record ArtistQueryModel(
+    public record ArtistQueryModel(
         Long id,
         String name,
         String profileImageUrl,

--- a/backend/src/main/java/com/festago/festival/dto/FestivalSearchV1Response.java
+++ b/backend/src/main/java/com/festago/festival/dto/FestivalSearchV1Response.java
@@ -1,7 +1,10 @@
 package com.festago.festival.dto;
 
 import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.festago.artist.infrastructure.JsonArtistsSerializer;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
 public record FestivalSearchV1Response(
@@ -10,7 +13,9 @@ public record FestivalSearchV1Response(
     LocalDate startDate,
     LocalDate endDate,
     String posterImageUrl,
-    @JsonRawValue String artists
+    @JsonRawValue
+    @ArraySchema(schema = @Schema(implementation = JsonArtistsSerializer.ArtistQueryModel.class))
+    String artists
 ) {
 
     @QueryProjection

--- a/backend/src/main/java/com/festago/festival/dto/FestivalV1Response.java
+++ b/backend/src/main/java/com/festago/festival/dto/FestivalV1Response.java
@@ -1,10 +1,12 @@
 package com.festago.festival.dto;
 
 import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.festago.artist.infrastructure.JsonArtistsSerializer;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
-//TODO: 아티스트 필드명을 변경할려면 JsonRawValue 형식이라 DB에 저장할 필드이름을 다르게 해야함
 public record FestivalV1Response(
     Long id,
     String name,
@@ -12,7 +14,10 @@ public record FestivalV1Response(
     LocalDate endDate,
     String posterImageUrl,
     SchoolV1Response school,
-    @JsonRawValue String artists) {
+    @JsonRawValue
+    @ArraySchema(schema = @Schema(implementation = JsonArtistsSerializer.ArtistQueryModel.class))
+    String artists
+) {
 
     @QueryProjection
     public FestivalV1Response {

--- a/backend/src/main/java/com/festago/festival/dto/StageV1Response.java
+++ b/backend/src/main/java/com/festago/festival/dto/StageV1Response.java
@@ -1,14 +1,17 @@
 package com.festago.festival.dto;
 
 import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.festago.artist.infrastructure.JsonArtistsSerializer;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
-//TODO: 필드명 변경으로 변경 불가
 public record StageV1Response(
     Long id,
     LocalDateTime startDateTime,
     @JsonRawValue
+    @ArraySchema(schema = @Schema(implementation = JsonArtistsSerializer.ArtistQueryModel.class))
     String artists
 ) {
 

--- a/backend/src/main/java/com/festago/school/dto/v1/SchoolFestivalV1Response.java
+++ b/backend/src/main/java/com/festago/school/dto/v1/SchoolFestivalV1Response.java
@@ -1,7 +1,10 @@
 package com.festago.school.dto.v1;
 
 import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.festago.artist.infrastructure.JsonArtistsSerializer;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
 public record SchoolFestivalV1Response(
@@ -10,7 +13,9 @@ public record SchoolFestivalV1Response(
     LocalDate startDate,
     LocalDate endDate,
     String posterImageUrl,
-    @JsonRawValue String artists
+    @JsonRawValue
+    @ArraySchema(schema = @Schema(implementation = JsonArtistsSerializer.ArtistQueryModel.class))
+    String artists
 ) {
 
     @QueryProjection


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #920

## ✨ PR 세부 내용

이슈에서 말한 것 처럼 스웨거 문서에 `@JsonRawValue` 어노테이션이 붙은 필드가 정상적으로 JSON 포맷이 보이도록 수정했습니다.

![image](https://github.com/woowacourse-teams/2023-festa-go/assets/116627736/1d3d5bc1-f686-4f53-ae38-e07dc1d3cb52)
