### PR TITLE
[BE] chore: Spring Boot 3.2.5 버전 업그레이드 (#989)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("org.springframework.boot") version "3.1.4"
+    id("org.springframework.boot") version "3.2.5"
     id("io.spring.dependency-management") version "1.1.0"
 }
 

--- a/backend/src/main/java/com/festago/bookmark/domain/Bookmark.java
+++ b/backend/src/main/java/com/festago/bookmark/domain/Bookmark.java
@@ -29,7 +29,7 @@ public class Bookmark extends BaseTimeEntity {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "bookmark_type")
+    @Column(name = "bookmark_type", columnDefinition = "varchar")
     private BookmarkType bookmarkType;
 
     @Column(name = "resource_id")

--- a/backend/src/main/java/com/festago/member/domain/Member.java
+++ b/backend/src/main/java/com/festago/member/domain/Member.java
@@ -52,7 +52,7 @@ public class Member extends BaseTimeEntity {
 
     @NotNull
     @Enumerated(value = EnumType.STRING)
-    @Column(name = "social_type")
+    @Column(name = "social_type", columnDefinition = "varchar")
     private SocialType socialType;
 
     @NotNull

--- a/backend/src/main/java/com/festago/school/domain/School.java
+++ b/backend/src/main/java/com/festago/school/domain/School.java
@@ -42,6 +42,7 @@ public class School extends BaseTimeEntity {
     private String backgroundUrl;
 
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar")
     private SchoolRegion region;
 
     public School(String domain, String name, String logoUrl, String backgroundUrl, SchoolRegion region) {

--- a/backend/src/main/java/com/festago/socialmedia/domain/SocialMedia.java
+++ b/backend/src/main/java/com/festago/socialmedia/domain/SocialMedia.java
@@ -35,11 +35,11 @@ public class SocialMedia extends BaseTimeEntity {
     private Long ownerId;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "owner_type")
+    @Column(name = "owner_type", columnDefinition = "varchar")
     private OwnerType ownerType;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "media_type")
+    @Column(name = "media_type", columnDefinition = "varchar")
     private SocialMediaType mediaType;
 
     private String name;

--- a/backend/src/main/java/com/festago/stage/domain/Stage.java
+++ b/backend/src/main/java/com/festago/stage/domain/Stage.java
@@ -41,6 +41,9 @@ public class Stage extends BaseTimeEntity {
     @OneToMany(mappedBy = "stage", fetch = FetchType.LAZY)
     private List<Ticket> tickets = new ArrayList<>();
 
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "stageId")
+    private List<StageArtist> artists = new ArrayList<>();
+
     public Stage(LocalDateTime startTime, LocalDateTime ticketOpenTime, Festival festival) {
         this(null, startTime, ticketOpenTime, festival);
     }

--- a/backend/src/main/java/com/festago/ticket/domain/Ticket.java
+++ b/backend/src/main/java/com/festago/ticket/domain/Ticket.java
@@ -7,6 +7,7 @@ import com.festago.common.util.Validator;
 import com.festago.school.domain.School;
 import com.festago.stage.domain.Stage;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -46,6 +47,7 @@ public class Ticket extends BaseTimeEntity {
 
     @NotNull
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar")
     private TicketType ticketType;
 
     @OneToOne(mappedBy = "ticket", optional = false, fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)

--- a/backend/src/main/java/com/festago/ticketing/domain/MemberTicket.java
+++ b/backend/src/main/java/com/festago/ticketing/domain/MemberTicket.java
@@ -10,6 +10,7 @@ import com.festago.ticket.domain.ReservationSequence;
 import com.festago.ticket.domain.Ticket;
 import com.festago.ticket.domain.TicketReserveInfo;
 import com.festago.ticket.domain.TicketType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -38,6 +39,7 @@ public class MemberTicket extends BaseTimeEntity {
 
     @NotNull
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar")
     private EntryState entryState = EntryState.BEFORE_ENTRY;
 
     @NotNull
@@ -56,6 +58,7 @@ public class MemberTicket extends BaseTimeEntity {
 
     @NotNull
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar")
     private TicketType ticketType;
 
     public MemberTicket(Member owner, Stage stage, int number, LocalDateTime entryTime, TicketType ticketType) {

--- a/backend/src/main/java/com/festago/upload/domain/UploadFile.java
+++ b/backend/src/main/java/com/festago/upload/domain/UploadFile.java
@@ -2,6 +2,7 @@ package com.festago.upload.domain;
 
 import com.festago.common.util.Validator;
 import jakarta.annotation.Nonnull;
+import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -31,6 +32,7 @@ public class UploadFile implements Persistable<UUID> {
     private UUID id;
 
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar")
     private UploadStatus status;
 
     private long size;
@@ -39,11 +41,13 @@ public class UploadFile implements Persistable<UUID> {
     private URI location;
 
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar")
     private FileExtension extension;
 
     private Long ownerId;
 
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar")
     private FileOwnerType ownerType;
 
     private LocalDateTime createdAt;


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #989

## ✨ PR 세부 내용

제목 그대로 Hibernate의 버그를 수정하기 위해 Spring Boot 버전을 3.2.5로 올렸습니다.

그에따라 수정한 점이 있는데, 엔티티에 Enum을 필드로 사용하는 곳에서 명확하게 `columnDefinition`을 지정해주어야 합니다.

이유는 [Hibernate 6.2](https://docs.jboss.org/hibernate/orm/6.2/migration-guide/migration-guide.html#ddl-implicit-datatype-enum) 부터 변경사항이 생겼기 때문인데, MySQL을 사용한다면 기본으로 데이터타입을 `ENUM`으로 사용한다고 합니다.

 하지만 DB 테이블에서 컬럼의 데이터 타입에 ENUM을 사용하는 것은 [안티 패턴](https://gompro.postype.com/post/8253823)이라고 하더군요.
(저 또한 마찬가지로, DB가 비즈니스 로직을 알게되므로 안티패턴이라고 생각합니다 😂)

그 외 테스트를 돌렸을 때 발생하는 문제는 없었습니다.
(기존 버전이 3.1.4를 사용했으니, 마이너 버전 업데이트이므로 크리티컬한 변경은 없어 보입니다)

해당 PR이 머지가 되면 RestTemplate을 사용하던 코드를 RestClient를 사용하도록 리팩터링해도 좋아보이네요.