### PR TITLE
[AN/USER] 디자인 수정 및 Domain Exception 추가 (#978) 

### DIFF
--- a/android/festago/data/src/main/java/com/festago/festago/data/util/ResponseExt.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/util/ResponseExt.kt
@@ -30,7 +30,7 @@ suspend fun <T> runCatchingResponse(
         )
     } catch (e: Exception) {
         if (e is UnknownHostException) {
-            return Result.failure(NetworkException)
+            return Result.failure(NetworkException())
         }
         return Result.failure(e)
     }
@@ -46,7 +46,7 @@ private fun <T> handleBadRequestException(response: Response<T>) {
     if (response.code() == 400) {
         response.errorBody()?.string()?.let {
             if (it.contains("BOOKMARK_LIMIT_EXCEEDED")) {
-                throw BookmarkLimitExceededException
+                throw BookmarkLimitExceededException()
             }
         }
         throw Throwable("400 Bad Request")

--- a/android/festago/domain/src/main/java/com/festago/festago/domain/exception/BookmarkLimitExeededException.kt
+++ b/android/festago/domain/src/main/java/com/festago/festago/domain/exception/BookmarkLimitExeededException.kt
@@ -1,7 +1,5 @@
 package com.festago.festago.domain.exception
 
-object BookmarkLimitExceededException : Exception() {
-    private fun readResolve(): Any = BookmarkLimitExceededException
-}
+class BookmarkLimitExceededException : Exception()
 
 fun Throwable.isBookmarkLimitExceeded() = this is BookmarkLimitExceededException

--- a/android/festago/domain/src/main/java/com/festago/festago/domain/exception/BookmarkLimitExeededException.kt
+++ b/android/festago/domain/src/main/java/com/festago/festago/domain/exception/BookmarkLimitExeededException.kt
@@ -1,0 +1,7 @@
+package com.festago.festago.domain.exception
+
+object BookmarkLimitExceededException : Exception() {
+    private fun readResolve(): Any = BookmarkLimitExceededException
+}
+
+fun Throwable.isBookmarkLimitExceeded() = this is BookmarkLimitExceededException

--- a/android/festago/domain/src/main/java/com/festago/festago/domain/exception/NetworkException.kt
+++ b/android/festago/domain/src/main/java/com/festago/festago/domain/exception/NetworkException.kt
@@ -1,7 +1,4 @@
 package com.festago.festago.domain.exception
 
-object NetworkException : Exception() {
-    private fun readResolve(): Any = NetworkException
-}
-
+class NetworkException : Exception()
 fun Throwable.isNetworkError() = this is NetworkException

--- a/android/festago/domain/src/main/java/com/festago/festago/domain/exception/NetworkException.kt
+++ b/android/festago/domain/src/main/java/com/festago/festago/domain/exception/NetworkException.kt
@@ -1,0 +1,7 @@
+package com.festago.festago.domain.exception
+
+object NetworkException : Exception() {
+    private fun readResolve(): Any = NetworkException
+}
+
+fun Throwable.isNetworkError() = this is NetworkException

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
@@ -121,7 +121,7 @@ class ArtistDetailViewModel @Inject constructor(
                         }
                         if (it.isNetworkError()) {
                             _uiState.value = uiState.copy(bookMarked = true)
-                            _event.emit(BookmarkFailure("북마크를 해제할 수 없습니다. 인터넷 연결을 확인해주세요"))
+                            _event.emit(BookmarkFailure("인터넷 연결을 확인해주세요"))
                         }
                     }
             } else {
@@ -135,6 +135,10 @@ class ArtistDetailViewModel @Inject constructor(
                         if (it.isBookmarkLimitExceeded()) {
                             _uiState.value = uiState.copy(bookMarked = false)
                             _event.emit(BookmarkFailure("북마크는 12개까지 가능해요"))
+                        }
+                        if (it.isNetworkError()) {
+                            _uiState.value = uiState.copy(bookMarked = false)
+                            _event.emit(BookmarkFailure("인터넷 연결을 확인해주세요"))
                         }
                     }
             }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
