### PR TITLE
[BE] fix: Swagger 문서에 잘못된 Parameter 수정 및 형식 통일 (#959)

### DIFF
--- a/backend/src/main/java/com/festago/artist/application/ArtistDetailV1QueryService.java
+++ b/backend/src/main/java/com/festago/artist/application/ArtistDetailV1QueryService.java
@@ -1,7 +1,7 @@
 package com.festago.artist.application;
 
 import com.festago.artist.dto.ArtistDetailV1Response;
-import com.festago.artist.dto.ArtistFestivalDetailV1Response;
+import com.festago.artist.dto.ArtistFestivalV1Response;
 import com.festago.artist.repository.ArtistDetailV1QueryDslRepository;
 import com.festago.artist.repository.ArtistFestivalSearchCondition;
 import com.festago.common.exception.ErrorCode;
@@ -27,9 +27,9 @@ public class ArtistDetailV1QueryService {
             .orElseThrow(() -> new NotFoundException(ErrorCode.ARTIST_NOT_FOUND));
     }
 
-    public Slice<ArtistFestivalDetailV1Response> findArtistFestivals(Long artistId, Long lastFestivalId,
-                                                                     LocalDate lastStartDate, boolean isPast,
-                                                                     Pageable pageable) {
+    public Slice<ArtistFestivalV1Response> findArtistFestivals(Long artistId, Long lastFestivalId,
+                                                               LocalDate lastStartDate, boolean isPast,
+                                                               Pageable pageable) {
         return artistDetailV1QueryDslRepository.findArtistFestivals(new ArtistFestivalSearchCondition(
                 artistId,
                 isPast,

--- a/backend/src/main/java/com/festago/artist/dto/ArtistFestivalV1Response.java
+++ b/backend/src/main/java/com/festago/artist/dto/ArtistFestivalV1Response.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
-public record ArtistFestivalDetailV1Response(
+public record ArtistFestivalV1Response(
     Long id,
     String name,
     LocalDate startDate,
@@ -19,7 +19,7 @@ public record ArtistFestivalDetailV1Response(
 ) {
 
     @QueryProjection
-    public ArtistFestivalDetailV1Response {
+    public ArtistFestivalV1Response {
 
     }
 }

--- a/backend/src/main/java/com/festago/artist/dto/ArtistMediaV1Response.java
+++ b/backend/src/main/java/com/festago/artist/dto/ArtistMediaV1Response.java
@@ -1,9 +1,10 @@
 package com.festago.artist.dto;
 
+import com.festago.socialmedia.domain.SocialMediaType;
 import com.querydsl.core.annotations.QueryProjection;
 
 public record ArtistMediaV1Response(
-    String type,
+    SocialMediaType type,
     String name,
     String logoUrl,
     String url

--- a/backend/src/main/java/com/festago/artist/presentation/v1/ArtistDetailV1Controller.java
+++ b/backend/src/main/java/com/festago/artist/presentation/v1/ArtistDetailV1Controller.java
@@ -10,9 +10,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,24 +28,24 @@ public class ArtistDetailV1Controller {
     private final ArtistDetailV1QueryService artistDetailV1QueryService;
 
     @GetMapping("/{artistId}")
-    @Operation(description = "아티스트의 정보를 조회한다.")
+    @Operation(description = "아티스트의 정보를 조회한다.", summary = "아티스트 정보 조회")
     public ResponseEntity<ArtistDetailV1Response> getArtistInfo(@PathVariable Long artistId) {
         return ResponseEntity.ok(artistDetailV1QueryService.findArtistDetail(artistId));
     }
 
     @GetMapping("/{artistId}/festivals")
-    @Operation(description = "아티스트가 참석한 축제를 조회한다. isPast 값으로 종료 축제 와 진행, 예정 축제를 구분 가능하다", summary = "아티스트 축제 조회")
+    @Operation(description = "아티스트가 참석한 축제를 조회한다. isPast 값으로 종료 축제와 진행, 예정 축제를 구분 가능하다. 0 < size <= 20", summary = "아티스트 축제 조회")
     @ValidPageable(maxSize = 20)
     public ResponseEntity<SliceResponse<ArtistFestivalDetailV1Response>> getArtistInfo(
         @PathVariable Long artistId,
         @RequestParam(required = false) Long lastFestivalId,
         @RequestParam(required = false) LocalDate lastStartDate,
         @RequestParam(required = false, defaultValue = "false") boolean isPast,
-        @PageableDefault(size = 10) Pageable pageable
+        @RequestParam(defaultValue = "10") int size
     ) {
         validate(lastFestivalId, lastStartDate);
         Slice<ArtistFestivalDetailV1Response> response = artistDetailV1QueryService.findArtistFestivals(artistId,
-            lastFestivalId, lastStartDate, isPast, pageable);
+            lastFestivalId, lastStartDate, isPast, PageRequest.ofSize(size));
         return ResponseEntity.ok(SliceResponse.from(response));
     }
 

--- a/backend/src/main/java/com/festago/artist/presentation/v1/ArtistSearchV1Controller.java
+++ b/backend/src/main/java/com/festago/artist/presentation/v1/ArtistSearchV1Controller.java
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/search/artists")
-@Tag(name = "아티스트 검색 V1")
+@Tag(name = "아티스트 검색 요청 V1")
 @RequiredArgsConstructor
 public class ArtistSearchV1Controller {
 
     private final ArtistTotalSearchV1Service artistTotalSearchV1Service;
 
     @GetMapping
-    @Operation(description = "키워드로 아티스트 목록을 검색한다", summary = "아티스트 목록 검색 조회")
+    @Operation(description = "키워드로 아티스트 목록을 검색한다.", summary = "아티스트 검색")
     public ResponseEntity<List<ArtistTotalSearchV1Response>> searchByKeyword(@RequestParam String keyword) {
         Validator.notBlank(keyword, "keyword");
         List<ArtistTotalSearchV1Response> response = artistTotalSearchV1Service.findAllByKeyword(keyword);

--- a/backend/src/main/java/com/festago/artist/presentation/v1/ArtistV1Controller.java
+++ b/backend/src/main/java/com/festago/artist/presentation/v1/ArtistV1Controller.java
@@ -2,11 +2,12 @@ package com.festago.artist.presentation.v1;
 
 import com.festago.artist.application.ArtistDetailV1QueryService;
 import com.festago.artist.dto.ArtistDetailV1Response;
-import com.festago.artist.dto.ArtistFestivalDetailV1Response;
+import com.festago.artist.dto.ArtistFestivalV1Response;
 import com.festago.common.aop.ValidPageable;
 import com.festago.common.dto.SliceResponse;
 import com.festago.common.exception.ValidException;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -23,28 +24,28 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/artists")
 @Tag(name = "아티스트 정보 요청 V1")
 @RequiredArgsConstructor
-public class ArtistDetailV1Controller {
+public class ArtistV1Controller {
 
     private final ArtistDetailV1QueryService artistDetailV1QueryService;
 
     @GetMapping("/{artistId}")
     @Operation(description = "아티스트의 정보를 조회한다.", summary = "아티스트 정보 조회")
-    public ResponseEntity<ArtistDetailV1Response> getArtistInfo(@PathVariable Long artistId) {
+    public ResponseEntity<ArtistDetailV1Response> findArtistDetail(@PathVariable Long artistId) {
         return ResponseEntity.ok(artistDetailV1QueryService.findArtistDetail(artistId));
     }
 
     @GetMapping("/{artistId}/festivals")
-    @Operation(description = "아티스트가 참석한 축제를 조회한다. isPast 값으로 종료 축제와 진행, 예정 축제를 구분 가능하다. 0 < size <= 20", summary = "아티스트 축제 조회")
+    @Operation(description = "아티스트가 참여한 축제 목록을 조회한다. isPast 값으로 종료 축제와 진행, 예정 축제를 구분 가능하다.", summary = "아티스트 참여 축제 목록 조회")
     @ValidPageable(maxSize = 20)
-    public ResponseEntity<SliceResponse<ArtistFestivalDetailV1Response>> getArtistInfo(
+    public ResponseEntity<SliceResponse<ArtistFestivalV1Response>> findArtistFestivals(
         @PathVariable Long artistId,
         @RequestParam(required = false) Long lastFestivalId,
         @RequestParam(required = false) LocalDate lastStartDate,
         @RequestParam(required = false, defaultValue = "false") boolean isPast,
-        @RequestParam(defaultValue = "10") int size
+        @Parameter(description = "0 < size <= 20") @RequestParam(defaultValue = "10") int size
     ) {
         validate(lastFestivalId, lastStartDate);
-        Slice<ArtistFestivalDetailV1Response> response = artistDetailV1QueryService.findArtistFestivals(artistId,
+        Slice<ArtistFestivalV1Response> response = artistDetailV1QueryService.findArtistFestivals(artistId,
             lastFestivalId, lastStartDate, isPast, PageRequest.ofSize(size));
         return ResponseEntity.ok(SliceResponse.from(response));
     }

--- a/backend/src/main/java/com/festago/artist/repository/ArtistDetailV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/artist/repository/ArtistDetailV1QueryDslRepository.java
@@ -46,7 +46,7 @@ public class ArtistDetailV1QueryDslRepository extends QueryDslRepositorySupport 
                         artist.backgroundImageUrl,
                         list(
                             new QArtistMediaV1Response(
-                                socialMedia.mediaType.stringValue(),
+                                socialMedia.mediaType,
                                 socialMedia.name,
                                 socialMedia.logoUrl,
                                 socialMedia.url

--- a/backend/src/main/java/com/festago/artist/repository/ArtistDetailV1QueryDslRepository.java
+++ b/backend/src/main/java/com/festago/artist/repository/ArtistDetailV1QueryDslRepository.java
@@ -11,9 +11,9 @@ import static com.querydsl.core.group.GroupBy.list;
 
 import com.festago.artist.domain.Artist;
 import com.festago.artist.dto.ArtistDetailV1Response;
-import com.festago.artist.dto.ArtistFestivalDetailV1Response;
+import com.festago.artist.dto.ArtistFestivalV1Response;
 import com.festago.artist.dto.QArtistDetailV1Response;
-import com.festago.artist.dto.QArtistFestivalDetailV1Response;
+import com.festago.artist.dto.QArtistFestivalV1Response;
 import com.festago.artist.dto.QArtistMediaV1Response;
 import com.festago.common.querydsl.QueryDslRepositorySupport;
 import com.festago.socialmedia.domain.OwnerType;
@@ -63,12 +63,12 @@ public class ArtistDetailV1QueryDslRepository extends QueryDslRepositorySupport 
         return Optional.of(response.get(0));
     }
 
-    public Slice<ArtistFestivalDetailV1Response> findArtistFestivals(ArtistFestivalSearchCondition condition) {
+    public Slice<ArtistFestivalV1Response> findArtistFestivals(ArtistFestivalSearchCondition condition) {
         Pageable pageable = condition.pageable();
         Long artistId = condition.artistId();
         return applySlice(
             pageable,
-            query -> query.select(new QArtistFestivalDetailV1Response(
+            query -> query.select(new QArtistFestivalV1Response(
                     festival.id,
                     festival.name,
                     festival.festivalDuration.startDate,

--- a/backend/src/main/java/com/festago/auth/presentation/v1/MemberAuthV1Controller.java
+++ b/backend/src/main/java/com/festago/auth/presentation/v1/MemberAuthV1Controller.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
-@Tag(name = "회원 인증 V1")
+@Tag(name = "회원 인증 요청 V1")
 public class MemberAuthV1Controller {
 
     private final MemberAuthFacadeService memberAuthFacadeService;

--- a/backend/src/main/java/com/festago/bookmark/presentation/v1/ArtistBookmarkV1Controller.java
+++ b/backend/src/main/java/com/festago/bookmark/presentation/v1/ArtistBookmarkV1Controller.java
@@ -16,14 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/bookmarks/artists")
-@Tag(name = "아티스트 북마크 V1")
+@Tag(name = "아티스트 북마크 요청 V1")
 public class ArtistBookmarkV1Controller {
 
     private final ArtistBookmarkV1QueryService artistBookmarkV1QueryService;
 
     @MemberAuth
     @GetMapping
-    @Operation(description = "유저의 아티스트 북마크 목록을 조회한다.", summary = "아티스트 북마크 조회")
+    @Operation(description = "회원의 아티스트 북마크 목록을 조회한다.", summary = "아티스트 북마크 조회")
     public ResponseEntity<List<ArtistBookmarkV1Response>> findArtistBookmarksByMemberId(
         @Member Long memberId
     ) {

--- a/backend/src/main/java/com/festago/bookmark/presentation/v1/BookmarkManagementV1Controller.java
+++ b/backend/src/main/java/com/festago/bookmark/presentation/v1/BookmarkManagementV1Controller.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/bookmarks")
-@Tag(name = "북마크 등록/삭제 V1")
+@Tag(name = "북마크 등록/삭제 요청 V1")
 public class BookmarkManagementV1Controller {
 
     private final BookmarkFacadeService bookmarkFacadeService;

--- a/backend/src/main/java/com/festago/bookmark/presentation/v1/FestivalBookmarkV1Controller.java
+++ b/backend/src/main/java/com/festago/bookmark/presentation/v1/FestivalBookmarkV1Controller.java
@@ -18,14 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/bookmarks/festivals")
-@Tag(name = "축제 북마크 V1")
+@Tag(name = "축제 북마크 요청 V1")
 public class FestivalBookmarkV1Controller {
 
     private final FestivalBookmarkV1QueryService festivalBookmarkV1QueryService;
 
     @MemberAuth
     @GetMapping("/ids")
-    @Operation(description = "북마크 된 축제의 식별자 목록을 조회한다.", summary = "북마크 된 축제 식별자 목록 조회")
+    @Operation(description = "회원의 북마크 된 축제 식별자 목록을 조회한다.", summary = "북마크 된 축제 식별자 목록 조회")
     public ResponseEntity<List<Long>> findBookmarkedFestivalIds(
         @Member Long memberId
     ) {
@@ -35,7 +35,7 @@ public class FestivalBookmarkV1Controller {
 
     @MemberAuth
     @GetMapping
-    @Operation(description = "축제의 식별자 목록으로 북마크 된 축제의 목록을 조회한다.", summary = "축제의 식별자 목록으로 북마크 된 축제의 목록 조회")
+    @Operation(description = "축제 식별자 목록으로 회원의 북마크 된 축제의 목록을 조회한다.", summary = "축제 식별자 목록으로 북마크 된 축제의 목록 조회")
     public ResponseEntity<List<FestivalBookmarkV1Response>> findBookmarkedFestivals(
         @Member Long memberId,
         @RequestParam List<Long> festivalIds,

--- a/backend/src/main/java/com/festago/bookmark/presentation/v1/SchoolBookmarkV1Controller.java
+++ b/backend/src/main/java/com/festago/bookmark/presentation/v1/SchoolBookmarkV1Controller.java
@@ -16,14 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/bookmarks/schools")
-@Tag(name = "학교 북마크 V1")
+@Tag(name = "학교 북마크 요청 V1")
 public class SchoolBookmarkV1Controller {
 
     private final SchoolBookmarkV1QueryService schoolBookmarkV1QueryService;
 
     @MemberAuth
     @GetMapping
-    @Operation(description = "특정한 회원의 학교 북마크 목록을 반환한다", summary = "회원 학교 북마크 목록 조회")
+    @Operation(description = "회원의 학교 북마크 목록을 조회한다", summary = "학교 북마크 조회")
     public ResponseEntity<List<SchoolBookmarkV1Response>> findAllByMemberId(@Member Long memberId) {
         return ResponseEntity.ok(schoolBookmarkV1QueryService.findAllByMemberId(memberId));
     }

--- a/backend/src/main/java/com/festago/common/presentation/PingController.java
+++ b/backend/src/main/java/com/festago/common/presentation/PingController.java
@@ -1,9 +1,11 @@
 package com.festago.common.presentation;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 @RequestMapping("/ping")
 public class PingController {

--- a/backend/src/main/java/com/festago/entry/presentation/MemberEntranceController.java
+++ b/backend/src/main/java/com/festago/entry/presentation/MemberEntranceController.java
@@ -3,6 +3,7 @@ package com.festago.entry.presentation;
 import com.festago.auth.annotation.Member;
 import com.festago.entry.application.EntryService;
 import com.festago.entry.dto.EntryCodeResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Deprecated(forRemoval = true)
+@Hidden
 @RestController
 @RequiredArgsConstructor
 public class MemberEntranceController {

--- a/backend/src/main/java/com/festago/entry/presentation/StaffMemberTicketController.java
+++ b/backend/src/main/java/com/festago/entry/presentation/StaffMemberTicketController.java
@@ -4,6 +4,7 @@ package com.festago.entry.presentation;
 import com.festago.entry.application.EntryService;
 import com.festago.entry.dto.TicketValidationRequest;
 import com.festago.entry.dto.TicketValidationResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -14,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Deprecated(forRemoval = true)
+@Hidden
 @RestController
 @RequestMapping("/staff/member-tickets")
 @Tag(name = "스태프 요청")

--- a/backend/src/main/java/com/festago/fcm/presentation/MemberFCMController.java
+++ b/backend/src/main/java/com/festago/fcm/presentation/MemberFCMController.java
@@ -3,6 +3,7 @@ package com.festago.fcm.presentation;
 import com.festago.auth.annotation.Member;
 import com.festago.fcm.application.MemberFCMService;
 import com.festago.fcm.dto.MemberFcmCreateRequest;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Deprecated(forRemoval = true)
+@Hidden
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "유저 FCM 정보 요청")

--- a/backend/src/main/java/com/festago/festival/presentation/v1/FestivalSearchV1Controller.java
+++ b/backend/src/main/java/com/festago/festival/presentation/v1/FestivalSearchV1Controller.java
@@ -22,8 +22,8 @@ public class FestivalSearchV1Controller {
     private final FestivalSearchV1QueryService festivalSearchV1QueryService;
 
     @GetMapping
-    @Operation(description = "축제를 검색한다. ~대 혹은 ~대학교로 끝날 시 대학교 축제 검색이며 그 외의 경우는 아티스트 기반 축제 검색입니다.", summary = "축제 검색")
-    public ResponseEntity<List<FestivalSearchV1Response>> getArtistInfo(@RequestParam String keyword) {
+    @Operation(description = "키워드로 축제를 검색한다. ~대, ~대학교로 끝날 시 대학교 축제 검색, 그 외의 경우 아티스트가 참여한 축제 검색.", summary = "축제 검색")
+    public ResponseEntity<List<FestivalSearchV1Response>> searchFestivals(@RequestParam String keyword) {
         validate(keyword);
         return ResponseEntity.ok(festivalSearchV1QueryService.search(keyword));
     }

--- a/backend/src/main/java/com/festago/festival/presentation/v1/FestivalV1Controller.java
+++ b/backend/src/main/java/com/festago/festival/presentation/v1/FestivalV1Controller.java
@@ -13,9 +13,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,9 +33,9 @@ public class FestivalV1Controller {
 
     @GetMapping
     @ValidPageable(maxSize = 20)
-    @Operation(description = "축제 목록를 조건별로 조회한다. PROGRESS: 진행 중, PLANNED: 진행 예정, END: 종료, 기본값 -> 진행 중, limit의 크기는 0 < limit < 21 이며 기본 값 10이다.", summary = "축제 목록 조회")
+    @Operation(description = "축제 목록를 조건별로 조회한다. PROGRESS: 진행 중, PLANNED: 진행 예정, END: 종료. 0 < size <= 20", summary = "축제 목록 조회")
     public ResponseEntity<Slice<FestivalV1Response>> findFestivals(
-        @PageableDefault(size = 10) Pageable pageable,
+        @RequestParam(defaultValue = "10") int size,
         @RequestParam(defaultValue = "ANY") SchoolRegion region,
         @RequestParam(defaultValue = "PROGRESS") FestivalFilter filter,
         @RequestParam(required = false) Long lastFestivalId,
@@ -44,7 +43,7 @@ public class FestivalV1Controller {
     ) {
         validateCursor(lastFestivalId, lastStartDate);
         var request = new FestivalV1QueryRequest(region, filter, lastFestivalId, lastStartDate);
-        var response = festivalV1QueryService.findFestivals(pageable, request);
+        var response = festivalV1QueryService.findFestivals(PageRequest.ofSize(size), request);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/festago/festival/presentation/v1/FestivalV1Controller.java
+++ b/backend/src/main/java/com/festago/festival/presentation/v1/FestivalV1Controller.java
@@ -10,6 +10,7 @@ import com.festago.festival.dto.FestivalV1Response;
 import com.festago.festival.repository.FestivalFilter;
 import com.festago.school.domain.SchoolRegion;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -33,11 +34,11 @@ public class FestivalV1Controller {
 
     @GetMapping
     @ValidPageable(maxSize = 20)
-    @Operation(description = "축제 목록를 조건별로 조회한다. PROGRESS: 진행 중, PLANNED: 진행 예정, END: 종료. 0 < size <= 20", summary = "축제 목록 조회")
+    @Operation(description = "축제 목록를 조건별로 조회한다.", summary = "축제 목록 조회")
     public ResponseEntity<Slice<FestivalV1Response>> findFestivals(
-        @RequestParam(defaultValue = "10") int size,
+        @Parameter(description = "0 < size <= 20") @RequestParam(defaultValue = "10") int size,
         @RequestParam(defaultValue = "ANY") SchoolRegion region,
-        @RequestParam(defaultValue = "PROGRESS") FestivalFilter filter,
+        @Parameter(description = "PROGRESS: 진행 중, PLANNED: 진행 예정, END: 종료") @RequestParam(defaultValue = "PROGRESS") FestivalFilter filter,
         @RequestParam(required = false) Long lastFestivalId,
         @RequestParam(required = false) LocalDate lastStartDate
     ) {
@@ -58,7 +59,7 @@ public class FestivalV1Controller {
     }
 
     @GetMapping("/{festivalId}")
-    @Operation(description = "특정 축제의 상세 정보를 조회한다.", summary = "특정 축제 상세 조회")
+    @Operation(description = "축제의 정보를 조회한다.", summary = "축제 정보 조회")
     public ResponseEntity<FestivalDetailV1Response> findFestivalDetail(
         @PathVariable Long festivalId
     ) {

--- a/backend/src/main/java/com/festago/festival/presentation/v1/PopularFestivalV1Controller.java
+++ b/backend/src/main/java/com/festago/festival/presentation/v1/PopularFestivalV1Controller.java
@@ -12,15 +12,15 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/popular/festivals")
-@Tag(name = "인기 축제 정보 요청 V1")
+@Tag(name = "인기 축제 목록 요청 V1")
 @RequiredArgsConstructor
 public class PopularFestivalV1Controller {
 
     private final PopularFestivalV1QueryService popularFestivalV1QueryService;
 
     @GetMapping
-    @Operation(description = "인기 축제 목록을 7개 반환한다.", summary = "인기 축제 목록 조회")
-    public ResponseEntity<PopularFestivalsV1Response> popularFestivals() {
+    @Operation(description = "인기 축제 목록 7개를 반환한다.", summary = "인기 축제 목록 조회")
+    public ResponseEntity<PopularFestivalsV1Response> findPopularFestivals() {
         return ResponseEntity.ok(popularFestivalV1QueryService.findPopularFestivals());
     }
 }

--- a/backend/src/main/java/com/festago/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/festago/member/presentation/MemberController.java
@@ -3,6 +3,7 @@ package com.festago.member.presentation;
 import com.festago.auth.annotation.Member;
 import com.festago.member.application.MemberService;
 import com.festago.member.dto.MemberProfileResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +13,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Deprecated(forRemoval = true)
+@Hidden
 @RestController
 @RequestMapping("/members")
 @Tag(name = "유저 정보 요청")

--- a/backend/src/main/java/com/festago/school/presentation/v1/SchoolSearchV1Controller.java
+++ b/backend/src/main/java/com/festago/school/presentation/v1/SchoolSearchV1Controller.java
@@ -22,7 +22,7 @@ public class SchoolSearchV1Controller {
     private final SchoolTotalSearchV1QueryService schoolTotalSearchV1QueryService;
 
     @GetMapping
-    @Operation(description = "곧 시작하는 축제일을 포함된 학교를 검색한다.", summary = "학교 검색")
+    @Operation(description = "키워드로 학교를 검색한다.", summary = "학교 검색")
     public ResponseEntity<List<SchoolTotalSearchV1Response>> searchSchools(
         @RequestParam String keyword
     ) {

--- a/backend/src/main/java/com/festago/school/presentation/v1/SchoolV1Controller.java
+++ b/backend/src/main/java/com/festago/school/presentation/v1/SchoolV1Controller.java
@@ -7,6 +7,7 @@ import com.festago.school.dto.v1.SchoolDetailV1Response;
 import com.festago.school.dto.v1.SchoolFestivalV1Response;
 import com.festago.school.repository.v1.SchoolFestivalV1SearchCondition;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -28,21 +29,21 @@ public class SchoolV1Controller {
     private final SchoolV1QueryService schoolV1QueryService;
 
     @GetMapping("/{schoolId}")
-    @Operation(description = "학교와 해당하는 소셜미디어 정보를 함께 조회한다.", summary = "학교 상세 조회")
-    public ResponseEntity<SchoolDetailV1Response> findDetailId(@PathVariable Long schoolId) {
+    @Operation(description = "학교의 정보를 조회한다.", summary = "학교 정보 조회")
+    public ResponseEntity<SchoolDetailV1Response> findDetailById(@PathVariable Long schoolId) {
         SchoolDetailV1Response response = schoolV1QueryService.findDetailById(schoolId);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{schoolId}/festivals")
     @ValidPageable(maxSize = 20)
-    @Operation(description = "해당 학교의 축제들을 페이징하여 조회한다.", summary = "학교 상세 조회")
+    @Operation(description = "학교의 축제 목록을 조회한다.", summary = "학교 축제 목록 조회")
     public ResponseEntity<SliceResponse<SchoolFestivalV1Response>> findFestivalsBySchoolId(
         @PathVariable Long schoolId,
         @RequestParam(required = false) Long lastFestivalId,
         @RequestParam(required = false) LocalDate lastStartDate,
         @RequestParam(defaultValue = "false") Boolean isPast,
-        @RequestParam(defaultValue = "10") int size
+        @Parameter(description = "0 < size <= 20") @RequestParam(defaultValue = "10") int size
     ) {
         LocalDate today = LocalDate.now();
         var searchCondition = new SchoolFestivalV1SearchCondition(lastFestivalId, lastStartDate, isPast,

--- a/backend/src/main/java/com/festago/school/presentation/v1/SchoolV1Controller.java
+++ b/backend/src/main/java/com/festago/school/presentation/v1/SchoolV1Controller.java
@@ -10,9 +10,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -43,10 +42,11 @@ public class SchoolV1Controller {
         @RequestParam(required = false) Long lastFestivalId,
         @RequestParam(required = false) LocalDate lastStartDate,
         @RequestParam(defaultValue = "false") Boolean isPast,
-        @PageableDefault(size = 10) Pageable pageable
+        @RequestParam(defaultValue = "10") int size
     ) {
         LocalDate today = LocalDate.now();
-        var searchCondition = new SchoolFestivalV1SearchCondition(lastFestivalId, lastStartDate, isPast, pageable);
+        var searchCondition = new SchoolFestivalV1SearchCondition(lastFestivalId, lastStartDate, isPast,
+            PageRequest.ofSize(size));
         Slice<SchoolFestivalV1Response> response = schoolV1QueryService.findFestivalsBySchoolId(
             schoolId,
             today,

--- a/backend/src/main/java/com/festago/student/presentation/StudentController.java
+++ b/backend/src/main/java/com/festago/student/presentation/StudentController.java
@@ -5,6 +5,7 @@ import com.festago.student.application.StudentService;
 import com.festago.student.dto.StudentResponse;
 import com.festago.student.dto.StudentSendMailRequest;
 import com.festago.student.dto.StudentVerificateRequest;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -16,6 +17,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Deprecated(forRemoval = true)
+@Hidden
 @RestController
 @RequestMapping("/students")
 @Tag(name = "학생 요청")

--- a/backend/src/main/java/com/festago/ticketing/presentation/MemberTicketController.java
+++ b/backend/src/main/java/com/festago/ticketing/presentation/MemberTicketController.java
@@ -7,6 +7,7 @@ import com.festago.ticketing.dto.MemberTicketResponse;
 import com.festago.ticketing.dto.MemberTicketsResponse;
 import com.festago.ticketing.dto.TicketingRequest;
 import com.festago.ticketing.dto.TicketingResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,6 +25,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Deprecated(forRemoval = true)
+@Hidden
 @RestController
 @SecurityRequirement(name = "bearerAuth")
 @RequestMapping("/member-tickets")

--- a/backend/src/test/java/com/festago/artist/application/integration/ArtistDetailV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/artist/application/integration/ArtistDetailV1QueryServiceIntegrationTest.java
@@ -118,7 +118,7 @@ class ArtistDetailV1QueryServiceIntegrationTest extends ApplicationIntegrationTe
             // then
             assertThat(actual.socialMedias())
                 .map(ArtistMediaV1Response::type)
-                .containsExactly(SocialMediaType.INSTAGRAM.name());
+                .containsExactly(SocialMediaType.INSTAGRAM);
         }
 
         @Test

--- a/backend/src/test/java/com/festago/artist/application/integration/ArtistDetailV1QueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/festago/artist/application/integration/ArtistDetailV1QueryServiceIntegrationTest.java
@@ -7,7 +7,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.festago.artist.application.ArtistDetailV1QueryService;
 import com.festago.artist.domain.Artist;
-import com.festago.artist.dto.ArtistFestivalDetailV1Response;
+import com.festago.artist.dto.ArtistFestivalV1Response;
 import com.festago.artist.dto.ArtistMediaV1Response;
 import com.festago.artist.repository.ArtistRepository;
 import com.festago.common.exception.ErrorCode;
@@ -212,7 +212,7 @@ class ArtistDetailV1QueryServiceIntegrationTest extends ApplicationIntegrationTe
 
             // then
             assertThat(actual.getContent())
-                .map(ArtistFestivalDetailV1Response::id)
+                .map(ArtistFestivalV1Response::id)
                 .containsExactly(부산대학교_축제.getId(), 대구대학교_축제.getId());
         }
 
@@ -229,7 +229,7 @@ class ArtistDetailV1QueryServiceIntegrationTest extends ApplicationIntegrationTe
 
             // then
             assertThat(actual.getContent())
-                .map(ArtistFestivalDetailV1Response::id)
+                .map(ArtistFestivalV1Response::id)
                 .containsExactly(서울대학교_축제.getId());
         }
 
@@ -257,7 +257,7 @@ class ArtistDetailV1QueryServiceIntegrationTest extends ApplicationIntegrationTe
 
             // then
             assertThat(secondResponse.getContent())
-                .map(ArtistFestivalDetailV1Response::id)
+                .map(ArtistFestivalV1Response::id)
                 .containsExactly(대구대학교_축제.getId());
         }
     }

--- a/backend/src/test/java/com/festago/artist/presentation/v1/ArtistDetailV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/artist/presentation/v1/ArtistDetailV1ControllerTest.java
@@ -56,9 +56,9 @@ class ArtistDetailV1ControllerTest {
                     "https://image.com/logo.png",
                     "https://image.com/backgroundLogo.png",
                     List.of(
-                        new ArtistMediaV1Response(SocialMediaType.YOUTUBE.name(), "유튜브",
+                        new ArtistMediaV1Response(SocialMediaType.YOUTUBE, "유튜브",
                             "https://image.com/youtube.png", "www.knu-youtube.com"),
-                        new ArtistMediaV1Response(SocialMediaType.INSTAGRAM.name(), "인스타그램",
+                        new ArtistMediaV1Response(SocialMediaType.INSTAGRAM, "인스타그램",
                             "https://image.com/youtube.png", "www.knu-instagram.com")
                     )
                 );

--- a/backend/src/test/java/com/festago/artist/presentation/v1/ArtistV1ControllerTest.java
+++ b/backend/src/test/java/com/festago/artist/presentation/v1/ArtistV1ControllerTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.festago.artist.application.ArtistDetailV1QueryService;
 import com.festago.artist.dto.ArtistDetailV1Response;
-import com.festago.artist.dto.ArtistFestivalDetailV1Response;
+import com.festago.artist.dto.ArtistFestivalV1Response;
 import com.festago.artist.dto.ArtistMediaV1Response;
 import com.festago.socialmedia.domain.SocialMediaType;
 import com.festago.support.CustomWebMvcTest;
@@ -28,7 +28,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @CustomWebMvcTest
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class ArtistDetailV1ControllerTest {
+class ArtistV1ControllerTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -88,7 +88,7 @@ class ArtistDetailV1ControllerTest {
             void 요청을_보내면_200_응답과_body가_반환된다() throws Exception {
                 // given
                 var today = LocalDate.now();
-                var content = List.of(new ArtistFestivalDetailV1Response(
+                var content = List.of(new ArtistFestivalV1Response(
                     1L, "경북대학교", today, today.plusDays(1), "www.image.com/image.png",
                     "아티스트"
                 ));


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #959

## ✨ PR 세부 내용

이슈에 적은 내용대로 사용되지 않는 `Pageable` 파라미터가 표시되는 문제를 해결했습니다.

또한 각자 Controller를 작업하다 보니, Swagger 문서의 내용이 통일되지 않아 혼란이 있는 관계로 형식을 모두 통일 시켰습니다.

Swagger가 자동화를 해주는 것은 참 좋긴 한데.. 오히려 불편하기도 하네요. 😂

그렇다고 REST Docs를 사용하기에는 공수가 너무 많이 필요하기도 하고...

아무튼 그렇습니다. 😂