### PR TITLE
[BE] feat: 사용자 기본 닉네임 정책 추가 (#972)

### DIFF
--- a/backend/src/main/java/com/festago/auth/application/command/MemberAuthCommandService.java
+++ b/backend/src/main/java/com/festago/auth/application/command/MemberAuthCommandService.java
@@ -2,6 +2,7 @@ package com.festago.auth.application.command;
 
 import com.festago.auth.domain.RefreshToken;
 import com.festago.auth.domain.UserInfo;
+import com.festago.auth.domain.UserInfoMemberMapper;
 import com.festago.auth.dto.event.MemberDeletedEvent;
 import com.festago.auth.dto.v1.LoginResult;
 import com.festago.auth.dto.v1.TokenRefreshResult;
@@ -28,6 +29,7 @@ public class MemberAuthCommandService {
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final UserInfoMemberMapper userInfoMemberMapper;
     private final Clock clock;
 
     public LoginResult oAuth2Login(UserInfo userInfo) {
@@ -44,7 +46,8 @@ public class MemberAuthCommandService {
     }
 
     private Member signUp(UserInfo userInfo) {
-        return memberRepository.save(userInfo.toMember());
+        Member member = userInfoMemberMapper.toMember(userInfo);
+        return memberRepository.save(member);
     }
 
     private RefreshToken saveRefreshToken(Long memberId) {

--- a/backend/src/main/java/com/festago/auth/domain/UserInfo.java
+++ b/backend/src/main/java/com/festago/auth/domain/UserInfo.java
@@ -1,6 +1,5 @@
 package com.festago.auth.domain;
 
-import com.festago.member.domain.Member;
 import lombok.Builder;
 
 @Builder
@@ -11,12 +10,4 @@ public record UserInfo(
     String profileImage
 ) {
 
-    public Member toMember() {
-        return new Member(
-            socialId,
-            socialType,
-            nickname,
-            profileImage
-        );
-    }
 }

--- a/backend/src/main/java/com/festago/auth/domain/UserInfoMemberMapper.java
+++ b/backend/src/main/java/com/festago/auth/domain/UserInfoMemberMapper.java
@@ -1,0 +1,24 @@
+package com.festago.auth.domain;
+
+import com.festago.member.domain.DefaultNicknamePolicy;
+import com.festago.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class UserInfoMemberMapper {
+
+    private final DefaultNicknamePolicy defaultNicknamePolicy;
+
+    public Member toMember(UserInfo userInfo) {
+        String nickname = userInfo.nickname();
+        return new Member(
+            userInfo.socialId(),
+            userInfo.socialType(),
+            StringUtils.hasText(nickname) ? nickname : defaultNicknamePolicy.generate(),
+            userInfo.profileImage()
+        );
+    }
+}

--- a/backend/src/main/java/com/festago/member/config/DefaultNicknamePolicyConfig.java
+++ b/backend/src/main/java/com/festago/member/config/DefaultNicknamePolicyConfig.java
@@ -1,0 +1,27 @@
+package com.festago.member.config;
+
+import com.festago.member.domain.DefaultNicknamePolicy;
+import com.festago.member.infrastructure.DefaultNicknamePolicyImpl;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DefaultNicknamePolicyConfig {
+
+    @Bean
+    public DefaultNicknamePolicy defaultNicknamePolicy() {
+        List<String> adjectives = List.of(
+            "츄러스를 먹는", "노래 부르는", "때창하는", "응원하는",
+            "응원봉을 든", "타코야끼를 먹는", "공연에 심취한", "신나는",
+            "춤추는", "행복한", "즐거운", "신나는", "흥겨운"
+        );
+        List<String> nouns = List.of(
+            "다람쥐", "토끼", "고양이", "펭귄",
+            "캥거루", "사슴", "미어캣", "호랑이",
+            "여우", "판다", "고슴도치", "토끼",
+            "햄스터", "얼룩말", "너구리", "치타"
+        );
+        return new DefaultNicknamePolicyImpl(adjectives, nouns);
+    }
+}

--- a/backend/src/main/java/com/festago/member/domain/DefaultNicknamePolicy.java
+++ b/backend/src/main/java/com/festago/member/domain/DefaultNicknamePolicy.java
@@ -1,0 +1,6 @@
+package com.festago.member.domain;
+
+public interface DefaultNicknamePolicy {
+
+    String generate();
+}

--- a/backend/src/main/java/com/festago/member/domain/Member.java
+++ b/backend/src/main/java/com/festago/member/domain/Member.java
@@ -38,7 +38,6 @@ import org.springframework.util.StringUtils;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 
-    private static final String DEFAULT_NICKNAME = "FestivalLover";
     private static final int MAX_SOCIAL_ID_LENGTH = 255;
     private static final int MAX_NICKNAME_LENGTH = 30;
     private static final int MAX_PROFILE_IMAGE_LENGTH = 255;
@@ -76,7 +75,7 @@ public class Member extends BaseTimeEntity {
         this.id = id;
         this.socialId = socialId;
         this.socialType = socialType;
-        this.nickname = (StringUtils.hasText(nickname)) ? nickname : DEFAULT_NICKNAME;
+        this.nickname = nickname;
         this.profileImage = ImageUrlHelper.getBlankStringIfBlank(profileImage);
     }
 
@@ -100,6 +99,7 @@ public class Member extends BaseTimeEntity {
     private void validateNickname(String nickname) {
         String fieldName = "nickname";
         Validator.maxLength(nickname, MAX_NICKNAME_LENGTH, fieldName);
+        Validator.notBlank(nickname, fieldName);
     }
 
     private void validateProfileImage(String profileImage) {

--- a/backend/src/main/java/com/festago/member/infrastructure/DefaultNicknamePolicyImpl.java
+++ b/backend/src/main/java/com/festago/member/infrastructure/DefaultNicknamePolicyImpl.java
@@ -1,0 +1,22 @@
+package com.festago.member.infrastructure;
+
+import com.festago.member.domain.DefaultNicknamePolicy;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DefaultNicknamePolicyImpl implements DefaultNicknamePolicy {
+
+    private final List<String> adjectives;
+    private final List<String> nouns;
+
+    @Override
+    public String generate() {
+        Random random = ThreadLocalRandom.current();
+        String adjective = adjectives.get(random.nextInt(adjectives.size()));
+        String noun = nouns.get(random.nextInt(nouns.size()));
+        return adjective + " " + noun;
+    }
+}

--- a/backend/src/test/java/com/festago/auth/application/command/MemberAuthCommandServiceTest.java
+++ b/backend/src/test/java/com/festago/auth/application/command/MemberAuthCommandServiceTest.java
@@ -9,11 +9,13 @@ import static org.mockito.BDDMockito.spy;
 import com.festago.auth.domain.RefreshToken;
 import com.festago.auth.domain.SocialType;
 import com.festago.auth.domain.UserInfo;
+import com.festago.auth.domain.UserInfoMemberMapper;
 import com.festago.auth.repository.MemoryRefreshTokenRepository;
 import com.festago.auth.repository.RefreshTokenRepository;
 import com.festago.common.exception.ErrorCode;
 import com.festago.common.exception.NotFoundException;
 import com.festago.common.exception.UnauthorizedException;
+import com.festago.member.domain.DefaultNicknamePolicy;
 import com.festago.member.domain.Member;
 import com.festago.member.repository.MemberRepository;
 import com.festago.member.repository.MemoryMemberRepository;
@@ -46,10 +48,12 @@ class MemberAuthCommandServiceTest {
         clock = spy(Clock.systemDefaultZone());
         memberRepository = new MemoryMemberRepository();
         refreshTokenRepository = new MemoryRefreshTokenRepository();
+        DefaultNicknamePolicy defaultNicknamePolicy = () -> "nickname";
         memberAuthCommandService = new MemberAuthCommandService(
             memberRepository,
             refreshTokenRepository,
             mock(ApplicationEventPublisher.class),
+            new UserInfoMemberMapper(defaultNicknamePolicy),
             clock
         );
     }

--- a/backend/src/test/java/com/festago/member/domain/MemberTest.java
+++ b/backend/src/test/java/com/festago/member/domain/MemberTest.java
@@ -55,12 +55,10 @@ class MemberTest {
     @ParameterizedTest
     @NullSource
     @ValueSource(strings = {"", " ", "\t", "\n"})
-    void nickname이_null_또는_공백이면_기본_닉네임_생성(String nickname) {
-        // given && when
-        Member member = new Member(1L, "12345", SocialType.FESTAGO, nickname, "profileImage.png");
-
-        // then
-        assertThat(member.getNickname()).isEqualTo("FestivalLover");
+    void nickname이_null_또는_공백이면_예외(String nickname) {
+        // when & then
+        assertThatThrownBy(() -> new Member(1L, "12345", SocialType.FESTAGO, nickname, "profileImage.png"))
+            .isInstanceOf(ValidException.class);
     }
 
     @Test

--- a/backend/src/test/java/com/festago/member/infrastructure/DefaultNicknamePolicyImplTest.java
+++ b/backend/src/test/java/com/festago/member/infrastructure/DefaultNicknamePolicyImplTest.java
@@ -1,0 +1,29 @@
+package com.festago.member.infrastructure;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.festago.member.domain.DefaultNicknamePolicy;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class DefaultNicknamePolicyImplTest {
+
+    @Test
+    void 형용사와_명사가_합쳐진_닉네임이_반환된다() {
+        // given
+        DefaultNicknamePolicy defaultNicknamePolicy = new DefaultNicknamePolicyImpl(
+            List.of("춤추는"),
+            List.of("다람쥐")
+        );
+
+        // when
+        String nickname = defaultNicknamePolicy.generate();
+
+        // then
+        assertThat(nickname).isEqualTo("춤추는 다람쥐");
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #972

## ✨ PR 세부 내용

이슈에 남긴 내용대로 사용자의 기본 닉네임 정책을 추가했습니다.

`Member` 엔티티에 static 메서드를 가진 클래스를 사용해서 기본 닉네임을 사용하려고 했으나..

테스트가 불가능한 문제도 있고, static 메서드를 사용하는 것이 불편해서, 객체지향적으로 구현했습니다. 😂

기본 닉네임을 정하는 것은 좋은데, 사용자가 기본 닉네임이 마음에 들지 않아 할 수 있어서, 닉네임 변경 기능이 필요하지 않을까 싶네요.