### PR TITLE
[AN/USER] 바텀 네비게이션 클릭 시 쌓였던 BackStack 이 초기화된다. (#980)

### DIFF
--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/HomeActivity.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/HomeActivity.kt
@@ -14,6 +14,7 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.navigation.NavController
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import com.festago.festago.presentation.R
@@ -60,7 +61,21 @@ class HomeActivity : AppCompatActivity() {
             (supportFragmentManager.findFragmentById(R.id.fcvHomeContainer) as NavHostFragment).navController
         val bottomNavigationView = findViewById<BottomNavigationView>(R.id.nvHome)
         bottomNavigationView.setupWithNavController(navController)
+
+        setBottomNavPopUpBackstack(bottomNavigationView)
         setNavColor()
+    }
+
+    private fun setBottomNavPopUpBackstack(bottomNavigationView: BottomNavigationView) {
+        bottomNavigationView.setOnItemSelectedListener {
+            val options = NavOptions.Builder()
+                .setPopUpTo(R.id.main_graph_xml, false)
+                .setLaunchSingleTop(true)
+                .build()
+
+            navController.navigate(it.itemId, null, options)
+            true
+        }
     }
 
     private fun setNavColor() {


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #980 

## ✨ PR 세부 내용

바텀네비게이션으로 화면 이동 시 백스택 초기화합니다.
기존 검색 크래시 발생 오류도 해결됩니다.
