### PR TITLE
fix: member 테이블 social_id 컬럼 길이 45글자 수정 (#965)

### DIFF
--- a/backend/src/main/resources/db/migration/V5__modify_member_social_id.sql
+++ b/backend/src/main/resources/db/migration/V5__modify_member_social_id.sql
@@ -1,0 +1,2 @@
+alter table member
+    modify social_id varchar(45) null;


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #965

## ✨ PR 세부 내용

이슈에 남긴 내용대로 member 테이블의 social_id 컬럼의 길이를 45글자로 늘렸습니다.

단순 DB 컬럼 길이 반영이므로 리뷰 없이 머지하도록 하겠습니다!