### PR TITLE
[BE] feat: 축제 대학교 검색 기능 보완 및 정렬(#926)

### DIFF
--- a/backend/src/main/java/com/festago/festival/application/FestivalSearchV1QueryService.java
+++ b/backend/src/main/java/com/festago/festival/application/FestivalSearchV1QueryService.java
@@ -10,6 +10,7 @@ import com.festago.festival.repository.FestivalFilter;
 import com.festago.festival.repository.SchoolFestivalSearchV1QueryDslRepository;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.List;
@@ -43,7 +44,7 @@ public class FestivalSearchV1QueryService {
         List<FestivalSearchV1Response> result = new ArrayList<>();
         for (FestivalFilter festivalFilter : determineFestivalOrder()) {
             List<FestivalSearchV1Response> festivalsByFilter = festivalByStatus.getOrDefault(festivalFilter,
-                new ArrayList<>());
+                Collections.emptyList());
             sortByStatus(festivalFilter, festivalsByFilter);
             result.addAll(festivalsByFilter);
         }
@@ -51,7 +52,8 @@ public class FestivalSearchV1QueryService {
     }
 
     private Map<FestivalFilter, List<FestivalSearchV1Response>> divideByStatus(
-        List<FestivalSearchV1Response> festivals) {
+        List<FestivalSearchV1Response> festivals
+    ) {
         return festivals.stream()
             .collect(Collectors.groupingBy(
                 this::determineStatus,

--- a/backend/src/main/java/com/festago/festival/application/FestivalSearchV1QueryService.java
+++ b/backend/src/main/java/com/festago/festival/application/FestivalSearchV1QueryService.java
@@ -1,11 +1,19 @@
 package com.festago.festival.application;
 
+import static com.festago.festival.repository.FestivalFilter.END;
+import static com.festago.festival.repository.FestivalFilter.PLANNED;
+import static com.festago.festival.repository.FestivalFilter.PROGRESS;
+
 import com.festago.festival.dto.FestivalSearchV1Response;
 import com.festago.festival.repository.ArtistFestivalSearchV1QueryDslRepository;
+import com.festago.festival.repository.FestivalFilter;
 import com.festago.festival.repository.SchoolFestivalSearchV1QueryDslRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,16 +23,101 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FestivalSearchV1QueryService {
 
-    private static final Pattern SCHOOL_PATTERN = Pattern.compile(".*대(학교)?$");
-
     private final ArtistFestivalSearchV1QueryDslRepository artistFestivalSearchV1QueryDslRepository;
     private final SchoolFestivalSearchV1QueryDslRepository schoolFestivalSearchV1QueryDslRepository;
 
     public List<FestivalSearchV1Response> search(String keyword) {
-        Matcher schoolMatcher = SCHOOL_PATTERN.matcher(keyword);
-        if (schoolMatcher.matches()) {
-            return schoolFestivalSearchV1QueryDslRepository.executeSearch(keyword);
+        return sortFestival(findFestivals(keyword));
+    }
+
+    private List<FestivalSearchV1Response> findFestivals(String keyword) {
+        if (artistFestivalSearchV1QueryDslRepository.existsByName(keyword)) {
+            return artistFestivalSearchV1QueryDslRepository.executeSearch(keyword);
         }
-        return artistFestivalSearchV1QueryDslRepository.executeSearch(keyword);
+        return schoolFestivalSearchV1QueryDslRepository.executeSearch(keyword);
+    }
+
+    private List<FestivalSearchV1Response> sortFestival(List<FestivalSearchV1Response> festivals) {
+        EnumMap<FestivalFilter, List<FestivalSearchV1Response>> festivalByStatus = divideByStatus(festivals);
+        List<FestivalSearchV1Response> result = new ArrayList<>();
+        result.addAll(sortByStatus(PROGRESS, festivalByStatus.get(PROGRESS)));
+        result.addAll(sortByStatus(PLANNED, festivalByStatus.get(PLANNED)));
+        result.addAll(sortByStatus(END, festivalByStatus.get(END)));
+        return result;
+    }
+
+    private EnumMap<FestivalFilter, List<FestivalSearchV1Response>> divideByStatus(
+        List<FestivalSearchV1Response> festivals) {
+        return festivals.stream()
+            .collect(Collectors.groupingBy(
+                this::determineStatus,
+                () -> new EnumMap<>(FestivalFilter.class),
+                Collectors.toList()
+            ));
+    }
+
+    private FestivalFilter determineStatus(FestivalSearchV1Response festival) {
+        LocalDate now = LocalDate.now();
+        if (now.isAfter(festival.endDate())) {
+            return END;
+        }
+        if (now.isBefore(festival.startDate())) {
+            return PLANNED;
+        }
+        return PROGRESS;
+    }
+
+    private List<FestivalSearchV1Response> sortByStatus(
+        FestivalFilter status,
+        List<FestivalSearchV1Response> festivals) {
+        if (festivals == null) {
+            return Collections.emptyList();
+        }
+        if (status == END) {
+            sortEndFestival(festivals);
+        }
+        if (status == PROGRESS) {
+            sortProgressFestival(festivals);
+        }
+        if (status == PLANNED) {
+            sortPlannedFestival(festivals);
+        }
+        return festivals;
+    }
+
+    private void sortEndFestival(List<FestivalSearchV1Response> festivals) {
+        festivals.sort((festival1, festival2) -> {
+            if (festival1.endDate().isAfter(festival2.endDate())) {
+                return 1;
+            }
+            if (festival1.endDate().isEqual(festival2.endDate())) {
+                return 0;
+            }
+            return -1;
+        });
+    }
+
+    private void sortProgressFestival(List<FestivalSearchV1Response> festivals) {
+        festivals.sort((festival1, festival2) -> {
+            if (festival1.startDate().isBefore(festival2.endDate())) {
+                return 1;
+            }
+            if (festival1.startDate().isEqual(festival2.startDate())) {
+                return 0;
+            }
+            return -1;
+        });
+    }
+
+    private void sortPlannedFestival(List<FestivalSearchV1Response> festivals) {
+        festivals.sort((festival1, festival2) -> {
+            if (festival1.startDate().isBefore(festival2.endDate())) {
+                return 1;
+            }
+            if (festival1.startDate().isEqual(festival2.startDate())) {
+                return 0;
+            }
+            return -1;
+        });
     }
 }

--- a/backend/src/main/java/com/festago/festival/repository/ArtistFestivalSearchV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/festival/repository/ArtistFestivalSearchV1QueryDslRepository.java
@@ -24,18 +24,18 @@ public class ArtistFestivalSearchV1QueryDslRepository extends QueryDslRepository
     }
 
     public List<FestivalSearchV1Response> executeSearch(String keyword) {
+        return searchByExpression(getBooleanExpressionByKeyword(keyword));
+    }
+
+    private BooleanExpression getBooleanExpressionByKeyword(String keyword) {
         int keywordLength = keyword.length();
         if (keywordLength == 0) {
             throw new BadRequestException(ErrorCode.INVALID_KEYWORD);
         }
         if (keywordLength == 1) {
-            return searchByEqual(keyword);
+            return artist.name.eq(keyword);
         }
-        return searchByLike(keyword);
-    }
-
-    private List<FestivalSearchV1Response> searchByEqual(String keyword) {
-        return searchByExpression(artist.name.eq(keyword));
+        return artist.name.contains(keyword);
     }
 
     private List<FestivalSearchV1Response> searchByExpression(BooleanExpression expression) {
@@ -56,7 +56,14 @@ public class ArtistFestivalSearchV1QueryDslRepository extends QueryDslRepository
             .fetch();
     }
 
-    private List<FestivalSearchV1Response> searchByLike(String keyword) {
-        return searchByExpression(artist.name.contains(keyword));
+    public boolean existsByName(String keyword) {
+        return existsByExpression(getBooleanExpressionByKeyword(keyword));
+    }
+
+    private boolean existsByExpression(BooleanExpression expression) {
+        return !selectFrom(artist)
+            .where(expression)
+            .fetch()
+            .isEmpty();
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #926 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

검색 로직은 기존에
~ 대학교 혹은 ~대로 끝난다면 축제 이름에 해당 대학교 이름이 적힌 축제를 반환하고 나머지 경우에 아티스트 이름을 기반으로 검색하였습니다.
변경된 로직은
해당 이름에 해당하는 아티스트가 있는지 확인하고 없으면 축제 이름에 해당 키워드가 포함되어 있다면 반환하도록 변경하였습니다.
이로 인해 부경만 쳤을 경우 부경이란 키워드가 포함된 모든 축제를 받을 수 있습니다.
축제 이름에 해당 키워드가 포함되었는지 확인하는 것이기 때문에 만약 "축제"로 검색을 한다면 "축제"가 이름에 포함된 모든 축제가 반환됩니다.
이 부분에 대한 방어 로직을 짜려했으나 앱 초기에는 데이터도 얼마 없을 뿐더러 후에 페이징 적용시에 고려해도 좋을 것이라 판단하여 최대한 검색이 자유롭게 되도록 그대로 두었습니다.


