### PR TITLE
[AN/USER] fix: refresh 토큰 인증 오류 수정(#941)

### DIFF
--- a/android/festago/app/build.gradle.kts
+++ b/android/festago/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.festago.festago"
         minSdk = 28
         targetSdk = 34
-        versionCode = 10
-        versionName = "2.0.1"
+        versionCode = 11
+        versionName = "2.0.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/festago/data/src/main/java/com/festago/festago/data/repository/DefaultUserRepository.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/repository/DefaultUserRepository.kt
@@ -86,8 +86,7 @@ class DefaultUserRepository @Inject constructor(
             )
         }.onSuccessOrCatch {
             kakaoAuthorization.signOut()
-            tokenDataSource.accessToken = null
-            tokenDataSource.refreshToken = null
+            clearToken()
         }
     }
 
@@ -98,16 +97,14 @@ class DefaultUserRepository @Inject constructor(
             )
         }.onSuccessOrCatch {
             kakaoAuthorization.deleteAccount()
-            tokenDataSource.accessToken = null
-            tokenDataSource.refreshToken = null
+            clearToken()
         }
     }
 
     private suspend fun refresh(refreshToken: Token): Result<Unit> {
         return runCatchingResponse {
             val refreshRequest = RefreshRequest(refreshToken.token)
-            tokenDataSource.accessToken = null
-            tokenDataSource.refreshToken = null
+            clearToken()
             authRetrofitService.refresh(refreshRequest)
         }.onSuccessOrCatch { refreshTokenResponse ->
             tokenDataSource.accessToken = refreshTokenResponse.accessToken.toEntity()
@@ -118,6 +115,11 @@ class DefaultUserRepository @Inject constructor(
     override suspend fun getUserInfo(): Result<UserInfo> {
         return userInfoDataSource.userInfo?.toDomain()?.let { Result.success(it) }
             ?: Result.failure(NullPointerException("User info is null"))
+    }
+
+    override suspend fun clearToken() {
+        tokenDataSource.accessToken = null
+        tokenDataSource.refreshToken = null
     }
 
     companion object {

--- a/android/festago/data/src/main/java/com/festago/festago/data/repository/DefaultUserRepository.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/repository/DefaultUserRepository.kt
@@ -105,9 +105,13 @@ class DefaultUserRepository @Inject constructor(
 
     private suspend fun refresh(refreshToken: Token): Result<Unit> {
         return runCatchingResponse {
-            authRetrofitService.refresh(RefreshRequest(refreshToken.token))
+            val refreshRequest = RefreshRequest(refreshToken.token)
+            tokenDataSource.accessToken = null
+            tokenDataSource.refreshToken = null
+            authRetrofitService.refresh(refreshRequest)
         }.onSuccessOrCatch { refreshTokenResponse ->
             tokenDataSource.accessToken = refreshTokenResponse.accessToken.toEntity()
+            tokenDataSource.refreshToken = refreshTokenResponse.refreshToken.toEntity()
         }
     }
 

--- a/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeUserRepository.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/repository/FakeUserRepository.kt
@@ -43,4 +43,6 @@ class FakeUserRepository @Inject constructor() : UserRepository {
     override suspend fun getUserInfo(): Result<UserInfo> {
         return Result.success(UserInfo("", ""))
     }
+
+    override suspend fun clearToken() = Unit
 }

--- a/android/festago/data/src/main/java/com/festago/festago/data/retrofit/AuthInterceptor.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/retrofit/AuthInterceptor.kt
@@ -27,7 +27,6 @@ class AuthInterceptor(private val userRepository: UserRepository) : Interceptor 
                 ),
             ).build()
 
-
     companion object {
         private const val HEADER_AUTHORIZATION = "Authorization"
         private const val AUTHORIZATION_TOKEN_FORMAT = "Bearer %s"

--- a/android/festago/data/src/main/java/com/festago/festago/data/retrofit/AuthInterceptor.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/retrofit/AuthInterceptor.kt
@@ -10,7 +10,10 @@ class AuthInterceptor(private val userRepository: UserRepository) : Interceptor 
 
     override fun intercept(chain: Interceptor.Chain): Response {
         return runBlocking {
-            chain.proceed(request = getNewRequest(chain))
+            chain.proceed(request = getNewRequest(chain)).also {
+                if (it.code == 401)
+                    userRepository.clearToken()
+            }
         }
     }
 
@@ -22,8 +25,8 @@ class AuthInterceptor(private val userRepository: UserRepository) : Interceptor 
                 AUTHORIZATION_TOKEN_FORMAT.format(
                     userRepository.getAccessToken().getOrNull()?.token ?: "TokenIsNull",
                 ),
-            )
-            .build()
+            ).build()
+
 
     companion object {
         private const val HEADER_AUTHORIZATION = "Authorization"

--- a/android/festago/domain/src/main/java/com/festago/festago/domain/repository/UserRepository.kt
+++ b/android/festago/domain/src/main/java/com/festago/festago/domain/repository/UserRepository.kt
@@ -13,4 +13,5 @@ interface UserRepository {
     suspend fun deleteAccount(): Result<Unit>
     suspend fun rejectSignIn()
     suspend fun getUserInfo(): Result<UserInfo>
+    suspend fun clearToken()
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #941 

## ✨ PR 세부 내용

1. refresh 요청 전에 토큰을 파기한다. (요청은 보내고 응답 받지 않은 채로 종료할 수 있기 때문)
2. refresh 성공 시 새로 갈아끼운다.