@@ -109,7 +109,7 @@ class ArtistDetailViewModel @Inject constructor(
             val uiState = uiState.value as? ArtistDetailUiState.Success ?: return@launch
 
             if (!userRepository.isSigned()) {
-                _event.emit(BookmarkFailure("로그인이 필요합니다"))
+                _event.emit(BookmarkFailure("로그인이 필요해요"))
                 return@launch
             }
 

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.festago.festago.common.analytics.AnalyticsHelper
 import com.festago.festago.common.analytics.logNetworkFailure
+import com.festago.festago.domain.exception.isBookmarkLimitExceeded
+import com.festago.festago.domain.exception.isNetworkError
+import com.festago.festago.domain.exception.isUnauthorized
 import com.festago.festago.domain.model.bookmark.BookmarkType
 import com.festago.festago.domain.model.festival.FestivalsPage
 import com.festago.festago.domain.repository.ArtistRepository
@@ -108,26 +111,31 @@ class ArtistDetailViewModel @Inject constructor(
         viewModelScope.launch {
             val uiState = uiState.value as? ArtistDetailUiState.Success ?: return@launch
 
-            if (!userRepository.isSigned()) {
-                _event.emit(BookmarkFailure("로그인이 필요해요"))
-                return@launch
-            }
-
             if (uiState.bookMarked) {
                 _uiState.value = uiState.copy(bookMarked = false)
                 bookmarkRepository.deleteArtistBookmark(artistId.toLong())
                     .onSuccess { _event.emit(BookmarkSuccess(false)) }
                     .onFailure {
-                        _uiState.value = uiState.copy(bookMarked = true)
-                        _event.emit(BookmarkFailure("북마크를 해제할 수 없습니다. 인터넷 연결을 확인해주세요"))
+                        if (it.isUnauthorized()) {
+                            _event.emit(BookmarkFailure("로그인이 필요해요"))
+                        }
+                        if (it.isNetworkError()) {
+                            _uiState.value = uiState.copy(bookMarked = true)
+                            _event.emit(BookmarkFailure("북마크를 해제할 수 없습니다. 인터넷 연결을 확인해주세요"))
+                        }
                     }
             } else {
                 _uiState.value = uiState.copy(bookMarked = true)
                 bookmarkRepository.addArtistBookmark(artistId.toLong())
                     .onSuccess { _event.emit(BookmarkSuccess(true)) }
                     .onFailure {
-                        _uiState.value = uiState.copy(bookMarked = false)
-                        _event.emit(BookmarkFailure("다른 북마크를 해제하거나 인터넷 연결을 확인해주세요"))
+                        if (it.isUnauthorized()) {
+                            _event.emit(BookmarkFailure("로그인이 필요해요"))
+                        }
+                        if (it.isBookmarkLimitExceeded()) {
+                            _uiState.value = uiState.copy(bookMarked = false)
+                            _event.emit(BookmarkFailure("북마크는 12개까지 가능해요"))
+                        }
                     }
             }
         }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailViewModel.kt
@@ -109,7 +109,7 @@ class FestivalDetailViewModel @Inject constructor(
                         }
                         if (it.isNetworkError()) {
                             _uiState.value = uiState.copy(bookmarked = true)
-                            _event.emit(BookmarkFailure("북마크를 해제할 수 없습니다. 인터넷 연결을 확인해주세요"))
+                            _event.emit(BookmarkFailure("인터넷 연결을 확인해주세요"))
                         }
                     }
             } else {
@@ -123,6 +123,10 @@ class FestivalDetailViewModel @Inject constructor(
                         if (it.isBookmarkLimitExceeded()) {
                             _uiState.value = uiState.copy(bookmarked = false)
                             _event.emit(BookmarkFailure("북마크는 12개까지 가능해요"))
+                        }
+                        if (it.isNetworkError()) {
+                            _uiState.value = uiState.copy(bookmarked = false)
+                            _event.emit(BookmarkFailure("인터넷 연결을 확인해주세요"))
                         }
                     }
             }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/festivaldetail/FestivalDetailViewModel.kt
@@ -97,7 +97,7 @@ class FestivalDetailViewModel @Inject constructor(
             val uiState = _uiState.value as? FestivalDetailUiState.Success ?: return@launch
 
             if (!userRepository.isSigned()) {
-                _event.emit(BookmarkFailure("로그인이 필요합니다"))
+                _event.emit(BookmarkFailure("로그인이 필요해요"))
                 return@launch
             }
 

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailViewModel.kt
@@ -119,7 +119,7 @@ class SchoolDetailViewModel @Inject constructor(
                         }
                         if (it.isNetworkError()) {
                             _uiState.value = uiState.copy(bookmarked = true)
-                            _event.emit(BookmarkFailure("북마크를 해제할 수 없습니다. 인터넷 연결을 확인해주세요"))
+                            _event.emit(BookmarkFailure("인터넷 연결을 확인해주세요"))
                         }
                     }
             } else {
@@ -133,6 +133,10 @@ class SchoolDetailViewModel @Inject constructor(
                         if (it.isBookmarkLimitExceeded()) {
                             _uiState.value = uiState.copy(bookmarked = false)
                             _event.emit(BookmarkFailure("북마크는 12개까지 가능해요"))
+                        }
+                        if (it.isNetworkError()) {
+                            _uiState.value = uiState.copy(bookmarked = false)
+                            _event.emit(BookmarkFailure("인터넷 연결을 확인해주세요"))
                         }
                     }
             }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.festago.festago.common.analytics.AnalyticsHelper
 import com.festago.festago.common.analytics.logNetworkFailure
