### PR TITLE
[BE] fix: 아티스트 생성, 수정, 삭제 이벤트 발행 추가 (#948)

### DIFF
--- a/backend/src/main/java/com/festago/artist/application/ArtistCommandService.java
+++ b/backend/src/main/java/com/festago/artist/application/ArtistCommandService.java
@@ -3,8 +3,12 @@ package com.festago.artist.application;
 import com.festago.artist.domain.Artist;
 import com.festago.artist.dto.command.ArtistCreateCommand;
 import com.festago.artist.dto.command.ArtistUpdateCommand;
+import com.festago.artist.dto.event.ArtistCreatedEvent;
+import com.festago.artist.dto.event.ArtistDeletedEvent;
+import com.festago.artist.dto.event.ArtistUpdatedEvent;
 import com.festago.artist.repository.ArtistRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,20 +18,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class ArtistCommandService {
 
     private final ArtistRepository artistRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public Long save(ArtistCreateCommand command) {
         Artist artist = artistRepository.save(
             new Artist(command.name(), command.profileImageUrl(), command.backgroundImageUrl())
         );
+        eventPublisher.publishEvent(new ArtistCreatedEvent(artist));
         return artist.getId();
     }
 
     public void update(ArtistUpdateCommand command, Long artistId) {
         Artist artist = artistRepository.getOrThrow(artistId);
         artist.update(command.name(), command.profileImageUrl(), command.backgroundImageUrl());
+        eventPublisher.publishEvent(new ArtistUpdatedEvent(artist));
     }
 
     public void delete(Long artistId) {
         artistRepository.deleteById(artistId);
+        eventPublisher.publishEvent(new ArtistDeletedEvent(artistId));
     }
 }

--- a/backend/src/test/java/com/festago/artist/application/ArtistCommandServiceTest.java
+++ b/backend/src/test/java/com/festago/artist/application/ArtistCommandServiceTest.java
@@ -2,6 +2,7 @@ package com.festago.artist.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.*;
 
 import com.festago.artist.domain.Artist;
 import com.festago.artist.dto.command.ArtistCreateCommand;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -25,7 +27,7 @@ class ArtistCommandServiceTest {
     @BeforeEach
     void setUp() {
         artistRepository = new MemoryArtistRepository();
-        artistCommandService = new ArtistCommandService(artistRepository);
+        artistCommandService = new ArtistCommandService(artistRepository, mock());
     }
 
     @Test


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #948

## ✨ PR 세부 내용

이슈 내용대로 아티스트 생성, 수정, 삭제시 이벤트 발행 로직을 추가했습니다.

해당 사항 지속되면 추후 이미지 삭제 로직 구현 시 기존 이미지가 모두 사라질 수 있기에 최대한 빠르게 처리해야 합니다.

따라서 리뷰 없이 바로 머지하도록 하겠습니다!