### PR TITLE
[BE] feat: Uploaded 상태로 오래되거나 Abandoned 상태의 UploadFile을 삭제하는 기능 추가 (#956)

### DIFF
--- a/backend/src/main/java/com/festago/admin/dto/upload/AdminDeleteAbandonedPeriodUploadFileV1Request.java
+++ b/backend/src/main/java/com/festago/admin/dto/upload/AdminDeleteAbandonedPeriodUploadFileV1Request.java
@@ -1,0 +1,11 @@
+package com.festago.admin.dto.upload;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record AdminDeleteAbandonedPeriodUploadFileV1Request(
+    @NotNull LocalDateTime startTime,
+    @NotNull LocalDateTime endTime
+) {
+
+}

--- a/backend/src/main/java/com/festago/admin/presentation/v1/AdminUploadFileDeleteV1Controller.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/AdminUploadFileDeleteV1Controller.java
@@ -1,0 +1,37 @@
+package com.festago.admin.presentation.v1;
+
+import com.festago.admin.dto.upload.AdminDeleteAbandonedPeriodUploadFileV1Request;
+import com.festago.upload.application.UploadFileDeleteService;
+import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/api/v1/upload/delete")
+@RequiredArgsConstructor
+@Hidden
+public class AdminUploadFileDeleteV1Controller {
+
+    private final UploadFileDeleteService uploadFileDeleteService;
+
+    @DeleteMapping("/abandoned-period")
+    public ResponseEntity<Void> deleteAbandonedWithPeriod(
+        @RequestBody @Valid AdminDeleteAbandonedPeriodUploadFileV1Request request
+    ) {
+        uploadFileDeleteService.deleteAbandonedStatusWithPeriod(request.startTime(), request.endTime());
+        return ResponseEntity.ok()
+            .build();
+    }
+
+    @DeleteMapping("/old-uploaded")
+    public ResponseEntity<Void> deleteOldUploaded() {
+        uploadFileDeleteService.deleteOldUploadedStatus();
+        return ResponseEntity.ok()
+            .build();
+    }
+}

--- a/backend/src/main/java/com/festago/admin/presentation/v1/AdminUploadImageV1Controller.java
+++ b/backend/src/main/java/com/festago/admin/presentation/v1/AdminUploadImageV1Controller.java
@@ -18,7 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/admin/api/v1/upload/images")
 @RequiredArgsConstructor
 @Hidden
-public class AdminUploadV1Controller {
+public class AdminUploadImageV1Controller {
 
     private final ImageFileUploadService imageFileUploadService;
 

--- a/backend/src/main/java/com/festago/upload/application/UploadFileDeleteService.java
+++ b/backend/src/main/java/com/festago/upload/application/UploadFileDeleteService.java
@@ -1,0 +1,38 @@
+package com.festago.upload.application;
+
+import com.festago.upload.domain.StorageClient;
+import com.festago.upload.domain.UploadFile;
+import com.festago.upload.domain.UploadStatus;
+import com.festago.upload.repository.UploadFileRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UploadFileDeleteService {
+
+    private final StorageClient storageClient;
+    private final UploadFileRepository uploadFileRepository;
+    private final Clock clock;
+
+    public void deleteAbandonedStatusWithPeriod(LocalDateTime startTime, LocalDateTime endTime) {
+        List<UploadFile> uploadFiles = uploadFileRepository.findByCreatedAtBetweenAndStatus(startTime, endTime, UploadStatus.ABANDONED);
+        deleteUploadFiles(uploadFiles);
+    }
+
+    private void deleteUploadFiles(List<UploadFile> uploadFiles) {
+        storageClient.delete(uploadFiles);
+        uploadFileRepository.deleteByIn(uploadFiles);
+    }
+
+    public void deleteOldUploadedStatus() {
+        LocalDateTime yesterday = LocalDateTime.now(clock).minusDays(1);
+        List<UploadFile> uploadFiles = uploadFileRepository.findByCreatedAtBeforeAndStatus(yesterday, UploadStatus.UPLOADED);
+        deleteUploadFiles(uploadFiles);
+    }
+}

--- a/backend/src/main/java/com/festago/upload/domain/StorageClient.java
+++ b/backend/src/main/java/com/festago/upload/domain/StorageClient.java
@@ -1,15 +1,24 @@
 package com.festago.upload.domain;
 
+import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface StorageClient {
 
     /**
-     * MultipartFile을 보관(영속)하는 클래스 <br/> 업로드 작업이 끝나면, 업로드한 파일의 정보를 가진 UploadStatus.UPLOADED 상태의 UploadFile를 반환해야 한다.
-     * <br/> 반환된 UploadFile을 영속하는 책임은 해당 클래스를 사용하는 클라이언트가 구현해야 한다. <br/>
+     * MultipartFile을 보관(영속)하는 메서드 <br/> 업로드 작업이 끝나면, 업로드한 파일의 정보를 가진 UploadStatus.UPLOADED 상태의 UploadFile를 반환해야 한다.
+     * <br/> 반환된 UploadFile을 영속하는 책임은 해당 메서드를 사용하는 클라이언트가 구현해야 한다. <br/>
      *
      * @param file 업로드 할 MultipartFile
      * @return UploadStatus.PENDING 상태의 영속되지 않은 UploadFile 엔티티
      */
     UploadFile storage(MultipartFile file);
+
+    /**
+     * 업로드 파일을 삭제하는 메서드 <br/> 삭제 작업이 끝나면, UploadFile이 가진 정보에 대한 업로드 된 파일이 없으므로, 인자로 들어온 UploadFiles를 삭제해야 한다. <br/> 삭제가
+     * 끝나고 UploadFile을 삭제하는 책임은 해당 메서드를 사용하는 클라이언트가 구현해야 한다. <br/>
+     *
+     * @param uploadFiles 삭제하려는 업로드 된 파일의 정보가 담긴 UploadFile 목록
+     */
+    void delete(List<UploadFile> uploadFiles);
 }

--- a/backend/src/main/java/com/festago/upload/infrastructure/R2StorageClient.java
+++ b/backend/src/main/java/com/festago/upload/infrastructure/R2StorageClient.java
@@ -76,11 +76,11 @@ public class R2StorageClient implements StorageClient {
             String mimeType = uploadFile.getMimeType().toString();
             RequestBody requestBody = RequestBody.fromContentProvider(() -> inputStream, fileSize, mimeType);
             UUID uploadFileId = uploadFile.getId();
-            log.info("파일 업로드 시작. id = {}, uploadUri={}, size={}", uploadFileId, uploadFile.getUploadUri(), fileSize);
+            log.info("파일 업로드 시작. id={}, uploadUri={}, size={}", uploadFileId, uploadFile.getUploadUri(), fileSize);
             s3Client.putObject(objectRequest, requestBody);
-            log.info("파일 업로드 완료. id = {}", uploadFileId);
+            log.info("파일 업로드 완료. id={}", uploadFileId);
         } catch (IOException e) {
-            log.warn("파일 업로드 중 문제가 발생했습니다. id = {}", uploadFile.getId());
+            log.warn("파일 업로드 중 문제가 발생했습니다. id={}", uploadFile.getId());
             throw new InternalServerException(ErrorCode.FILE_UPLOAD_ERROR, e);
         }
     }

--- a/backend/src/main/java/com/festago/upload/infrastructure/R2StorageClient.java
+++ b/backend/src/main/java/com/festago/upload/infrastructure/R2StorageClient.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,7 +21,11 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Error;
 
 @Slf4j
 @Component
@@ -78,5 +83,37 @@ public class R2StorageClient implements StorageClient {
             log.warn("파일 업로드 중 문제가 발생했습니다. id = {}", uploadFile.getId());
             throw new InternalServerException(ErrorCode.FILE_UPLOAD_ERROR, e);
         }
+    }
+
+    @Override
+    public void delete(List<UploadFile> uploadFiles) {
+        if (uploadFiles.isEmpty()) {
+            log.info("삭제하려는 파일이 없습니다.");
+            return;
+        }
+        int fileSize = uploadFiles.size();
+        UUID firstFileId = uploadFiles.get(0).getId();
+        DeleteObjectsRequest deleteObjectsRequest = getDeleteObjectsRequest(uploadFiles);
+
+        log.info("{}개 파일 삭제 시작. 첫 번째 파일 식별자={}", fileSize, firstFileId);
+        DeleteObjectsResponse response = s3Client.deleteObjects(deleteObjectsRequest);
+        log.info("{}개 파일 삭제 완료. 첫 번째 파일 식별자={}", fileSize, firstFileId);
+
+        if (response.hasErrors()) {
+            List<S3Error> errors = response.errors();
+            log.warn("{}개 파일 삭제 중 에러가 발생했습니다. 첫 번째 파일 식별자={}, 에러 개수={}", fileSize, firstFileId, errors.size());
+            errors.forEach(error -> log.info("파일 삭제 중 에러가 발생했습니다. key={}, message={}", error.key(), error.message()));
+        }
+    }
+
+    private DeleteObjectsRequest getDeleteObjectsRequest(List<UploadFile> uploadFiles) {
+        List<ObjectIdentifier> objectIdentifiers = uploadFiles.stream()
+            .map(UploadFile::getName)
+            .map(name -> ObjectIdentifier.builder().key(name).build())
+            .toList();
+        return DeleteObjectsRequest.builder()
+            .bucket(bucket)
+            .delete(builder -> builder.objects(objectIdentifiers).build())
+            .build();
     }
 }