+import com.festago.festago.domain.exception.isBookmarkLimitExceeded
+import com.festago.festago.domain.exception.isNetworkError
 import com.festago.festago.domain.exception.isUnauthorized
 import com.festago.festago.domain.model.bookmark.BookmarkType
 import com.festago.festago.domain.model.festival.Festival
@@ -115,8 +117,10 @@ class SchoolDetailViewModel @Inject constructor(
                         if (it.isUnauthorized()) {
                             _event.emit(BookmarkFailure("로그인이 필요해요"))
                         }
-                        _uiState.value = uiState.copy(bookmarked = true)
-                        _event.emit(BookmarkFailure("북마크를 해제할 수 없습니다. 인터넷 연결을 확인해주세요"))
+                        if (it.isNetworkError()) {
+                            _uiState.value = uiState.copy(bookmarked = true)
+                            _event.emit(BookmarkFailure("북마크를 해제할 수 없습니다. 인터넷 연결을 확인해주세요"))
+                        }
                     }
             } else {
                 _uiState.value = uiState.copy(bookmarked = true)
@@ -126,8 +130,10 @@ class SchoolDetailViewModel @Inject constructor(
                         if (it.isUnauthorized()) {
                             _event.emit(BookmarkFailure("로그인이 필요해요"))
                         }
-                        _uiState.value = uiState.copy(bookmarked = false)
-                        _event.emit(BookmarkFailure("다른 북마크를 해제하거나 인터넷 연결을 확인해주세요"))
+                        if (it.isBookmarkLimitExceeded()) {
+                            _uiState.value = uiState.copy(bookmarked = false)
+                            _event.emit(BookmarkFailure("북마크는 12개까지 가능해요"))
+                        }
                     }
             }
         }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/search/artistsearch/ArtistSearchViewHolder.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/search/artistsearch/ArtistSearchViewHolder.kt
