### PR TITLE
[AN/USER] fix: 상세 화면 축제 목록 요청 로직 변경 및 Throwable 예외 처리 제거(#986)

### DIFF
--- a/android/festago/data/src/main/java/com/festago/festago/data/util/ResponseExt.kt
+++ b/android/festago/data/src/main/java/com/festago/festago/data/util/ResponseExt.kt
@@ -49,6 +49,5 @@ private fun <T> handleBadRequestException(response: Response<T>) {
                 throw BookmarkLimitExceededException()
             }
         }
-        throw Throwable("400 Bad Request")
     }
 }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/ArtistDetailViewModel.kt
@@ -69,7 +69,7 @@ class ArtistDetailViewModel @Inject constructor(
                     artist = artist,
                     bookMarked = isBookmarked,
                     festivals = festivalPage.toUiState(),
-                    userRepository.isSigned(),
+                    festivalPage.isLastPage,
                     onBookmarkClick = ::toggleArtistBookmark,
                 )
 

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/adapter/festival/ArtistDetailFestivalViewHolder.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/artistdetail/adapter/festival/ArtistDetailFestivalViewHolder.kt
@@ -29,6 +29,7 @@ class ArtistDetailFestivalViewHolder(
     fun bind(item: FestivalItemUiState) {
         binding.item = item
         artistAdapter.submitList(item.artists)
+        binding.tvEmptyStage.visibility = if (item.artists.isEmpty()) View.VISIBLE else View.GONE
         bindDDayView(item)
     }
 

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/bookmarklist/festivalbookmark/adapater/FestivalBookmarkViewHolder.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/bookmarklist/festivalbookmark/adapater/FestivalBookmarkViewHolder.kt
@@ -30,6 +30,7 @@ class FestivalBookmarkViewHolder(
     fun bind(item: FestivalBookmarkItemUiState) {
         binding.item = item
         artistAdapter.submitList(item.artists)
+        binding.tvEmptyStage.visibility = if (item.artists.isEmpty()) View.VISIBLE else View.GONE
         bindDDayView(item)
     }
 

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/festival/FestivalListFestivalViewHolder.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/festivallist/festival/FestivalListFestivalViewHolder.kt
@@ -32,6 +32,7 @@ class FestivalListFestivalViewHolder(
     fun bind(item: FestivalItemUiState) {
         binding.item = item
         artistAdapter.submitList(item.artists)
+        binding.tvEmptyStage.visibility = if (item.artists.isEmpty()) View.VISIBLE else View.GONE
         bindDDayView(item)
     }
 

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/mypage/MyPageFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/home/mypage/MyPageFragment.kt
@@ -59,7 +59,7 @@ class MyPageFragment : Fragment() {
         binding.tvPersonalInfoPolicy.setOnClickListener {
             val intent = Intent(Intent.ACTION_VIEW)
             intent.data =
-                Uri.parse("https://wooteco-ash.notion.site/fe0ca28535044db999d998eb4ea37e83")
+                Uri.parse("https://sites.google.com/view/privacy-festago")
             startActivity(intent)
         }
     }

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailFestivalViewHolder.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailFestivalViewHolder.kt
@@ -28,6 +28,7 @@ class SchoolDetailFestivalViewHolder(
     fun bind(item: FestivalItemUiState) {
         binding.item = item
         artistAdapter.submitList(item.artists)
+        binding.tvEmptyStage.visibility = if (item.artists.isEmpty()) View.VISIBLE else View.GONE
         bindDDayView(item)
     }
 

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailFragment.kt
@@ -17,7 +17,6 @@ import com.festago.festago.presentation.R
 import com.festago.festago.presentation.databinding.FragmentSchoolDetailBinding
 import com.festago.festago.presentation.databinding.ItemMediaBinding
 import com.festago.festago.presentation.ui.artistdetail.ArtistDetailArgs
-import com.festago.festago.presentation.ui.bindingadapter.setImage
 import com.festago.festago.presentation.ui.festivaldetail.FestivalDetailArgs
 import com.festago.festago.presentation.ui.schooldetail.uistate.MoreItemUiState
 import com.festago.festago.presentation.ui.schooldetail.uistate.SchoolDetailUiState

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailFragment.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/schooldetail/SchoolDetailFragment.kt
@@ -74,7 +74,6 @@ class SchoolDetailFragment : Fragment() {
 
     private fun loadSchoolDetail() {
         binding.tvSchoolName.text = args.school.name
-        binding.ivSchoolLogoImage.setImage(args.school.profileImageUrl)
         val delayTimeMillis = resources.getInteger(R.integer.nav_Anim_time).toLong()
         vm.loadSchoolDetail(args.school.id, delayTimeMillis)
     }
@@ -97,7 +96,6 @@ class SchoolDetailFragment : Fragment() {
         binding.successUiState = uiState
         binding.ivBookmark.isSelected = uiState.bookmarked
         binding.tvSchoolName.text = uiState.schoolInfo.schoolName
-        binding.ivSchoolLogoImage.setImage(uiState.schoolInfo.logoUrl)
         val items: List<Any> = if (uiState.isLast) {
             uiState.festivals
         } else {

--- a/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/search/festivalsearch/FestivalSearchViewHolder.kt
+++ b/android/festago/presentation/src/main/java/com/festago/festago/presentation/ui/search/festivalsearch/FestivalSearchViewHolder.kt
@@ -30,6 +30,7 @@ class FestivalSearchViewHolder(
     fun bind(item: FestivalSearchItemUiState) {
         binding.item = item
         artistAdapter.submitList(item.artists)
+        binding.tvEmptyStage.visibility = if (item.artists.isEmpty()) View.VISIBLE else View.GONE
         binding.tvFestivalDDay.bindFestivalDday(item)
     }
 

--- a/android/festago/presentation/src/main/res/layout/fragment_bookmark_list.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_bookmark_list.xml
@@ -34,7 +34,7 @@
             app:tabIndicatorHeight="2dp"
             app:tabSelectedTextColor="@color/contents_gray_07"
             app:tabTextAppearance="@style/H4Bold16Lh20"
-            app:tabTextColor="@color/contents_gray_07">
+            app:tabTextColor="@color/contents_gray_05">
 
             <com.google.android.material.tabs.TabItem
                 android:id="@+id/tiBookmarkListFestival"

--- a/android/festago/presentation/src/main/res/layout/fragment_my_page.xml
+++ b/android/festago/presentation/src/main/res/layout/fragment_my_page.xml
@@ -79,8 +79,7 @@
             android:gravity="center_vertical"
             android:paddingHorizontal="16dp"
             android:paddingVertical="16dp"
-            app:layout_constraintTop_toBottomOf="@id/tvMyPageAppbar"
-            android:visibility="gone">
+            app:layout_constraintTop_toBottomOf="@id/tvMyPageAppbar">
 
             <androidx.cardview.widget.CardView
                 android:id="@+id/cvProfileImage"
@@ -92,10 +91,10 @@
 
                 <ImageView
                     android:id="@+id/ivProfileImage"
-                    imageUrl="@{successUiState.userInfo.profileImageUrl}"
                     android:layout_width="60dp"
                     android:layout_height="60dp"
-                    android:contentDescription="@null" />
+                    android:contentDescription="@null"
+                    android:src="@drawable/ic_user_profile_default" />
 
             </androidx.cardview.widget.CardView>
 

--- a/android/festago/presentation/src/main/res/layout/item_artist_detail_festival.xml
+++ b/android/festago/presentation/src/main/res/layout/item_artist_detail_festival.xml
@@ -106,7 +106,6 @@
         <TextView
             android:id="@+id/tvEmptyStage"
             style="@style/H5Bold14Lh16"
-            visibility="@{item.artists.isEmpty()}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center"

--- a/android/festago/presentation/src/main/res/layout/item_festival_bookmark.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_bookmark.xml
@@ -107,7 +107,6 @@
         <TextView
             android:id="@+id/tvEmptyStage"
             style="@style/H5Bold14Lh16"
-            visibility="@{item.artists.isEmpty()}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center"

--- a/android/festago/presentation/src/main/res/layout/item_festival_list_festival.xml
+++ b/android/festago/presentation/src/main/res/layout/item_festival_list_festival.xml
@@ -107,7 +107,6 @@
         <TextView
             android:id="@+id/tvEmptyStage"
             style="@style/H5Bold14Lh16"
-            visibility="@{item.artists.isEmpty()}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center"

--- a/android/festago/presentation/src/main/res/layout/item_school_bookmark.xml
+++ b/android/festago/presentation/src/main/res/layout/item_school_bookmark.xml
@@ -32,12 +32,11 @@
 
             <ImageView
                 android:id="@+id/ivFestivalImage"
-                imageUrl="@{school.imageUrl}"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/festival_list_iv_image"
                 android:scaleType="centerCrop"
-                tools:src="@color/background_gray_03" />
+                android:src="@drawable/img_default_school" />
         </androidx.cardview.widget.CardView>
 
         <TextView

--- a/android/festago/presentation/src/main/res/layout/item_school_detail_festival.xml
+++ b/android/festago/presentation/src/main/res/layout/item_school_detail_festival.xml
@@ -109,7 +109,6 @@
         <TextView
             android:id="@+id/tvEmptyStage"
             style="@style/H5Bold14Lh16"
-            visibility="@{item.artists.isEmpty()}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center"

--- a/android/festago/presentation/src/main/res/layout/item_search_artist.xml
+++ b/android/festago/presentation/src/main/res/layout/item_search_artist.xml
@@ -90,12 +90,15 @@
             style="@style/B2Medium14Lh20"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/search_artist_tv_no_plan"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="16dp"
             android:includeFontPadding="false"
+            android:text="@string/search_artist_tv_no_plan"
             android:textColor="@color/contents_gray_05"
-            app:layout_constraintBottom_toBottomOf="@id/tvTodayStageCount"
-            app:layout_constraintStart_toEndOf="@id/tvTodayStageCount"
-            app:layout_constraintTop_toTopOf="@id/tvTodayStageCount" />
+            app:layout_constraintBottom_toBottomOf="parent"
+
+            app:layout_constraintStart_toStartOf="@+id/tvArtistName"
+            app:layout_constraintTop_toBottomOf="@+id/tvArtistName" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/festago/presentation/src/main/res/layout/item_search_festival.xml
+++ b/android/festago/presentation/src/main/res/layout/item_search_festival.xml
@@ -107,7 +107,6 @@
         <TextView
             android:id="@+id/tvEmptyStage"
             style="@style/H5Bold14Lh16"
-            visibility="@{item.artists.isEmpty()}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center"

--- a/android/festago/presentation/src/main/res/layout/item_search_school.xml
+++ b/android/festago/presentation/src/main/res/layout/item_search_school.xml
@@ -32,12 +32,12 @@
 
             <ImageView
                 android:id="@+id/ivSchoolLogoImage"
-                imageUrl="@{item.logoUrl}"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:importantForAccessibility="no"
                 android:scaleType="centerCrop"
-                tools:src="@drawable/ic_launcher_foreground" />
+                android:src="@drawable/img_default_school"
+                tools:src="@drawable/img_default_school" />
         </androidx.cardview.widget.CardView>
 
         <TextView


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #986

## ✨ PR 세부 내용

### 상세 화면 축제 목록 요청 로직 변경
서버로 isPast == true 를 요청할 때
lastFestivalId, lastLocalDate 가 past 가 아니면 데이터가 제대로 반환되지 않습니다.
그래서 그 로직을 수정했습니다.

추가로 10 개 요청을 20개 요청으로 늘렸습니다. (서버는 페이징이 되고 있지 않기 때문에..)

**30개로 늘리면 400 에러가 발생합니다 참고해주세요!**


### Throwable 을 던지지 않도록 코드 제거