--- a/backend/src/main/java/com/festago/upload/repository/UploadFileRepository.java
+++ b/backend/src/main/java/com/festago/upload/repository/UploadFileRepository.java
@@ -2,11 +2,16 @@ package com.festago.upload.repository;
 
 import com.festago.upload.domain.FileOwnerType;
 import com.festago.upload.domain.UploadFile;
+import com.festago.upload.domain.UploadStatus;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 public interface UploadFileRepository extends Repository<UploadFile, UUID> {
 
@@ -17,4 +22,13 @@ public interface UploadFileRepository extends Repository<UploadFile, UUID> {
     List<UploadFile> findAllByOwnerIdAndOwnerType(Long ownerId, FileOwnerType ownerType);
 
     List<UploadFile> findByIdIn(Collection<UUID> ids);
+
+    List<UploadFile> findByCreatedAtBetweenAndStatus(LocalDateTime startTime, LocalDateTime endTime,
+                                                     UploadStatus status);
+
+    List<UploadFile> findByCreatedAtBeforeAndStatus(LocalDateTime createdAt, UploadStatus status);
+
+    @Modifying
+    @Query("delete from UploadFile uf where uf in :uploadFiles")
+    void deleteByIn(@Param("uploadFiles") List<UploadFile> uploadFiles);
 }

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminUploadFileDeleteV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminUploadFileDeleteV1ControllerTest.java
@@ -1,0 +1,114 @@
+package com.festago.admin.presentation.v1;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festago.admin.dto.upload.AdminDeleteAbandonedPeriodUploadFileV1Request;
+import com.festago.auth.domain.Role;
+import com.festago.support.CustomWebMvcTest;
+import com.festago.support.WithMockAuth;
+import jakarta.servlet.http.Cookie;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class AdminUploadFileDeleteV1ControllerTest {
+
+    private static final Cookie TOKEN_COOKIE = new Cookie("token", "token");
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Nested
+    class ABANDONED_상태와_기간에_포함되는_파일_삭제 {
+
+        final String uri = "/admin/api/v1/upload/delete/abandoned-period";
+
+        @Nested
+        @DisplayName("DELETE " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                // given
+                LocalDateTime now = LocalDateTime.now();
+                var request = new AdminDeleteAbandonedPeriodUploadFileV1Request(now, now);
+
+                // when & then
+                mockMvc.perform(delete(uri)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(delete(uri))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(delete(uri)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
+
+    @Nested
+    class 오래된_UPLOADED_상태_파일_삭제 {
+
+        final String uri = "/admin/api/v1/upload/delete/old-uploaded";
+
+        @Nested
+        @DisplayName("DELETE " + uri)
+        class 올바른_주소로 {
+
+            @Test
+            @WithMockAuth(role = Role.ADMIN)
+            void 요청을_보내면_200_응답이_반환된다() throws Exception {
+                // given
+                // when & then
+                mockMvc.perform(delete(uri)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isOk());
+            }
+
+            @Test
+            void 토큰_없이_보내면_401_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(delete(uri))
+                    .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @WithMockAuth(role = Role.MEMBER)
+            void 토큰의_권한이_Admin이_아니면_404_응답이_반환된다() throws Exception {
+                // when & then
+                mockMvc.perform(delete(uri)
+                        .cookie(TOKEN_COOKIE))
+                    .andExpect(status().isNotFound());
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/admin/presentation/v1/AdminUploadImageV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/admin/presentation/v1/AdminUploadImageV1ControllerTest.java
@@ -28,7 +28,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @CustomWebMvcTest
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class AdminUploadV1ControllerTest {
+class AdminUploadImageV1ControllerTest {
 
     private static final Cookie TOKEN_COOKIE = new Cookie("token", "token");
 

--- a/backend/src/test/java/com/festago/upload/application/UploadFileDeleteServiceTest.java
+++ b/backend/src/test/java/com/festago/upload/application/UploadFileDeleteServiceTest.java
@@ -1,0 +1,147 @@
+package com.festago.upload.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.spy;
+
+import com.festago.support.TimeInstantProvider;
+import com.festago.support.fixture.UploadFileFixture;
+import com.festago.upload.domain.UploadFile;
+import com.festago.upload.infrastructure.FakeStorageClient;
+import com.festago.upload.repository.MemoryUploadFileRepository;
+import com.festago.upload.repository.UploadFileRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class UploadFileDeleteServiceTest {
+
+    UploadFileDeleteService uploadFileDeleteService;
+
+    UploadFileRepository uploadFileRepository;
+
+    Clock clock;
+
+    @BeforeEach
+    void setUp() {
+        uploadFileRepository = new MemoryUploadFileRepository();
+        clock = spy(Clock.systemDefaultZone());
+        uploadFileDeleteService = new UploadFileDeleteService(
+            new FakeStorageClient(),
+            uploadFileRepository,
+            clock
+        );
+    }
+
+    @Nested
+    class deleteAbandonedStatusWithPeriod {
+
+        LocalDateTime _6월_30일_18시_0분_0초 = LocalDateTime.parse("2077-06-30T18:00:00");
+        LocalDateTime _6월_30일_18시_0분_1초 = LocalDateTime.parse("2077-06-30T18:00:01");
+        LocalDateTime _6월_30일_18시_0분_2초 = LocalDateTime.parse("2077-06-30T18:00:02");
+
+        @Test
+        void 삭제되는_파일은_시작일에_포함되고_종료일에도_포함된다() {
+            // given
+            UploadFile _6월_30일_18시_0분_0초_생성된_파일 = uploadFileRepository.save(
+                UploadFileFixture.builder().createdAt(_6월_30일_18시_0분_0초).buildAbandoned());
+            UploadFile _6월_30일_18시_0분_1초_생성된_파일 = uploadFileRepository.save(
+                UploadFileFixture.builder().createdAt(_6월_30일_18시_0분_1초).buildAbandoned());
+            UploadFile _6월_30일_18시_0분_2초_생성된_파일 = uploadFileRepository.save(
+                UploadFileFixture.builder().createdAt(_6월_30일_18시_0분_2초).buildAbandoned());
+
+            // when
+            uploadFileDeleteService.deleteAbandonedStatusWithPeriod(_6월_30일_18시_0분_0초, _6월_30일_18시_0분_1초);
+
+            // then
+            var expect = uploadFileRepository.findByIdIn(List.of(
+                _6월_30일_18시_0분_0초_생성된_파일.getId(),
+                _6월_30일_18시_0분_1초_생성된_파일.getId(),
+                _6월_30일_18시_0분_2초_생성된_파일.getId()
+            ));
+            assertThat(expect)
+                .map(UploadFile::getId)
+                .containsExactly(_6월_30일_18시_0분_2초_생성된_파일.getId());
+        }
+
+        @Test
+        void ABANDONED_상태의_파일만_삭제된다() {
+            // given
+            UploadFile UPLOADED_상태_파일 = uploadFileRepository.save(
+                UploadFileFixture.builder().createdAt(_6월_30일_18시_0분_0초).build());
+            UploadFile ABANDONED_상태_파일 = uploadFileRepository.save(
+                UploadFileFixture.builder().createdAt(_6월_30일_18시_0분_0초).buildAbandoned());
+
+            // when
+            uploadFileDeleteService.deleteAbandonedStatusWithPeriod(_6월_30일_18시_0분_0초, _6월_30일_18시_0분_0초);
+
+            // then
+            assertThat(uploadFileRepository.findById(UPLOADED_상태_파일.getId())).isPresent();
+            assertThat(uploadFileRepository.findById(ABANDONED_상태_파일.getId())).isEmpty();
+        }
+    }
+
+    @Nested
+    class deleteOldUploadedStatus {
+
+        LocalDateTime _6월_29일_17시_59분_59초 = LocalDateTime.parse("2077-06-29T17:59:59");
+        LocalDateTime _6월_29일_18시_0분_0초 = LocalDateTime.parse("2077-06-29T18:00:00");
+        LocalDateTime _6월_29일_18시_0분_1초 = LocalDateTime.parse("2077-06-29T18:00:01");
+        LocalDateTime _6월_30일_18시_0분_1초 = LocalDateTime.parse("2077-06-30T18:00:01");
+
+        @Test
+        void 생성된지_정확히_하루가_지난_파일만_삭제된다() {
+            // given
+            UploadFile _6월_29일_17시_59분_59초_생성된_파일 = uploadFileRepository.save(
+                UploadFileFixture.builder().createdAt(_6월_29일_17시_59분_59초).build());
+            UploadFile _6월_29일_18시_0분_0초_생성된_파일 = uploadFileRepository.save(
+                UploadFileFixture.builder().createdAt(_6월_29일_18시_0분_0초).build());
+            UploadFile _6월_29일_18시_0분_1초_생성된_파일 = uploadFileRepository.save(
+                UploadFileFixture.builder().createdAt(_6월_29일_18시_0분_1초).build());
+
+            LocalDateTime now = _6월_30일_18시_0분_1초;
+            given(clock.instant())
+                .willReturn(TimeInstantProvider.from(now));
+
+            // when
+            uploadFileDeleteService.deleteOldUploadedStatus();
+
+            // then
+            var expect = uploadFileRepository.findByIdIn(List.of(
+                _6월_29일_17시_59분_59초_생성된_파일.getId(),
+                _6월_29일_18시_0분_0초_생성된_파일.getId(),
+                _6월_29일_18시_0분_1초_생성된_파일.getId()
+            ));
+            assertThat(expect)
+                .map(UploadFile::getId)
+                .containsExactly(_6월_29일_18시_0분_1초_생성된_파일.getId());
+        }
+
+        @Test
+        void UPLOADED_상태의_파일만_삭제된다() {
+            // given
+            UploadFile UPLOADED_상태_파일 = uploadFileRepository.save(
+                UploadFileFixture.builder().createdAt(_6월_29일_18시_0분_0초).build());
+            UploadFile ABANDONED_상태_파일 = uploadFileRepository.save(
+                UploadFileFixture.builder().createdAt(_6월_29일_18시_0분_0초).buildAbandoned());
+
+            LocalDateTime now = _6월_30일_18시_0분_1초;
+            given(clock.instant())
+                .willReturn(TimeInstantProvider.from(now));
+
+            // when
+            uploadFileDeleteService.deleteOldUploadedStatus();
+
+            // then
+            assertThat(uploadFileRepository.findById(UPLOADED_상태_파일.getId())).isEmpty();
+            assertThat(uploadFileRepository.findById(ABANDONED_상태_파일.getId())).isPresent();
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/upload/infrastructure/FakeStorageClient.java
+++ b/backend/src/test/java/com/festago/upload/infrastructure/FakeStorageClient.java
@@ -3,6 +3,7 @@ package com.festago.upload.infrastructure;
 import com.festago.support.fixture.UploadFileFixture;
 import com.festago.upload.domain.StorageClient;
 import com.festago.upload.domain.UploadFile;
+import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public class FakeStorageClient implements StorageClient {
@@ -10,5 +11,10 @@ public class FakeStorageClient implements StorageClient {
     @Override
     public UploadFile storage(MultipartFile file) {
         return UploadFileFixture.builder().build();
+    }
+
+    @Override
+    public void delete(List<UploadFile> uploadFiles) {
+        // NOOP
     }
 }

--- a/backend/src/test/java/com/festago/upload/repository/MemoryUploadFileRepository.java
+++ b/backend/src/test/java/com/festago/upload/repository/MemoryUploadFileRepository.java
@@ -2,6 +2,8 @@ package com.festago.upload.repository;
 
 import com.festago.upload.domain.FileOwnerType;
 import com.festago.upload.domain.UploadFile;
+import com.festago.upload.domain.UploadStatus;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -37,5 +39,30 @@ public class MemoryUploadFileRepository implements UploadFileRepository {
         return memory.values().stream()
             .filter(uploadFile -> ids.contains(uploadFile.getId()))
             .toList();
+    }
+
+    @Override
+    public List<UploadFile> findByCreatedAtBetweenAndStatus(LocalDateTime startTime, LocalDateTime endTime,
+                                                            UploadStatus status) {
+        return memory.values().stream()
+            .filter(it -> it.getStatus() == status)
+            .filter(it -> it.getCreatedAt().isEqual(startTime) || it.getCreatedAt().isAfter(startTime))
+            .filter(it -> it.getCreatedAt().isEqual(endTime) || it.getCreatedAt().isBefore(endTime))
+            .toList();
+    }
+
+    @Override
+    public List<UploadFile> findByCreatedAtBeforeAndStatus(LocalDateTime createdAt, UploadStatus status) {
+        return memory.values().stream()
+            .filter(it -> it.getStatus() == status)
+            .filter(it -> it.getCreatedAt().isBefore(createdAt))
+            .toList();
+    }
+
+    @Override
+    public void deleteByIn(List<UploadFile> uploadFiles) {
+        for (UploadFile uploadFile : uploadFiles) {
+            memory.remove(uploadFile.getId());
+        }
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #956

## ✨ PR 세부 내용

Uploaded 상태로 오래되거나 Abandoned 상태의 UploadFile을 삭제하는 기능을 추가했습니다.

파일을 삭제할 때 `S3Client.deleteObject()` 메서드를 사용하지 않고 `S3Client.deleteObjects()` 메서드를 사용했습니다.

이유는 파일을 삭제할 때, 요청을 한 번씩 여러 번 보내는 것 보다, 한 번의 요청으로 모든 파일을 삭제하는 것이 효율적이라고 판단했습니다.

그에 따라 실패한 요청이 있을 수 있으므로 에러가 있는지 확인하고, 에러가 있으면 로그를 남기는 식으로 구현했습니다.
(FCM과 비슷하네요. Javadoc에 `that if the object specified in the request is not found, Amazon S3 returns the result as deleted` 라는 내용이 있습니다. 따라서 권한 문제가 아니라면 에러가 날 일이 있을까 싶네요 😂)
 
파일을 삭제하면, DB 데이터도 당연히 삭제를 해야하는데, JPA의 `Query Creation` 기능을 사용하지 않고, `@Query` 어노테이션을 사용하여 JPQL로 작성했습니다.

이유는 Query Creation 기능을 사용하면 in절로 사용을 했다고 생각했지만, delete 쿼리가 별도로 날아갑니다..!

![image](https://github.com/woowacourse-teams/2023-festa-go/assets/116627736/30fda568-bf05-45ef-9bf8-d7483a3e3592)

이에 대한 자세한 내용은 [동욱님 블로그](https://jojoldu.tistory.com/235) 참고하시면 될 것 같습니다.

덤으로 바로 `List<UploadFile>` 타입을 넘길 수 있어서도 있습니다. 😂

그 외 삭제할 대상을 찾기 위해 `findByCreatedAtBetweenAndStatus()`, `findByCreatedAtBeforeAndStatus()` 메서드가 생겼습니다.

해당 메서드는 ANSI 표준을 따르므로 비즈니스 로직이 쿼리에 의존적이지 않기 때문에 굳이 실제 MySQL 구현체를 사용한 통합 테스트를 진행하지 않고, 메모리를 사용한 단위 테스트로 진행했습니다.

실제 파일이 삭제되는지, 테스트 코드로 확인이 불가능하기에 요청을 직접 날려봤는데, 우선 삭제는 잘 됩니다.

![image](https://github.com/woowacourse-teams/2023-festa-go/assets/116627736/ad4d6923-65a0-40fc-8959-8f804930d69c)

머지 되고나서, 개발 환경에 제대로 삭제가 되는지 테스트가 필요합니다!