@@ -19,14 +19,22 @@ class ArtistSearchViewHolder(
 
     fun bind(item: ArtistSearchItemUiState) {
         binding.item = item
-        binding.tvTodayStageCount.setStageCount(
-            count = item.todayStage,
-            stringRes = R.string.search_artist_tv_today_stage_count,
-        )
-        binding.tvUpcomingStageCount.setStageCount(
-            item.upcomingStage,
-            stringRes = R.string.search_artist_tv_upcoming_stage_count,
-        )
+
+        if (item.todayStage == 0 && item.upcomingStage == 0) {
+            binding.tvTodayStageCount.visibility = TextView.GONE
+            binding.tvUpcomingStageCount.visibility = TextView.GONE
+        } else {
+            binding.tvTodayStageCount.setStageCount(
+                count = item.todayStage,
+                stringRes = R.string.search_artist_tv_today_stage_count,
+            )
+
+            binding.tvUpcomingStageCount.setStageCount(
+                item.upcomingStage,
+                stringRes = R.string.search_artist_tv_upcoming_stage_count,
+            )
+            binding.tvEmptyStage.visibility = TextView.GONE
+        }
     }
 
     private fun TextView.setStageCount(count: Int, @StringRes stringRes: Int) {
@@ -35,8 +43,14 @@ class ArtistSearchViewHolder(
             getPartialColorText(
                 start = COLOR_INDEX,
                 end = COLOR_INDEX + count.toString().length,
-                color = context.getColor(R.color.secondary_pink_01),
+                color = when (count) {
+                    0 -> context.getColor(R.color.contents_gray_05)
+                    else -> context.getColor(R.color.secondary_pink_01)
+                },
             )
+        }
+        if (count == 0) {
+            setTextColor(context.getColor(R.color.contents_gray_05))
         }
     }
 

--- a/android/festago/presentation/src/main/res/layout/fragment_bookmark_list.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_bookmark_list.xml
@@ -30,6 +30,7 @@
             app:tabGravity="fill"
             app:tabIndicatorColor="@color/contents_gray_07"
             app:tabIndicatorFullWidth="false"
+            app:tabRippleColor="@color/contents_gray_04"
             app:tabIndicatorHeight="2dp"
             app:tabSelectedTextColor="@color/contents_gray_07"
             app:tabTextAppearance="@style/H4Bold16Lh20"

--- a/android/festago/presentation/src/main/res/layout/item_search_artist.xml
+++ b/android/festago/presentation/src/main/res/layout/item_search_artist.xml
@@ -86,5 +86,17 @@
             app:layout_constraintTop_toTopOf="@id/tvTodayStageCount"
             tools:text="공연 예정 2개" />
 
+        <TextView
+            android:id="@+id/tvEmptyStage"
+            style="@style/B2Medium14Lh20"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/search_artist_tv_no_plan"
+            android:includeFontPadding="false"
+            android:textColor="@color/contents_gray_05"
+            app:layout_constraintBottom_toBottomOf="@id/tvTodayStageCount"
+            app:layout_constraintStart_toEndOf="@id/tvTodayStageCount"
+            app:layout_constraintTop_toTopOf="@id/tvTodayStageCount" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/festago/presentation/src/main/res/layout/item_search_artist.xml
+++ b/android/festago/presentation/src/main/res/layout/item_search_artist.xml
@@ -36,8 +36,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:importantForAccessibility="no"
-                android:scaleType="centerCrop"
-                tools:src="@drawable/ic_launcher_foreground" />
+                android:scaleType="centerCrop"/>
         </androidx.cardview.widget.CardView>
 
         <TextView

--- a/android/festago/presentation/src/main/res/values/strings.xml
+++ b/android/festago/presentation/src/main/res/values/strings.xml
@@ -28,8 +28,8 @@
     <!-- String related to artist detail -->
     <string name="artist_detail_tv_dday_format">D%1$s</string>
     <string name="artist_detail_tv_empty_festivals">아직 축제가 없어요</string>
-    <string name="artist_detail_bookmark_success">아티스트를 북마크 했습니다</string>
-    <string name="artist_detail_bookmark_cancel">북마크를 취소했습니다</string>
+    <string name="artist_detail_bookmark_success">북마크에 추가했어요</string>
+    <string name="artist_detail_bookmark_cancel">북마크에서 삭제했어요</string>
 
     <!-- String related to notification list-->
     <string name="notification_list_tv_notification_app_bar">알림</string>
@@ -38,8 +38,8 @@
 
     <!-- String related to festival detail -->
     <string name="festival_detail_tv_empty_stages">아직 라인업이 공개되지 않았어요</string>
-    <string name="festival_detail_bookmark_success">축제를 북마크 했습니다</string>
-    <string name="festival_detail_bookmark_cancel">북마크를 취소했습니다</string>
+    <string name="festival_detail_bookmark_success">북마크에 추가했어요</string>
+    <string name="festival_detail_bookmark_cancel">북마크에서 삭제했어요</string>
 
     <!-- String related to festival dday -->
     <string name="tv_dday_in_progress">진행 중</string>
@@ -51,8 +51,8 @@
 
     <!-- String related to school detail -->
     <string name="school_detail_tv_empty_festivals">아직 축제가 없어요</string>
-    <string name="school_detail_bookmark_success">학교를 북마크 했습니다</string>
-    <string name="school_detail_bookmark_cancel">북마크를 취소했습니다</string>
+    <string name="school_detail_bookmark_success">북마크에 추가했어요</string>
+    <string name="school_detail_bookmark_cancel">북마크에서 삭제했어요</string>
 
     <!-- String related to search -->
     <string name="search_et_search_hint">학교명, 아티스트명, 축제명으로 입력하세요.</string>

--- a/android/festago/presentation/src/main/res/values/strings.xml
+++ b/android/festago/presentation/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="search_school_tv_no_plan">예정 없음</string>
     <string name="search_artist_tv_today_stage_count">오늘 공연 %d개</string>
     <string name="search_artist_tv_upcoming_stage_count">공연 예정 %d개</string>
+    <string name="search_artist_tv_no_plan">예정 없음</string>
     <string name="search_tv_no_result">앗! 검색 결과가 없네요</string>
     <string name="search_tv_no_result_guide">찾으시는 정보가 없다면 저희에게 알려주세요</string>
     <string name="search_tv_request_add">추가 요청하러 가기</string>


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #978 

## ✨ PR 세부 내용

- [x] 아티스트 검색에서 오늘 공연/공연 예정이 0개일 때의 글자 색 변화 적용 부탁드립니다.
- [x]  (비로그인 플로우) 북마크 시, 로그인 해야 사용 가능하다는 토스트 메시지 화면으로 추가 수정하기
    - 로그인이 필요합니다 → 로그인이 필요해요 로 변경
- [x] 북마크를 취소했습니다 → 북마크에서 삭제했어요 로 변경
<!-- 이슈의 세부적인 내용을 적어주세요. -->
- [x]  (로그인 플로우) 북마크 시, 토스트 메시지로 추가 또는 삭제 되었다는 토스트 메시지 화면들 추가하기
    - 아티스트를 북마크 했습니다 → 북마크에 추가했어요 로 변경
- [x] 화면 터치 시 보라색 터치 영역 무채색(그레이)으로 변경 수정 확인  🌕
    - 북마크 탭 이동 (보라색 보임)
   

[Screen_recording_20240519_123412.webm](https://github.com/woowacourse-teams/2023-festa-go/assets/37167652/586828e1-2e81-42d9-a8c9-992f4d922d56)

<!-- 수정/추가한 내용을 적어주세요. -->
