### PR TITLE
[BE] feat: FestivalQueryInfo, StageQueryInfo를 재갱신하는 어드민 API 추가 (#933)

### DIFF
--- a/backend/src/main/java/com/festago/admin/application/AdminQueryInfoRenewalService.java
+++ b/backend/src/main/java/com/festago/admin/application/AdminQueryInfoRenewalService.java
@@ -30,7 +30,7 @@ public class AdminQueryInfoRenewalService {
 
     public void renewalByFestivalStartDatePeriod(LocalDate to, LocalDate end) {
         List<Long> festivalIds = adminFestivalIdResolverQueryDslRepository.findFestivalIdsByStartDatePeriod(to, end);
-        log.info("{}개의 축제에 대해 QueryInfo를 새로 갱신합니다.", festivalIds);
+        log.info("{}개의 축제에 대해 QueryInfo를 새로 갱신합니다.", festivalIds.size());
         festivalIds.forEach(festivalQueryInfoArtistRenewService::renewArtistInfo);
         adminStageIdResolverQueryDslRepository.findStageIdsByFestivalIdIn(festivalIds)
             .forEach(stageQueryInfoService::renewalStageQueryInfo);

--- a/backend/src/main/java/com/festago/admin/application/AdminQueryInfoRenewalService.java
+++ b/backend/src/main/java/com/festago/admin/application/AdminQueryInfoRenewalService.java
@@ -1,0 +1,38 @@
+package com.festago.admin.application;
+
+import com.festago.admin.repository.AdminFestivalIdResolverQueryDslRepository;
+import com.festago.admin.repository.AdminStageIdResolverQueryDslRepository;
+import com.festago.festival.application.FestivalQueryInfoArtistRenewService;
+import com.festago.stage.application.StageQueryInfoService;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminQueryInfoRenewalService {
+
+    private final FestivalQueryInfoArtistRenewService festivalQueryInfoArtistRenewService;
+    private final StageQueryInfoService stageQueryInfoService;
+    private final AdminStageIdResolverQueryDslRepository adminStageIdResolverQueryDslRepository;
+    private final AdminFestivalIdResolverQueryDslRepository adminFestivalIdResolverQueryDslRepository;
+
+    public void renewalByFestivalId(Long festivalId) {
+        festivalQueryInfoArtistRenewService.renewArtistInfo(festivalId);
+        adminStageIdResolverQueryDslRepository.findStageIdsByFestivalId(festivalId)
+            .forEach(stageQueryInfoService::renewalStageQueryInfo);
+    }
+
+    public void renewalByFestivalStartDatePeriod(LocalDate to, LocalDate end) {
+        List<Long> festivalIds = adminFestivalIdResolverQueryDslRepository.findFestivalIdsByStartDatePeriod(to, end);
+        log.info("{}개의 축제에 대해 QueryInfo를 새로 갱신합니다.", festivalIds);
+        festivalIds.forEach(festivalQueryInfoArtistRenewService::renewArtistInfo);
+        adminStageIdResolverQueryDslRepository.findStageIdsByFestivalIdIn(festivalIds)
+            .forEach(stageQueryInfoService::renewalStageQueryInfo);
+    }
+}

--- a/backend/src/main/java/com/festago/admin/dto/queryinfo/QueryInfoRenewalFestivalPeriodV1Request.java
+++ b/backend/src/main/java/com/festago/admin/dto/queryinfo/QueryInfoRenewalFestivalPeriodV1Request.java
@@ -1,0 +1,11 @@
+package com.festago.admin.dto.queryinfo;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record QueryInfoRenewalFestivalPeriodV1Request(
+    @NotNull LocalDate to,
+    @NotNull LocalDate end
+) {
+
+}

--- a/backend/src/main/java/com/festago/admin/presentation/v1/AdminQueryInfoRenewalV1Controller.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/AdminQueryInfoRenewalV1Controller.java
@@ -1,0 +1,38 @@
+package com.festago.admin.presentation.v1;
+
+import com.festago.admin.application.AdminQueryInfoRenewalService;
+import com.festago.admin.dto.queryinfo.QueryInfoRenewalFestivalPeriodV1Request;
+import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/api/v1/query-info/renewal")
+@RequiredArgsConstructor
+@Hidden
+public class AdminQueryInfoRenewalV1Controller {
+
+    private final AdminQueryInfoRenewalService queryInfoRenewalService;
+
+    @PostMapping("/festival-id/{festivalId}")
+    public ResponseEntity<Void> renewalByFestivalId(
+        @PathVariable Long festivalId
+    ) {
+        queryInfoRenewalService.renewalByFestivalId(festivalId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/festival-period")
+    public ResponseEntity<Void> renewalByFestivalStartDatePeriod(
+        @RequestBody @Valid QueryInfoRenewalFestivalPeriodV1Request request
+    ) {
+        queryInfoRenewalService.renewalByFestivalStartDatePeriod(request.to(), request.end());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/festago/admin/repository/AdminFestivalIdResolverQueryDslRepository.java
+++ b/backend/src/main/java/com/festago/admin/repository/AdminFestivalIdResolverQueryDslRepository.java
@@ -1,0 +1,25 @@
+package com.festago.admin.repository;
+
+import static com.festago.festival.domain.QFestival.festival;
+
+import com.festago.common.querydsl.QueryDslRepositorySupport;
+import com.festago.festival.domain.Festival;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class AdminFestivalIdResolverQueryDslRepository extends QueryDslRepositorySupport {
+
+    public AdminFestivalIdResolverQueryDslRepository() {
+        super(Festival.class);
+    }
+
+    public List<Long> findFestivalIdsByStartDatePeriod(LocalDate to, LocalDate end) {
+        return select(festival.id)
+            .from(festival)
+            .where(festival.festivalDuration.startDate.goe(to)
+                .and(festival.festivalDuration.startDate.loe(end)))
+            .fetch();
+    }
+}

--- a/backend/src/main/java/com/festago/admin/repository/AdminStageIdResolverQueryDslRepository.java
+++ b/backend/src/main/java/com/festago/admin/repository/AdminStageIdResolverQueryDslRepository.java
@@ -1,0 +1,33 @@
+package com.festago.admin.repository;
+
+import static com.festago.festival.domain.QFestival.festival;
+import static com.festago.stage.domain.QStage.stage;
+
+import com.festago.common.querydsl.QueryDslRepositorySupport;
+import com.festago.stage.domain.Stage;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class AdminStageIdResolverQueryDslRepository extends QueryDslRepositorySupport {
+
+    public AdminStageIdResolverQueryDslRepository() {
+        super(Stage.class);
+    }
+
+    public List<Long> findStageIdsByFestivalId(Long festivalId) {
+        return select(stage.id)
+            .from(stage)
+            .innerJoin(festival).on(festival.id.eq(stage.festival.id))
+            .where(festival.id.eq(festivalId))
+            .fetch();
+    }
+
+    public List<Long> findStageIdsByFestivalIdIn(List<Long> festivalIds) {
+        return select(stage.id)
+            .from(stage)
+            .innerJoin(festival).on(festival.id.eq(stage.festival.id))
+            .where(festival.id.in(festivalIds))
+            .fetch();
+    }
+}

--- a/backend/src/main/java/com/festago/stage/application/StageQueryInfoEventListener.java
+++ b/backend/src/main/java/com/festago/stage/application/StageQueryInfoEventListener.java
@@ -1,20 +1,9 @@
 package com.festago.stage.application;
 
-import com.festago.artist.domain.Artist;
-import com.festago.artist.domain.ArtistsSerializer;
-import com.festago.artist.repository.ArtistRepository;
-import com.festago.common.exception.ErrorCode;
-import com.festago.common.exception.InternalServerException;
-import com.festago.common.exception.NotFoundException;
 import com.festago.stage.domain.Stage;
-import com.festago.stage.domain.StageQueryInfo;
 import com.festago.stage.dto.event.StageCreatedEvent;
 import com.festago.stage.dto.event.StageDeletedEvent;
 import com.festago.stage.dto.event.StageUpdatedEvent;
-import com.festago.stage.repository.StageArtistRepository;
-import com.festago.stage.repository.StageQueryInfoRepository;
-import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -27,49 +16,26 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class StageQueryInfoEventListener {
 
-    private final StageQueryInfoRepository stageQueryInfoRepository;
-    private final StageArtistRepository stageArtistRepository;
-    private final ArtistRepository artistRepository;
-    private final ArtistsSerializer serializer;
+    private final StageQueryInfoService stageQueryInfoService;
 
     @EventListener
     @Transactional(propagation = Propagation.MANDATORY)
     public void stageCreatedEventHandler(StageCreatedEvent event) {
         Stage stage = event.stage();
-        Long stageId = stage.getId();
-        List<Artist> artists = getStageArtists(stageId);
-        StageQueryInfo stageQueryInfo = StageQueryInfo.of(stageId, artists, serializer);
-        stageQueryInfoRepository.save(stageQueryInfo);
-    }
-
-    /**
-     * 해당 메서드를 사용하는 로직이 비동기로 처리된다면 예외 던지는 것을 다시 생각해볼것! (동기로 실행되면 ControllerAdvice에서 처리가 됨)
-     */
-    private List<Artist> getStageArtists(Long stageId) {
-        Set<Long> artistIds = stageArtistRepository.findAllArtistIdByStageId(stageId);
-        List<Artist> artists = artistRepository.findByIdIn(artistIds);
-        if (artists.size() != artistIds.size()) {
-            log.error("StageArtist에 존재하지 않은 Artist가 있습니다. artistsIds=" + artistIds);
-            throw new InternalServerException(ErrorCode.ARTIST_NOT_FOUND);
-        }
-        return artists;
+        stageQueryInfoService.initialStageQueryInfo(stage.getId());
     }
 
     @EventListener
     @Transactional(propagation = Propagation.MANDATORY)
     public void stageUpdatedEventHandler(StageUpdatedEvent event) {
         Stage stage = event.stage();
-        Long stageId = stage.getId();
-        List<Artist> artists = getStageArtists(stageId);
-        StageQueryInfo stageQueryInfo = stageQueryInfoRepository.findByStageId(stageId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.STAGE_NOT_FOUND));
-        stageQueryInfo.updateArtist(artists, serializer);
+        stageQueryInfoService.renewalStageQueryInfo(stage.getId());
     }
 
     @EventListener
     @Transactional(propagation = Propagation.MANDATORY)
     public void stageDeletedEventHandler(StageDeletedEvent event) {
         Stage stage = event.stage();
-        stageQueryInfoRepository.deleteByStageId(stage.getId());
+        stageQueryInfoService.deleteStageQueryInfo(stage.getId());
     }
 }

--- a/backend/src/main/java/com/festago/stage/application/StageQueryInfoService.java
+++ b/backend/src/main/java/com/festago/stage/application/StageQueryInfoService.java
@@ -1,0 +1,56 @@
+package com.festago.stage.application;
+
+import com.festago.artist.domain.Artist;
+import com.festago.artist.domain.ArtistsSerializer;
+import com.festago.artist.repository.ArtistRepository;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.InternalServerException;
+import com.festago.common.exception.NotFoundException;
+import com.festago.stage.domain.StageQueryInfo;
+import com.festago.stage.repository.StageArtistRepository;
+import com.festago.stage.repository.StageQueryInfoRepository;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class StageQueryInfoService {
+
+    private final StageQueryInfoRepository stageQueryInfoRepository;
+    private final StageArtistRepository stageArtistRepository;
+    private final ArtistRepository artistRepository;
+    private final ArtistsSerializer serializer;
+
+    public void initialStageQueryInfo(Long stageId) {
+        List<Artist> artists = getStageArtists(stageId);
+        StageQueryInfo stageQueryInfo = StageQueryInfo.of(stageId, artists, serializer);
+        stageQueryInfoRepository.save(stageQueryInfo);
+    }
+
+    private List<Artist> getStageArtists(Long stageId) {
+        Set<Long> artistIds = stageArtistRepository.findAllArtistIdByStageId(stageId);
+        List<Artist> artists = artistRepository.findByIdIn(artistIds);
+        if (artists.size() != artistIds.size()) {
+            log.error("StageArtist에 존재하지 않은 Artist가 있습니다. artistsIds=" + artistIds);
+            throw new InternalServerException(ErrorCode.ARTIST_NOT_FOUND);
+        }
+        return artists;
+    }
+
+    public void renewalStageQueryInfo(Long stageId) {
+        StageQueryInfo stageQueryInfo = stageQueryInfoRepository.findByStageId(stageId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.STAGE_NOT_FOUND));
+        List<Artist> artists = getStageArtists(stageId);
+        stageQueryInfo.updateArtist(artists, serializer);
+    }
+
+    public void deleteStageQueryInfo(Long stageId) {
+        stageQueryInfoRepository.deleteByStageId(stageId);
+    }
+}

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminQueryInfoRenewalV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminQueryInfoRenewalV1ControllerTest.java
@@ -1,0 +1,117 @@
+package com.festago.admin.presentation.v1;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.admin.application.AdminQueryInfoRenewalService;
+import com.festago.admin.dto.queryinfo.QueryInfoRenewalFestivalPeriodV1Request;
+import com.festago.auth.domain.Role;
+import com.festago.support.CustomWebMvcTest;
+import com.festago.support.WithMockAuth;
+import jakarta.servlet.http.Cookie;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class AdminQueryInfoRenewalV1ControllerTest {
+
+    private static final Cookie TOKEN_COOKIE = new Cookie("token", "token");
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    AdminQueryInfoRenewalService adminQueryInfoRenewalService;
+
+    @Nested
+    class QueryInfo_재갱신_by_festivalId {
+
+        final String uri = "/admin/api/v1/query-info/renewal/festival-id/{festivalId}";
+
+        @Nested
+        @DisplayName("POST " + uri)
+        class 올바른_주소로 {
+
+            private long festivalId = 1L;
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri, festivalId)
+                        .cookie(TOKEN_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri, festivalId))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri, festivalId)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
+
+    @Nested
+    class QueryInfo_재갱신_by_festival_startDate_period {
+
+        final String uri = "/admin/api/v1/query-info/renewal/festival-period";
+
+        @Nested
+        @DisplayName("POST " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                // given
+                var request = new QueryInfoRenewalFestivalPeriodV1Request(LocalDate.now(), LocalDate.now());
+                // when & then
+                mockMvc.perform(post(uri)
+                        .content(objectMapper.writeValueAsString(request))
+                        .cookie(TOKEN_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(post(uri)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/admin/repository/AdminFestivalIdResolverQueryDslRepositoryTest.java
+++ b/backend/src/test/java/com/festago/admin/repository/AdminFestivalIdResolverQueryDslRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.festago.admin.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.festago.festival.domain.Festival;
+import com.festago.festival.repository.FestivalRepository;
+import com.festago.school.domain.School;
+import com.festago.school.repository.SchoolRepository;
+import com.festago.support.ApplicationIntegrationTest;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.SchoolFixture;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class AdminFestivalIdResolverQueryDslRepositoryTest extends ApplicationIntegrationTest {
+
+    @Autowired
+    AdminFestivalIdResolverQueryDslRepository adminFestivalIdResolverQueryDslRepository;
+
+    @Autowired
+    FestivalRepository festivalRepository;
+
+    @Autowired
+    SchoolRepository schoolRepository;
+
+    School 테코대학교;
+
+    LocalDate _6월_12일 = LocalDate.parse("2077-06-12");
+    LocalDate _6월_13일 = LocalDate.parse("2077-06-13");
+    LocalDate _6월_14일 = LocalDate.parse("2077-06-14");
+    LocalDate _6월_15일 = LocalDate.parse("2077-06-15");
+
+    @BeforeEach
+    void setUp() {
+        테코대학교 = schoolRepository.save(SchoolFixture.builder().name("테코대학교").build());
+    }
+
+    @Nested
+    class findFestivalIdsByWithinDates {
+
+        @Test
+        void 축제의_시작일에_포함되는_축제의_식별자_목록을_반환한다() {
+            // given
+            Festival _6월_12일_축제 = festivalRepository.save(
+                FestivalFixture.builder().startDate(_6월_12일).school(테코대학교).build());
+            Festival _6월_13일_축제 = festivalRepository.save(
+                FestivalFixture.builder().startDate(_6월_13일).school(테코대학교).build());
+            Festival _6월_14일_축제 = festivalRepository.save(
+                FestivalFixture.builder().startDate(_6월_14일).school(테코대학교).build());
+            Festival _6월_15일_축제 = festivalRepository.save(
+                FestivalFixture.builder().startDate(_6월_15일).school(테코대학교).build());
+
+            // when
+            var actual = adminFestivalIdResolverQueryDslRepository.findFestivalIdsByStartDatePeriod(_6월_13일, _6월_14일);
+
+            // then
+            assertThat(actual).containsExactlyInAnyOrder(_6월_13일_축제.getId(), _6월_14일_축제.getId());
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/admin/repository/AdminStageIdResolverQueryDslRepositoryTest.java
+++ b/backend/src/test/java/com/festago/admin/repository/AdminStageIdResolverQueryDslRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.festago.admin.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.festago.festival.domain.Festival;
+import com.festago.festival.repository.FestivalRepository;
+import com.festago.school.domain.School;
+import com.festago.school.repository.SchoolRepository;
+import com.festago.stage.domain.Stage;
+import com.festago.stage.repository.StageRepository;
+import com.festago.support.ApplicationIntegrationTest;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StageFixture;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class AdminStageIdResolverQueryDslRepositoryTest extends ApplicationIntegrationTest {
+
+    @Autowired
+    AdminStageIdResolverQueryDslRepository adminStageIdResolverQueryDslRepository;
+
+    @Autowired
+    FestivalRepository festivalRepository;
+
+    @Autowired
+    StageRepository stageRepository;
+
+    @Autowired
+    SchoolRepository schoolRepository;
+
+    School 테코대학교;
+
+    @BeforeEach
+    void setUp() {
+        테코대학교 = schoolRepository.save(SchoolFixture.builder().name("테코대학교").build());
+    }
+
+    @Nested
+    class findStageIdsByFestivalId {
+
+        @Test
+        void 축제_식별자로_공연의_식별자를_모두_조회한다() {
+            // given
+            Festival festival = festivalRepository.save(FestivalFixture.builder().school(테코대학교).build());
+            List<Long> expect = IntStream.rangeClosed(1, 3)
+                .mapToObj(i -> stageRepository.save(StageFixture.builder().festival(festival).build()))
+                .map(Stage::getId)
+                .toList();
+
+            // when
+            List<Long> actual = adminStageIdResolverQueryDslRepository.findStageIdsByFestivalId(festival.getId());
+
+            // then
+            assertThat(actual).containsExactlyInAnyOrderElementsOf(expect);
+        }
+    }
+
+    @Nested
+    class findStageIdsByFestivalIdIn {
+
+        @Test
+        void 축제_식별자_목록으로_공연의_식별자를_모두_조회한다() {
+            // given
+            List<Festival> festivals = IntStream.rangeClosed(1, 2)
+                .mapToObj(i -> festivalRepository.save(FestivalFixture.builder().school(테코대학교).build()))
+                .toList();
+            List<Long> expect = festivals.stream()
+                .map(festival -> IntStream.rangeClosed(1, 3)
+                    .mapToObj(j -> stageRepository.save(StageFixture.builder().festival(festival).build()))
+                    .map(Stage::getId)
+                    .toList())
+                .flatMap(List::stream)
+                .toList();
+
+            // when
+            List<Long> festivalIds = festivals.stream()
+                .map(Festival::getId)
+                .toList();
+            List<Long> actual = adminStageIdResolverQueryDslRepository.findStageIdsByFestivalIdIn(festivalIds);
+
+            // then
+            assertThat(actual).containsExactlyInAnyOrderElementsOf(expect);
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/artist/infrastructure/DelimiterArtistsSerializer.java
+++ b/backend/src/test/java/com/festago/artist/infrastructure/DelimiterArtistsSerializer.java
@@ -1,0 +1,23 @@
+package com.festago.artist.infrastructure;
+
+import static java.util.stream.Collectors.joining;
+
+import com.festago.artist.domain.Artist;
+import com.festago.artist.domain.ArtistsSerializer;
+import java.util.List;
+
+public class DelimiterArtistsSerializer implements ArtistsSerializer {
+
+    private final String delimiter;
+
+    public DelimiterArtistsSerializer(String delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    @Override
+    public String serialize(List<Artist> artists) {
+        return artists.stream()
+            .map(Artist::getName)
+            .collect(joining(delimiter));
+    }
+}

--- a/backend/src/test/java/com/festago/stage/application/StageQueryInfoServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/StageQueryInfoServiceTest.java
@@ -1,0 +1,129 @@
+package com.festago.stage.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.festago.artist.domain.Artist;
+import com.festago.artist.domain.ArtistsSerializer;
+import com.festago.artist.infrastructure.DelimiterArtistsSerializer;
+import com.festago.artist.repository.ArtistRepository;
+import com.festago.artist.repository.MemoryArtistRepository;
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.InternalServerException;
+import com.festago.common.exception.NotFoundException;
+import com.festago.stage.domain.StageQueryInfo;
+import com.festago.stage.repository.MemoryStageArtistRepository;
+import com.festago.stage.repository.MemoryStageQueryInfoRepository;
+import com.festago.stage.repository.StageArtistRepository;
+import com.festago.stage.repository.StageQueryInfoRepository;
+import com.festago.support.fixture.ArtistFixture;
+import com.festago.support.fixture.StageArtistFixture;
+import com.festago.support.fixture.StageQueryInfoFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class StageQueryInfoServiceTest {
+
+    private final Long stageId = 1L;
+
+    StageQueryInfoService stageQueryInfoService;
+
+    StageQueryInfoRepository stageQueryInfoRepository;
+
+    StageArtistRepository stageArtistRepository;
+
+    ArtistRepository artistRepository;
+
+    ArtistsSerializer artistsSerializer = new DelimiterArtistsSerializer(",");
+
+    Artist 뉴진스;
+
+    @BeforeEach
+    void setUp() {
+        stageQueryInfoRepository = new MemoryStageQueryInfoRepository();
+        stageArtistRepository = new MemoryStageArtistRepository();
+        artistRepository = new MemoryArtistRepository();
+        stageQueryInfoService = new StageQueryInfoService(
+            stageQueryInfoRepository,
+            stageArtistRepository,
+            artistRepository,
+            artistsSerializer
+        );
+        뉴진스 = artistRepository.save(ArtistFixture.builder().name("뉴진스").build());
+    }
+
+    @Nested
+    class initialStageQueryInfo {
+
+        @Test
+        void Artist가_존재하지_않으면_예외() {
+            // given
+            stageArtistRepository.save(StageArtistFixture.builder(stageId, 4885L).build());
+
+            // when
+            assertThatThrownBy(() -> stageQueryInfoService.initialStageQueryInfo(stageId))
+                .isInstanceOf(InternalServerException.class)
+                .hasMessage(ErrorCode.ARTIST_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void StageQueryInfo가_생성된다() {
+            // given
+            stageArtistRepository.save(StageArtistFixture.builder(stageId, 뉴진스.getId()).build());
+
+            // when
+            stageQueryInfoService.initialStageQueryInfo(stageId);
+
+            // then
+            assertThat(stageQueryInfoRepository.findByStageId(stageId)).isPresent();
+        }
+    }
+
+    @Nested
+    class renewalStageQueryInfo {
+
+        @Test
+        void Stage_식별자에_대한_StageQueryInfo가_없으면_예외() {
+            // when & then
+            assertThatThrownBy(() -> stageQueryInfoService.renewalStageQueryInfo(stageId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.STAGE_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void StageQueryInfo가_새롭게_갱신된다() {
+            // given
+            stageQueryInfoRepository.save(
+                StageQueryInfoFixture.builder().stageId(stageId).artistInfo("oldInfo").build());
+            stageArtistRepository.save(StageArtistFixture.builder(stageId, 뉴진스.getId()).build());
+
+            // when
+            stageQueryInfoService.renewalStageQueryInfo(stageId);
+
+            // then
+            StageQueryInfo stageQueryInfo = stageQueryInfoRepository.findByStageId(stageId).get();
+            assertThat(stageQueryInfo.getArtistInfo()).isNotEqualTo("oldInfo");
+        }
+    }
+
+    @Nested
+    class deleteStageQueryInfo {
+
+        @Test
+        void StageQueryInfo가_삭제된다() {
+            // given
+            stageQueryInfoRepository.save(StageQueryInfoFixture.builder().stageId(stageId).build());
+
+            // when
+            stageQueryInfoService.deleteStageQueryInfo(stageId);
+
+            // then
+            assertThat(stageQueryInfoRepository.findByStageId(stageId)).isEmpty();
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/stage/repository/MemoryStageQueryInfoRepository.java
+++ b/backend/src/test/java/com/festago/stage/repository/MemoryStageQueryInfoRepository.java
@@ -1,0 +1,24 @@
+package com.festago.stage.repository;
+
+import com.festago.stage.domain.StageQueryInfo;
+import com.festago.support.AbstractMemoryRepository;
+import java.util.Objects;
+import java.util.Optional;
+
+public class MemoryStageQueryInfoRepository extends AbstractMemoryRepository<StageQueryInfo> implements
+    StageQueryInfoRepository {
+
+    @Override
+    public Optional<StageQueryInfo> findByStageId(Long stageId) {
+        return memory.values()
+            .stream()
+            .filter(stageQueryInfo -> Objects.equals(stageQueryInfo.getStageId(), stageId))
+            .findAny();
+    }
+
+    @Override
+    public void deleteByStageId(Long stageId) {
+        memory.entrySet()
+            .removeIf(entry -> Objects.equals(entry.getValue().getStageId(), stageId));
+    }
+}

--- a/backend/src/test/java/com/festago/support/fixture/FestivalFixture.java
+++ b/backend/src/test/java/com/festago/support/fixture/FestivalFixture.java
@@ -10,7 +10,7 @@ public class FestivalFixture extends BaseFixture {
     private Long id;
     private String name;
     private LocalDate startDate = LocalDate.now();
-    private LocalDate endDate = LocalDate.now().plusDays(3L);
+    private LocalDate endDate;
     private String posterImageUrl = "https://picsum.photos/536/354";
     private School school = SchoolFixture.builder().build();
 
@@ -52,6 +52,9 @@ public class FestivalFixture extends BaseFixture {
     }
 
     public Festival build() {
+        if (endDate == null) {
+            endDate = startDate.plusDays(3L);
+        }
         return new Festival(id, uniqueValue("페스타고 대학교 축제", name), new FestivalDuration(startDate, endDate),
             posterImageUrl, school);
     }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #933

## ✨ PR 세부 내용

이슈에 적은 내용대로, 관리자 페이지에 사용할 QueryInfo를 초기화하는 API를 추가했습니다.

구현한 재갱신 방법은 두 가지가 있습니다.
1. 축제의 식별자와 같은 경우
2. 두 날짜를 받아, 축제의 시작일이 포함되는 축제인 경우

1번은 단순히 축제의 식별자를 받아, 해당 축제+공연 QueryInfo를 재갱신 합니다.
2번은 두 날짜를 받고, 축제의 시작일이 해당 두 날짜 범위에 포함되는 축제+공연 QueryInfo를 재갱신 합니다.

주의사항으로 2번의 경우 날짜를 넉넉하게 잡아버리면, 모든 축제+공연에 대해 재갱신이 이뤄지므로 잠깐 부하가 크게 발생할 수 있습니다.
(운영 환경에서는 축제 개수가 작으므로 큰 문제는 없을 것 같네요)
