### PR TITLE
[BE] feat: ImageFileUploadService jpeg 확장자 지원 추가 (#946)

### DIFF
--- a/backend/src/main/java/com/festago/upload/application/ImageFileUploadService.java
+++ b/backend/src/main/java/com/festago/upload/application/ImageFileUploadService.java
@@ -25,7 +25,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class ImageFileUploadService {
 
     private static final int MAX_FILE_SIZE = 2_000_000; // 2MB
-    private static final Set<FileExtension> ALLOW_IMAGE_EXTENSION = EnumSet.of(FileExtension.JPG, FileExtension.PNG);
+    private static final Set<FileExtension> ALLOW_IMAGE_EXTENSION = EnumSet.of(FileExtension.JPG, FileExtension.JPEG,
+        FileExtension.PNG, FileExtension.WEBP);
 
     private final StorageClient storageClient;
     private final UploadFileRepository uploadFileRepository;

--- a/backend/src/main/java/com/festago/upload/application/ImageFileUploadService.java
+++ b/backend/src/main/java/com/festago/upload/application/ImageFileUploadService.java
@@ -25,8 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ImageFileUploadService {
 
     private static final int MAX_FILE_SIZE = 2_000_000; // 2MB
-    private static final Set<FileExtension> ALLOW_IMAGE_EXTENSION = EnumSet.of(FileExtension.JPG, FileExtension.JPEG,
-        FileExtension.PNG, FileExtension.WEBP);
+    private static final Set<FileExtension> ALLOW_IMAGE_EXTENSION = EnumSet.of(FileExtension.JPG, FileExtension.JPEG, FileExtension.PNG);
 
     private final StorageClient storageClient;
     private final UploadFileRepository uploadFileRepository;

--- a/backend/src/main/java/com/festago/upload/domain/FileExtension.java
+++ b/backend/src/main/java/com/festago/upload/domain/FileExtension.java
@@ -10,7 +10,6 @@ public enum FileExtension {
     JPG(".jpg", MimeTypeUtils.IMAGE_JPEG),
     JPEG(".jpeg", MimeTypeUtils.IMAGE_JPEG),
     PNG(".png", MimeTypeUtils.IMAGE_PNG),
-    WEBP(".webp", new MimeType("image", "webp")),
     NONE("", MimeTypeUtils.APPLICATION_OCTET_STREAM),
     ;
 

--- a/backend/src/main/java/com/festago/upload/domain/FileExtension.java
+++ b/backend/src/main/java/com/festago/upload/domain/FileExtension.java
@@ -8,7 +8,9 @@ import org.springframework.util.MimeTypeUtils;
 @RequiredArgsConstructor
 public enum FileExtension {
     JPG(".jpg", MimeTypeUtils.IMAGE_JPEG),
+    JPEG(".jpeg", MimeTypeUtils.IMAGE_JPEG),
     PNG(".png", MimeTypeUtils.IMAGE_PNG),
+    WEBP(".webp", new MimeType("image", "webp")),
     NONE("", MimeTypeUtils.APPLICATION_OCTET_STREAM),
     ;
 

--- a/backend/src/test/java/com/festago/upload/application/ImageFileUploadServiceTest.java
+++ b/backend/src/test/java/com/festago/upload/application/ImageFileUploadServiceTest.java
@@ -41,7 +41,7 @@ class ImageFileUploadServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"image.png", "image.jpg"})
+    @ValueSource(strings = {"image.png", "image.jpg", "image.jpeg", "image.webp"})
     void 이미지를_업로드할때_JPG_PNG_확장자이면_성공한다(String filename) {
         // given
         MultipartFile multipartFile = new MockMultipartFile("image", filename, "image/png",

--- a/backend/src/test/java/com/festago/upload/application/ImageFileUploadServiceTest.java
+++ b/backend/src/test/java/com/festago/upload/application/ImageFileUploadServiceTest.java
@@ -41,7 +41,7 @@ class ImageFileUploadServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"image.png", "image.jpg", "image.jpeg", "image.webp"})
+    @ValueSource(strings = {"image.png", "image.jpg", "image.jpeg"})
     void 이미지를_업로드할때_JPG_PNG_확장자이면_성공한다(String filename) {
         // given
         MultipartFile multipartFile = new MockMultipartFile("image", filename, "image/png",


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #946

## ✨ PR 세부 내용

ImageFileUploadService에서 `jpeg`, ~~`webp`~~ 확장자에 대한 지원을 추가했습니다.

~~참고로 `webp` 확장자가 좋은 점이, png에 비해 용량이 2~3배 정도 작습니다. (png 561kb, webp 204kb)~~

~~가능하다면 이미지 업로드는 `webp`로 변환한 뒤 올리는 게 좋을 것 같습니다.~~

`webp` 확장자 지원은 iOS 이슈로 인해 삭제하였습니다. 😂