### PR TITLE
[BE] refactor: 이미지 URL을 가진 엔티티에 모든 이미지 URL 반환하는 메서드 추가 (#999)

### DIFF
--- a/backend/src/main/java/com/festago/artist/domain/Artist.java
+++ b/backend/src/main/java/com/festago/artist/domain/Artist.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -47,6 +48,10 @@ public class Artist extends BaseTimeEntity {
         this.name = name;
         this.profileImage = ImageUrlHelper.getBlankStringIfBlank(profileImage);
         this.backgroundImageUrl = ImageUrlHelper.getBlankStringIfBlank(backgroundImageUrl);
+    }
+
+    public List<String> getImageUrls() {
+        return List.of(profileImage, backgroundImageUrl);
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/festago/festival/domain/Festival.java
+++ b/backend/src/main/java/com/festago/festival/domain/Festival.java
@@ -15,6 +15,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -99,6 +100,10 @@ public class Festival extends BaseTimeEntity {
     public void changeFestivalDuration(FestivalDuration festivalDuration) {
         validateFestivalDuration(festivalDuration);
         this.festivalDuration = festivalDuration;
+    }
+
+    public List<String> getImageUrls() {
+        return List.of(posterImageUrl);
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/festago/school/domain/School.java
+++ b/backend/src/main/java/com/festago/school/domain/School.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -110,6 +111,10 @@ public class School extends BaseTimeEntity {
     public void changeBackgroundImageUrl(String backgroundImageUrl) {
         validateImageUrl(backgroundImageUrl, "backgroundImageUrl");
         this.backgroundUrl = ImageUrlHelper.getBlankStringIfBlank(backgroundImageUrl);
+    }
+
+    public List<String> getImageUrls() {
+        return List.of(backgroundUrl, logoUrl);
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/festago/upload/application/artist/AsyncArtistUploadImagesStatusChangeEventListener.java
+++ b/backend/src/main/java/com/festago/upload/application/artist/AsyncArtistUploadImagesStatusChangeEventListener.java
@@ -27,7 +27,7 @@ public class AsyncArtistUploadImagesStatusChangeEventListener {
     public void changeAttachedStatusArtistImagesEventHandler(ArtistCreatedEvent event) {
         Artist artist = event.artist();
         Long artistId = artist.getId();
-        List<String> imageUris = List.of(artist.getProfileImage(), artist.getBackgroundImageUrl());
+        List<String> imageUris = artist.getImageUrls();
         uploadFileStatusChangeService.changeAttached(artistId, ARTIST, imageUris);
     }
 
@@ -35,7 +35,7 @@ public class AsyncArtistUploadImagesStatusChangeEventListener {
     public void changeRenewalStatusArtistImagesEventHandler(ArtistUpdatedEvent event) {
         Artist artist = event.artist();
         Long artistId = artist.getId();
-        List<String> imageUris = List.of(artist.getProfileImage(), artist.getBackgroundImageUrl());
+        List<String> imageUris = artist.getImageUrls();
         uploadFileStatusChangeService.changeRenewal(artistId, ARTIST, imageUris);
     }
 

--- a/backend/src/main/java/com/festago/upload/application/festival/AsyncFestivalUploadImagesStatusChangeEventListener.java
+++ b/backend/src/main/java/com/festago/upload/application/festival/AsyncFestivalUploadImagesStatusChangeEventListener.java
@@ -27,7 +27,7 @@ public class AsyncFestivalUploadImagesStatusChangeEventListener {
     public void changeAttachedStatusFestivalImagesEventHandler(FestivalCreatedEvent event) {
         Festival festival = event.festival();
         Long festivalId = festival.getId();
-        List<String> imageUris = List.of(festival.getPosterImageUrl());
+        List<String> imageUris = festival.getImageUrls();
         uploadFileStatusChangeService.changeAttached(festivalId, FESTIVAL, imageUris);
     }
 
@@ -35,7 +35,7 @@ public class AsyncFestivalUploadImagesStatusChangeEventListener {
     public void changeRenewalStatusFestivalImagesEventHandler(FestivalUpdatedEvent event) {
         Festival festival = event.festival();
         Long festivalId = festival.getId();
-        List<String> imageUris = List.of(festival.getPosterImageUrl());
+        List<String> imageUris = festival.getImageUrls();
         uploadFileStatusChangeService.changeRenewal(festivalId, FESTIVAL, imageUris);
     }
 

--- a/backend/src/main/java/com/festago/upload/application/school/AsyncSchoolUploadImagesStatusChangeEventListener.java
+++ b/backend/src/main/java/com/festago/upload/application/school/AsyncSchoolUploadImagesStatusChangeEventListener.java
@@ -27,7 +27,7 @@ public class AsyncSchoolUploadImagesStatusChangeEventListener {
     public void changeAttachedStatusSchoolImagesEventHandler(SchoolCreatedEvent event) {
         School school = event.school();
         Long schoolId = school.getId();
-        List<String> imageUris = List.of(school.getBackgroundUrl(), school.getLogoUrl());
+        List<String> imageUris = school.getImageUrls();
         uploadFileStatusChangeService.changeAttached(schoolId, SCHOOL, imageUris);
     }
 
@@ -35,7 +35,7 @@ public class AsyncSchoolUploadImagesStatusChangeEventListener {
     public void changeRenewalStatusSchoolImagesEventHandler(SchoolUpdatedEvent event) {
         School school = event.school();
         Long schoolId = school.getId();
-        List<String> imageUris = List.of(school.getBackgroundUrl(), school.getLogoUrl());
+        List<String> imageUris = school.getImageUrls();
         uploadFileStatusChangeService.changeRenewal(schoolId, SCHOOL, imageUris);
     }
 

--- a/backend/src/test/java/com/festago/artist/domain/ArtistTest.java
+++ b/backend/src/test/java/com/festago/artist/domain/ArtistTest.java
@@ -1,0 +1,32 @@
+package com.festago.artist.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.festago.support.fixture.ArtistFixture;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ArtistTest {
+
+    @Nested
+    class getImageUrls {
+
+        @Test
+        void 가지고_있는_모든_이미지_URL을_반환한다() {
+            // given
+            Artist artist = ArtistFixture.builder().build();
+
+            // when
+            List<String> imageUrls = artist.getImageUrls();
+
+            // then
+            assertThat(imageUrls)
+                .containsExactlyInAnyOrder(artist.getProfileImage(), artist.getBackgroundImageUrl());
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/festival/domain/FestivalTest.java
+++ b/backend/src/test/java/com/festago/festival/domain/FestivalTest.java
@@ -1,0 +1,32 @@
+package com.festago.festival.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.festago.support.fixture.FestivalFixture;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class FestivalTest {
+
+    @Nested
+    class getImageUrls {
+
+        @Test
+        void 가지고_있는_모든_이미지_URL을_반환한다() {
+            // given
+            Festival festival = FestivalFixture.builder().build();
+
+            // when
+            List<String> imageUrls = festival.getImageUrls();
+
+            // then
+            assertThat(imageUrls)
+                .containsExactlyInAnyOrder(festival.getPosterImageUrl());
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/school/domain/SchoolTest.java
+++ b/backend/src/test/java/com/festago/school/domain/SchoolTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.festago.common.exception.ValidException;
+import com.festago.support.fixture.SchoolFixture;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -355,6 +357,23 @@ class SchoolTest {
             // when & then
             assertThatThrownBy(() -> school.changeBackgroundImageUrl(backgroundImageUrl))
                 .isInstanceOf(ValidException.class);
+        }
+    }
+
+    @Nested
+    class getImageUrls {
+
+        @Test
+        void 가지고_있는_모든_이미지_URL을_반환한다() {
+            // given
+            School school = SchoolFixture.builder().build();
+
+            // when
+            List<String> imageUrls = school.getImageUrls();
+
+            // then
+            assertThat(imageUrls)
+                .containsExactlyInAnyOrder(school.getLogoUrl(), school.getBackgroundUrl());
         }
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #999 🐦

## ✨ PR 세부 내용

이슈 내용 그대로 이미지 URL을 가진 엔티티에 모든 이미지 URL을 반환하는 메서드를 추가했습니다.

큰 변경은 없습니다.

1000번째 PR은 제가 잘 가져갑니다 😂