### PR TITLE
[BE] feat: Artist 생성 시 중복 이름 검증 추가 (#963)

### DIFF
--- a/backend/src/main/java/com/festago/artist/application/ArtistCommandService.java
+++ b/backend/src/main/java/com/festago/artist/application/ArtistCommandService.java
@@ -7,6 +7,8 @@ import com.festago.artist.dto.event.ArtistCreatedEvent;
 import com.festago.artist.dto.event.ArtistDeletedEvent;
 import com.festago.artist.dto.event.ArtistUpdatedEvent;
 import com.festago.artist.repository.ArtistRepository;
+import com.festago.common.exception.BadRequestException;
+import com.festago.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -21,11 +23,18 @@ public class ArtistCommandService {
     private final ApplicationEventPublisher eventPublisher;
 
     public Long save(ArtistCreateCommand command) {
+        validateSave(command);
         Artist artist = artistRepository.save(
             new Artist(command.name(), command.profileImageUrl(), command.backgroundImageUrl())
         );
         eventPublisher.publishEvent(new ArtistCreatedEvent(artist));
         return artist.getId();
+    }
+
+    private void validateSave(ArtistCreateCommand command) {
+        if (artistRepository.existsByName(command.name())) {
+            throw new BadRequestException(ErrorCode.DUPLICATE_ARTIST_NAME);
+        }
     }
 
     public void update(ArtistUpdateCommand command, Long artistId) {

--- a/backend/src/main/java/com/festago/artist/repository/ArtistRepository.java
+++ b/backend/src/main/java/com/festago/artist/repository/ArtistRepository.java
@@ -26,4 +26,6 @@ public interface ArtistRepository extends Repository<Artist, Long> {
     List<Artist> findByIdIn(Collection<Long> artistIds);
 
     boolean existsById(Long id);
+
+    boolean existsByName(String name);
 }

--- a/backend/src/main/java/com/festago/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/festago/common/exception/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
     OPEN_ID_NOT_SUPPORTED_SOCIAL_TYPE("해당 OpenId 제공자는 지원되지 않습니다."),
     OPEN_ID_INVALID_TOKEN("잘못된 OpenID 토큰입니다."),
     NOT_SUPPORT_FILE_EXTENSION("해당 파일의 확장자는 허용되지 않습니다."),
+    DUPLICATE_ARTIST_NAME("이미 존재하는 아티스트의 이름입니다."),
 
     // 401
     EXPIRED_AUTH_TOKEN("만료된 로그인 토큰입니다."),

--- a/backend/src/test/java/com/festago/artist/application/ArtistCommandServiceTest.java
+++ b/backend/src/test/java/com/festago/artist/application/ArtistCommandServiceTest.java
@@ -1,20 +1,22 @@
 package com.festago.artist.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.mock;
 
 import com.festago.artist.domain.Artist;
 import com.festago.artist.dto.command.ArtistCreateCommand;
 import com.festago.artist.dto.command.ArtistUpdateCommand;
 import com.festago.artist.repository.ArtistRepository;
 import com.festago.artist.repository.MemoryArtistRepository;
+import com.festago.common.exception.BadRequestException;
+import com.festago.common.exception.ErrorCode;
 import com.festago.support.fixture.ArtistFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -41,6 +43,19 @@ class ArtistCommandServiceTest {
 
         // then
         assertThat(artistRepository.findById(artistId)).isPresent();
+    }
+
+    @Test
+    void 중복된_이름의_아티스트가_저장되면_예외가_발생한다() {
+        // given
+        artistRepository.save(ArtistFixture.builder().name("윤서연").build());
+        ArtistCreateCommand command = new ArtistCreateCommand("윤서연", "https://image.com/image.png",
+            "https://image.com/image.png");
+
+        // when & then
+        assertThatThrownBy(() -> artistCommandService.save(command))
+            .isInstanceOf(BadRequestException.class)
+            .hasMessage(ErrorCode.DUPLICATE_ARTIST_NAME.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/festago/artist/repository/MemoryArtistRepository.java
+++ b/backend/src/test/java/com/festago/artist/repository/MemoryArtistRepository.java
@@ -4,6 +4,7 @@ import com.festago.artist.domain.Artist;
 import com.festago.support.AbstractMemoryRepository;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 public class MemoryArtistRepository extends AbstractMemoryRepository<Artist> implements ArtistRepository {
 
@@ -19,5 +20,11 @@ public class MemoryArtistRepository extends AbstractMemoryRepository<Artist> imp
         return memory.values().stream()
             .filter(artist -> artistIds.contains(artist.getId()))
             .toList();
+    }
+
+    @Override
+    public boolean existsByName(String name) {
+        return memory.values().stream()
+            .anyMatch(it -> Objects.equals(it.getName(), name));
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #963

## ✨ PR 세부 내용

Artist 생성 시 이름으로 중복이 있는지 검사하는 기능을 추가했습니다.

큰 기능이 아니라, 크게 적을 내용이 없네요. 😂