### PR TITLE
[BE] 기본 이미지 URL 정책 빈 문자열로 변경 (#952)

### DIFF
--- a/backend/src/main/java/com/festago/admin/dto/artist/ArtistV1CreateRequest.java
+++ b/backend/src/main/java/com/festago/admin/dto/artist/ArtistV1CreateRequest.java
@@ -1,14 +1,15 @@
 package com.festago.admin.dto.artist;
 
 import com.festago.artist.dto.command.ArtistCreateCommand;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 
 public record ArtistV1CreateRequest(
     @NotBlank
     String name,
-    @NotBlank
+    @Nullable
     String profileImageUrl,
-    @NotBlank
+    @Nullable
     String backgroundImageUrl
 ) {
 

--- a/backend/src/main/java/com/festago/admin/dto/artist/ArtistV1UpdateRequest.java
+++ b/backend/src/main/java/com/festago/admin/dto/artist/ArtistV1UpdateRequest.java
@@ -1,14 +1,15 @@
 package com.festago.admin.dto.artist;
 
 import com.festago.artist.dto.command.ArtistUpdateCommand;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 
 public record ArtistV1UpdateRequest(
     @NotBlank
     String name,
-    @NotBlank
+    @Nullable
     String profileImageUrl,
-    @NotBlank
+    @Nullable
     String backgroundImageUrl
 ) {
 

--- a/backend/src/main/java/com/festago/admin/dto/socialmedia/SocialMediaCreateV1Request.java
+++ b/backend/src/main/java/com/festago/admin/dto/socialmedia/SocialMediaCreateV1Request.java
@@ -3,6 +3,7 @@ package com.festago.admin.dto.socialmedia;
 import com.festago.socialmedia.domain.OwnerType;
 import com.festago.socialmedia.domain.SocialMediaType;
 import com.festago.socialmedia.dto.command.SocialMediaCreateCommand;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -17,7 +18,7 @@ public record SocialMediaCreateV1Request(
     SocialMediaType socialMediaType,
     @NotBlank
     String name,
-    @NotBlank
+    @Nullable
     String logoUrl,
     @NotBlank
     String url

--- a/backend/src/main/java/com/festago/admin/dto/socialmedia/SocialMediaUpdateV1Request.java
+++ b/backend/src/main/java/com/festago/admin/dto/socialmedia/SocialMediaUpdateV1Request.java
@@ -1,6 +1,7 @@
 package com.festago.admin.dto.socialmedia;
 
 import com.festago.socialmedia.dto.command.SocialMediaUpdateCommand;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
@@ -8,7 +9,7 @@ import lombok.Builder;
 public record SocialMediaUpdateV1Request(
     @NotBlank
     String name,
-    @NotBlank
+    @Nullable
     String logoUrl,
     @NotBlank
     String url

--- a/backend/src/main/java/com/festago/artist/domain/Artist.java
+++ b/backend/src/main/java/com/festago/artist/domain/Artist.java
@@ -1,6 +1,8 @@
 package com.festago.artist.domain;
 
 import com.festago.common.domain.BaseTimeEntity;
+import com.festago.common.util.ImageUrlHelper;
+import com.festago.common.util.Validator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -12,8 +14,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Artist extends BaseTimeEntity {
-
-    private static final String DEFAULT_URL = "https://picsum.photos/536/354";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,14 +27,15 @@ public class Artist extends BaseTimeEntity {
     private String backgroundImageUrl;
 
     public Artist(Long id, String name, String profileImage, String backgroundImageUrl) {
+        validateName(name);
         this.id = id;
         this.name = name;
-        this.profileImage = profileImage;
-        this.backgroundImageUrl = backgroundImageUrl;
+        this.profileImage = ImageUrlHelper.getBlankStringIfBlank(profileImage);
+        this.backgroundImageUrl = ImageUrlHelper.getBlankStringIfBlank(backgroundImageUrl);
     }
 
-    public Artist(String name, String profileImage) {
-        this(null, name, profileImage, DEFAULT_URL);
+    private void validateName(String name) {
+        Validator.notBlank(name, "name");
     }
 
     public Artist(String name, String profileImage, String backgroundImageUrl) {
@@ -42,9 +43,10 @@ public class Artist extends BaseTimeEntity {
     }
 
     public void update(String name, String profileImage, String backgroundImageUrl) {
+        validateName(name);
         this.name = name;
-        this.profileImage = profileImage;
-        this.backgroundImageUrl = backgroundImageUrl;
+        this.profileImage = ImageUrlHelper.getBlankStringIfBlank(profileImage);
+        this.backgroundImageUrl = ImageUrlHelper.getBlankStringIfBlank(backgroundImageUrl);
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/festago/common/util/ImageUrlHelper.java
+++ b/backend/src/main/java/com/festago/common/util/ImageUrlHelper.java
@@ -1,0 +1,17 @@
+package com.festago.common.util;
+
+import org.springframework.util.StringUtils;
+
+public class ImageUrlHelper {
+
+    private ImageUrlHelper() {
+
+    }
+
+    public static String getBlankStringIfBlank(String input) {
+        if (StringUtils.hasText(input)) {
+            return input;
+        }
+        return "";
+    }
+}

--- a/backend/src/main/java/com/festago/festival/domain/Festival.java
+++ b/backend/src/main/java/com/festago/festival/domain/Festival.java
@@ -1,6 +1,7 @@
 package com.festago.festival.domain;
 
 import com.festago.common.domain.BaseTimeEntity;
+import com.festago.common.util.ImageUrlHelper;
 import com.festago.common.util.Validator;
 import com.festago.school.domain.School;
 import jakarta.persistence.Embedded;
@@ -21,7 +22,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Festival extends BaseTimeEntity {
 
-    private static final String DEFAULT_POSTER_IMAGE_URL = "https://picsum.photos/536/354";
     private static final int MAX_NAME_LENGTH = 50;
     private static final int MAX_POSTER_IMAGE_URL_LENGTH = 255;
 
@@ -44,10 +44,6 @@ public class Festival extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private School school;
 
-    public Festival(String name, FestivalDuration festivalDuration, School school) {
-        this(null, name, festivalDuration, DEFAULT_POSTER_IMAGE_URL, school);
-    }
-
     public Festival(String name, FestivalDuration festivalDuration, String posterImageUrl, School school) {
         this(null, name, festivalDuration, posterImageUrl, school);
     }
@@ -60,7 +56,7 @@ public class Festival extends BaseTimeEntity {
         this.id = id;
         this.name = name;
         this.festivalDuration = festivalDuration;
-        this.posterImageUrl = posterImageUrl;
+        this.posterImageUrl = ImageUrlHelper.getBlankStringIfBlank(posterImageUrl);
         this.school = school;
     }
 
@@ -71,9 +67,10 @@ public class Festival extends BaseTimeEntity {
     }
 
     private void validatePosterImageUrl(String posterImageUrl) {
-        String fieldName = "posterImageUrl";
-        Validator.notBlank(posterImageUrl, fieldName);
-        Validator.maxLength(posterImageUrl, MAX_POSTER_IMAGE_URL_LENGTH, fieldName);
+        if (posterImageUrl == null) {
+            return;
+        }
+        Validator.maxLength(posterImageUrl, MAX_POSTER_IMAGE_URL_LENGTH, "posterImageUrl");
     }
 
     private void validateFestivalDuration(FestivalDuration festivalDuration) {
@@ -99,7 +96,7 @@ public class Festival extends BaseTimeEntity {
 
     public void changePosterImageUrl(String posterImageUrl) {
         validatePosterImageUrl(posterImageUrl);
-        this.posterImageUrl = posterImageUrl;
+        this.posterImageUrl = ImageUrlHelper.getBlankStringIfBlank(posterImageUrl);
     }
 
     public void changeFestivalDuration(FestivalDuration festivalDuration) {

--- a/backend/src/main/java/com/festago/festival/domain/Festival.java
+++ b/backend/src/main/java/com/festago/festival/domain/Festival.java
@@ -67,9 +67,6 @@ public class Festival extends BaseTimeEntity {
     }
 
     private void validatePosterImageUrl(String posterImageUrl) {
-        if (posterImageUrl == null) {
-            return;
-        }
         Validator.maxLength(posterImageUrl, MAX_POSTER_IMAGE_URL_LENGTH, "posterImageUrl");
     }
 

--- a/backend/src/main/java/com/festago/member/domain/Member.java
+++ b/backend/src/main/java/com/festago/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.festago.member.domain;
 
 import com.festago.auth.domain.SocialType;
 import com.festago.common.domain.BaseTimeEntity;
+import com.festago.common.util.ImageUrlHelper;
 import com.festago.common.util.Validator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -37,7 +38,6 @@ import org.springframework.util.StringUtils;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 
-    private static final String DEFAULT_IMAGE_URL = "https://festa-go.site/images/default-profile.png";
     private static final String DEFAULT_NICKNAME = "FestivalLover";
     private static final int MAX_SOCIAL_ID_LENGTH = 255;
     private static final int MAX_NICKNAME_LENGTH = 30;
@@ -77,7 +77,7 @@ public class Member extends BaseTimeEntity {
         this.socialId = socialId;
         this.socialType = socialType;
         this.nickname = (StringUtils.hasText(nickname)) ? nickname : DEFAULT_NICKNAME;
-        this.profileImage = (StringUtils.hasText(profileImage)) ? profileImage : DEFAULT_IMAGE_URL;
+        this.profileImage = ImageUrlHelper.getBlankStringIfBlank(profileImage);
     }
 
     private void validate(String socialId, SocialType socialType, String nickname, String profileImage) {

--- a/backend/src/main/java/com/festago/mock/domain/MockFestivalsGenerator.java
+++ b/backend/src/main/java/com/festago/mock/domain/MockFestivalsGenerator.java
@@ -26,6 +26,7 @@ public class MockFestivalsGenerator {
                 return new Festival(
                     school.getName() + " " + festivalDuration.getStartDate().format(DATE_TIME_FORMATTER) + " 축제",
                     festivalDuration,
+                    "",
                     school
                 );
             })

--- a/backend/src/main/java/com/festago/mock/domain/MockSchoolsGenerator.java
+++ b/backend/src/main/java/com/festago/mock/domain/MockSchoolsGenerator.java
@@ -33,6 +33,8 @@ public class MockSchoolsGenerator {
         return new School(
             schoolEmail,
             schoolName,
+            "",
+            "",
             schoolRegion
         );
     }

--- a/backend/src/main/java/com/festago/school/domain/School.java
+++ b/backend/src/main/java/com/festago/school/domain/School.java
@@ -1,6 +1,7 @@
 package com.festago.school.domain;
 
 import com.festago.common.domain.BaseTimeEntity;
+import com.festago.common.util.ImageUrlHelper;
 import com.festago.common.util.Validator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,13 +14,11 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.springframework.util.StringUtils;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class School extends BaseTimeEntity {
 
-    private static final String DEFAULT_URL = "https://picsum.photos/536/354";
     private static final int MAX_DOMAIN_LENGTH = 50;
     private static final int MAX_NAME_LENGTH = 255;
     private static final int MAX_IMAGE_URL_LENGTH = 255;
@@ -46,25 +45,18 @@ public class School extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private SchoolRegion region;
 
+    public School(String domain, String name, String logoUrl, String backgroundUrl, SchoolRegion region) {
+        this(null, domain, name, logoUrl, backgroundUrl, region);
+    }
+
     public School(Long id, String domain, String name, String logoUrl, String backgroundImageUrl, SchoolRegion region) {
         validate(domain, name, region, logoUrl, backgroundImageUrl);
         this.id = id;
         this.domain = domain;
         this.name = name;
-        this.logoUrl = getDefaultUrlIfBlank(logoUrl);
-        this.backgroundUrl = getDefaultUrlIfBlank(backgroundImageUrl);
+        this.logoUrl = ImageUrlHelper.getBlankStringIfBlank(logoUrl);
+        this.backgroundUrl = ImageUrlHelper.getBlankStringIfBlank(backgroundImageUrl);
         this.region = region;
-    }
-
-    private String getDefaultUrlIfBlank(String imageUrl) {
-        if (StringUtils.hasText(imageUrl)) {
-            return imageUrl;
-        }
-        return DEFAULT_URL;
-    }
-
-    public School(String domain, String name, SchoolRegion region) {
-        this(null, domain, name, DEFAULT_URL, DEFAULT_URL, region);
     }
 
     private void validate(String domain, String name, SchoolRegion region, String logoUrl, String backgroundImageUrl) {
@@ -112,12 +104,12 @@ public class School extends BaseTimeEntity {
 
     public void changeLogoUrl(String logoUrl) {
         validateImageUrl(logoUrl, "logoUrl");
-        this.logoUrl = getDefaultUrlIfBlank(logoUrl);
+        this.logoUrl = ImageUrlHelper.getBlankStringIfBlank(logoUrl);
     }
 
     public void changeBackgroundImageUrl(String backgroundImageUrl) {
         validateImageUrl(backgroundImageUrl, "backgroundImageUrl");
-        this.backgroundUrl = getDefaultUrlIfBlank(backgroundImageUrl);
+        this.backgroundUrl = ImageUrlHelper.getBlankStringIfBlank(backgroundImageUrl);
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/festago/socialmedia/domain/SocialMedia.java
+++ b/backend/src/main/java/com/festago/socialmedia/domain/SocialMedia.java
@@ -1,6 +1,8 @@
 package com.festago.socialmedia.domain;
 
 import com.festago.common.domain.BaseTimeEntity;
+import com.festago.common.util.ImageUrlHelper;
+import com.festago.common.util.Validator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -19,7 +21,7 @@ import lombok.NoArgsConstructor;
     name = "social_media",
     uniqueConstraints = {
         @UniqueConstraint(
-            columnNames= {"owner_id", "owner_type", "media_type"}
+            columnNames = {"owner_id", "owner_type", "media_type"}
         )
     }
 )
@@ -47,14 +49,18 @@ public class SocialMedia extends BaseTimeEntity {
     private String url;
 
     public SocialMedia(Long id, Long ownerId, OwnerType ownerType, SocialMediaType mediaType, String name,
-                       String logoUrl,
-                       String url) {
+                       String logoUrl, String url) {
+        Validator.notNull(ownerId, "ownerId");
+        Validator.notNull(ownerType, "ownerType");
+        Validator.notNull(mediaType, "mediaType");
+        Validator.notBlank(name, "name");
+        Validator.notBlank(url, "url");
         this.id = id;
         this.ownerId = ownerId;
         this.ownerType = ownerType;
         this.mediaType = mediaType;
         this.name = name;
-        this.logoUrl = logoUrl;
+        this.logoUrl = ImageUrlHelper.getBlankStringIfBlank(logoUrl);
         this.url = url;
     }
 
@@ -64,10 +70,12 @@ public class SocialMedia extends BaseTimeEntity {
     }
 
     public void changeName(String name) {
+        Validator.notBlank(name, "name");
         this.name = name;
     }
 
     public void changeUrl(String url) {
+        Validator.notBlank(url, "url");
         this.url = url;
     }
 

--- a/backend/src/test/java/com/festago/member/domain/MemberTest.java
+++ b/backend/src/test/java/com/festago/member/domain/MemberTest.java
@@ -91,7 +91,6 @@ class MemberTest {
         Member actual = new Member("12345", SocialType.FESTAGO, "nickname", profileImage);
 
         // when & then
-        assertThat(actual.getProfileImage()).isNotNull();
-        assertThat(actual.getProfileImage()).isNotBlank();
+        assertThat(actual.getProfileImage()).isEmpty();
     }
 }

--- a/backend/src/test/java/com/festago/school/domain/SchoolTest.java
+++ b/backend/src/test/java/com/festago/school/domain/SchoolTest.java
@@ -27,7 +27,7 @@ class SchoolTest {
             String domain = "1".repeat(51);
 
             // when & then
-            assertThatThrownBy(() -> new School(domain, "테코대학교", SchoolRegion.서울))
+            assertThatThrownBy(() -> new School(domain, "테코대학교", "", "", SchoolRegion.서울))
                 .isInstanceOf(ValidException.class);
         }
 
@@ -36,7 +36,7 @@ class SchoolTest {
         @ValueSource(strings = {"", " ", "\t", "\n"})
         void 도메인이_null_또는_공백이면_예외(String domain) {
             // when & then
-            assertThatThrownBy(() -> new School(domain, "테코대학교", SchoolRegion.서울))
+            assertThatThrownBy(() -> new School(domain, "테코대학교", "", "", SchoolRegion.서울))
                 .isInstanceOf(ValidException.class);
         }
 
@@ -47,7 +47,7 @@ class SchoolTest {
             String domain = "1".repeat(length);
 
             // when
-            School school = new School(domain, "테코대학교", SchoolRegion.서울);
+            School school = new School(domain, "테코대학교", "", "", SchoolRegion.서울);
 
             // then
             assertThat(school.getDomain()).isEqualTo(domain);
@@ -59,7 +59,7 @@ class SchoolTest {
             String name = "1".repeat(256);
 
             // when & then
-            assertThatThrownBy(() -> new School("teco.ac.kr", name, SchoolRegion.서울))
+            assertThatThrownBy(() -> new School("teco.ac.kr", name, "", "", SchoolRegion.서울))
                 .isInstanceOf(ValidException.class);
         }
 
@@ -68,7 +68,7 @@ class SchoolTest {
         @ValueSource(strings = {"", " ", "\t", "\n"})
         void 이름이_null_또는_공백이면_예외(String name) {
             // when & then
-            assertThatThrownBy(() -> new School("teco.ac.kr", name, SchoolRegion.서울))
+            assertThatThrownBy(() -> new School("teco.ac.kr", name, "", "", SchoolRegion.서울))
                 .isInstanceOf(ValidException.class);
         }
 
@@ -79,7 +79,7 @@ class SchoolTest {
             String name = "1".repeat(length);
 
             // when
-            School school = new School("teco.ac.kr", name, SchoolRegion.서울);
+            School school = new School("teco.ac.kr", name, "", "", SchoolRegion.서울);
 
             // then
             assertThat(school.getName()).isEqualTo(name);
@@ -91,20 +91,20 @@ class SchoolTest {
             SchoolRegion region = null;
 
             // when & then
-            assertThatThrownBy(() -> new School("teco.ac.kr", "테코대학교", region))
+            assertThatThrownBy(() -> new School("teco.ac.kr", "테코대학교", "", "", region))
                 .isInstanceOf(ValidException.class);
         }
 
         @ParameterizedTest
         @NullSource
         @ValueSource(strings = {"", " ", "\t", "\n"})
-        void logoUrl이_null_또는_공백이어도_성공(String logoUrl) {
+        void logoUrl이_null_또는_공백이면_기본값이_할당된다(String logoUrl) {
             // when
             School school = new School(1L, "teco.ac.kr", "테코대학교", logoUrl, "https://image.com/backgroundImage.png",
                 SchoolRegion.서울);
 
             // then
-            assertThat(school.getLogoUrl()).isNotBlank();
+            assertThat(school.getLogoUrl()).isEmpty();
         }
 
         @ParameterizedTest
@@ -136,13 +136,13 @@ class SchoolTest {
         @ParameterizedTest
         @NullSource
         @ValueSource(strings = {"", " ", "\t", "\n"})
-        void backgroundImageUrl이_null_또는_공백이어도_성공(String backgroundImageUrl) {
+        void backgroundImageUrl이_null_또는_공백이면_기본값이_할당된다(String backgroundImageUrl) {
             // when
             School school = new School(1L, "teco.ac.kr", "테코대학교", "https://image.com/logo.png", backgroundImageUrl,
                 SchoolRegion.서울);
 
             // then
-            assertThat(school.getBackgroundUrl()).isNotBlank();
+            assertThat(school.getBackgroundUrl()).isEmpty();
         }
 
         @ParameterizedTest
@@ -295,12 +295,12 @@ class SchoolTest {
         @ParameterizedTest
         @NullSource
         @ValueSource(strings = {"", " ", "\t", "\n"})
-        void logoUrl이_null_또는_공백이어도_성공(String logoUrl) {
+        void logoUrl이_null_또는_공백이면_기본값이_할당된다(String logoUrl) {
             // when
             school.changeLogoUrl(logoUrl);
 
             // then
-            assertThat(school.getLogoUrl()).isNotBlank();
+            assertThat(school.getLogoUrl()).isEmpty();
         }
 
         @ParameterizedTest
@@ -328,12 +328,12 @@ class SchoolTest {
         @ParameterizedTest
         @NullSource
         @ValueSource(strings = {"", " ", "\t", "\n"})
-        void backgroundImageUrl이_null_또는_공백이어도_성공(String backgroundImageUrl) {
+        void backgroundImageUrl이_null_또는_공백이면_기본값이_할당된다(String backgroundImageUrl) {
             // when
             school.changeBackgroundImageUrl(backgroundImageUrl);
 
             // then
-            assertThat(school.getBackgroundUrl()).isNotBlank();
+            assertThat(school.getBackgroundUrl()).isEmpty();
         }
 
         @ParameterizedTest


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #952

## ✨ PR 세부 내용

도메인에 대해 기본 이미지에 대한 정책을 빈 문자열("")으로 설정했습니다.

따라서 모든 엔티티 생성, 수정 요청 시 이미지 필드는 nullable 하도록 변경하였습니다.