### PR TITLE
fix: SocialMediaUpdateCommand, SocialMediaCreateCommand 빌더 패턴 사용 (#938)

### DIFF
--- a/backend/src/main/java/com/festago/admin/dto/socialmedia/SocialMediaCreateV1Request.java
+++ b/backend/src/main/java/com/festago/admin/dto/socialmedia/SocialMediaCreateV1Request.java
@@ -24,13 +24,13 @@ public record SocialMediaCreateV1Request(
 ) {
 
     public SocialMediaCreateCommand toCommand() {
-        return new SocialMediaCreateCommand(
-            ownerId,
-            ownerType,
-            socialMediaType,
-            name,
-            logoUrl,
-            url
-        );
+        return SocialMediaCreateCommand.builder()
+            .ownerId(ownerId)
+            .ownerType(ownerType)
+            .socialMediaType(socialMediaType)
+            .name(name)
+            .logoUrl(logoUrl)
+            .url(url)
+            .build();
     }
 }

--- a/backend/src/main/java/com/festago/admin/dto/socialmedia/SocialMediaUpdateV1Request.java
+++ b/backend/src/main/java/com/festago/admin/dto/socialmedia/SocialMediaUpdateV1Request.java
@@ -15,10 +15,10 @@ public record SocialMediaUpdateV1Request(
 ) {
 
     public SocialMediaUpdateCommand toCommand() {
-        return new SocialMediaUpdateCommand(
-            name,
-            logoUrl,
-            url
-        );
+        return SocialMediaUpdateCommand.builder()
+            .name(name)
+            .logoUrl(logoUrl)
+            .url(url)
+            .build();
     }
 }

--- a/backend/src/main/java/com/festago/socialmedia/dto/command/SocialMediaCreateCommand.java
+++ b/backend/src/main/java/com/festago/socialmedia/dto/command/SocialMediaCreateCommand.java
@@ -3,7 +3,9 @@ package com.festago.socialmedia.dto.command;
 import com.festago.socialmedia.domain.OwnerType;
 import com.festago.socialmedia.domain.SocialMedia;
 import com.festago.socialmedia.domain.SocialMediaType;
+import lombok.Builder;
 
+@Builder
 public record SocialMediaCreateCommand(
     Long ownerId,
     OwnerType ownerType,

--- a/backend/src/main/java/com/festago/socialmedia/dto/command/SocialMediaUpdateCommand.java
+++ b/backend/src/main/java/com/festago/socialmedia/dto/command/SocialMediaUpdateCommand.java
@@ -1,5 +1,8 @@
 package com.festago.socialmedia.dto.command;
 
+import lombok.Builder;
+
+@Builder
 public record SocialMediaUpdateCommand(
     String name,
     String url,


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #938

## ✨ PR 세부 내용

이슈에 적은 내용처럼 SocialMediaUpdateCommand, SocialMediaCreateCommand에 빌더 패턴을 적용하여, logoUrl과 url이 반대로 적용되는 문제를 수정했습니다.

추후 이러한 문제가 발생하지 않도록 Command 전부에 빌더 패턴을 적용하여 사용하는 것이 좋을 것 같네요.

운영 환경에서 발생하고 있는 문제이므로 바로 머지 하도록 하겠습니다!