### PR TITLE
[BE] refactor: StageQueryInfo, FestivalQueryInfo 직렬화 시 쿼리에 의존적인 로직 어플리케이션 로직으로 이동 (#1003)

### DIFF
--- a/backend/src/main/java/com/festago/artist/domain/Artist.java
+++ b/backend/src/main/java/com/festago/artist/domain/Artist.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.hibernate.proxy.HibernateProxy;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -63,5 +65,33 @@ public class Artist extends BaseTimeEntity {
 
     public String getBackgroundImageUrl() {
         return backgroundImageUrl;
+    }
+
+    @Override
+    public final boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null) {
+            return false;
+        }
+        Class<?> oEffectiveClass = object instanceof HibernateProxy
+            ? ((HibernateProxy) object).getHibernateLazyInitializer().getPersistentClass()
+            : object.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy
+            ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass()
+            : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) {
+            return false;
+        }
+        Artist artist = (Artist) object;
+        return getId() != null && Objects.equals(getId(), artist.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer()
+            .getPersistentClass()
+            .hashCode() : getClass().hashCode();
     }
 }

--- a/backend/src/main/java/com/festago/festival/domain/FestivalQueryInfo.java
+++ b/backend/src/main/java/com/festago/festival/domain/FestivalQueryInfo.java
@@ -1,5 +1,7 @@
 package com.festago.festival.domain;
 
+import static java.util.Comparator.comparingLong;
+
 import com.festago.artist.domain.Artist;
 import com.festago.artist.domain.ArtistsSerializer;
 import com.festago.common.domain.BaseTimeEntity;
@@ -39,7 +41,11 @@ public class FestivalQueryInfo extends BaseTimeEntity {
     }
 
     public void updateArtistInfo(List<Artist> artists, ArtistsSerializer serializer) {
-        this.artistInfo = serializer.serialize(artists);
+        List<Artist> distinctSortedArtists = artists.stream()
+            .distinct()
+            .sorted(comparingLong(Artist::getId))
+            .toList();
+        this.artistInfo = serializer.serialize(distinctSortedArtists);
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/festago/stage/domain/StageQueryInfo.java
+++ b/backend/src/main/java/com/festago/stage/domain/StageQueryInfo.java
@@ -1,5 +1,7 @@
 package com.festago.stage.domain;
 
+import static java.util.Comparator.comparingLong;
+
 import com.festago.artist.domain.Artist;
 import com.festago.artist.domain.ArtistsSerializer;
 import jakarta.persistence.Column;
@@ -40,7 +42,10 @@ public class StageQueryInfo {
     }
 
     public void updateArtist(List<Artist> artists, ArtistsSerializer serializer) {
-        this.artistInfo = serializer.serialize(artists);
+        List<Artist> sortedArtists = artists.stream()
+            .sorted(comparingLong(Artist::getId))
+            .toList();
+        this.artistInfo = serializer.serialize(sortedArtists);
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/festago/stage/infrastructure/FestivalIdStageArtistsQueryDslResolver.java
+++ b/backend/src/main/java/com/festago/stage/infrastructure/FestivalIdStageArtistsQueryDslResolver.java
@@ -22,12 +22,10 @@ public class FestivalIdStageArtistsQueryDslResolver implements FestivalIdStageAr
     public List<Artist> resolve(Long festivalId) {
         return queryDslHelper.select(artist)
             .from(festival)
-            .join(stage).on(stage.festival.id.eq(festival.id))
-            .join(stageArtist).on(stageArtist.stageId.eq(stage.id))
-            .join(artist).on(artist.id.eq(stageArtist.artistId))
+            .innerJoin(stage).on(stage.festival.id.eq(festival.id))
+            .innerJoin(stageArtist).on(stageArtist.stageId.eq(stage.id))
+            .innerJoin(artist).on(artist.id.eq(stageArtist.artistId))
             .where(festival.id.eq(festivalId))
-            .orderBy(artist.id.asc())
-            .distinct()
             .fetch();
     }
 }

--- a/backend/src/test/java/com/festago/festival/application/FestivalQueryInfoArtistRenewServiceTest.java
+++ b/backend/src/test/java/com/festago/festival/application/FestivalQueryInfoArtistRenewServiceTest.java
@@ -1,6 +1,5 @@
 package com.festago.festival.application;
 
-import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -9,6 +8,7 @@ import static org.mockito.BDDMockito.reset;
 
 import com.festago.artist.domain.Artist;
 import com.festago.artist.domain.ArtistsSerializer;
+import com.festago.artist.infrastructure.DelimiterArtistsSerializer;
 import com.festago.festival.domain.FestivalIdStageArtistsResolver;
 import com.festago.festival.domain.FestivalQueryInfo;
 import com.festago.festival.repository.FestivalInfoRepository;
@@ -28,9 +28,7 @@ class FestivalQueryInfoArtistRenewServiceTest {
 
     FestivalInfoRepository festivalInfoRepository;
     FestivalIdStageArtistsResolver festivalIdStageArtistsResolver = mock();
-    ArtistsSerializer artistsSerializer = artists -> artists.stream()
-        .map(Artist::getName)
-        .collect(joining(",")); // "뉴진스,에픽하이"
+    ArtistsSerializer artistsSerializer = new DelimiterArtistsSerializer(",");
     FestivalQueryInfoArtistRenewService festivalQueryInfoArtistRenewService;
 
     @BeforeEach

--- a/backend/src/test/java/com/festago/festival/domain/FestivalQueryInfoTest.java
+++ b/backend/src/test/java/com/festago/festival/domain/FestivalQueryInfoTest.java
@@ -1,0 +1,40 @@
+package com.festago.festival.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.festago.artist.domain.Artist;
+import com.festago.artist.infrastructure.DelimiterArtistsSerializer;
+import com.festago.support.fixture.ArtistFixture;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class FestivalQueryInfoTest {
+
+    @Nested
+    class updateArtistInfo {
+
+        @Test
+        void 직렬화된_아티스트_정보는_중복이_없고_아티스트_식별자_오름차순_정렬된다() {
+            // given
+            FestivalQueryInfo festivalQueryInfo = FestivalQueryInfo.create(1L);
+            DelimiterArtistsSerializer serializer = new DelimiterArtistsSerializer(",");
+            List<Artist> artists = List.of(
+                ArtistFixture.builder().id(3L).name("아이유").build(),
+                ArtistFixture.builder().id(2L).name("에픽하이").build(),
+                ArtistFixture.builder().id(2L).name("에픽하이").build(),
+                ArtistFixture.builder().id(1L).name("SG워너비").build()
+            );
+
+            // when
+            festivalQueryInfo.updateArtistInfo(artists, serializer);
+
+            // then
+            assertThat(festivalQueryInfo.getArtistInfo()).isEqualTo("SG워너비,에픽하이,아이유");
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/stage/infrastructure/FestivalIdStageArtistsQueryDslResolverTest.java
+++ b/backend/src/test/java/com/festago/stage/infrastructure/FestivalIdStageArtistsQueryDslResolverTest.java
@@ -79,18 +79,4 @@ class FestivalIdStageArtistsQueryDslResolverTest extends ApplicationIntegrationT
             .map(Artist::getName)
             .containsOnly(뉴진스.getName(), 에픽하이.getName(), 아이유.getName());
     }
-
-    @Test
-    void 중복된_아티스트가_있으면_중복된_아티스트는_포함되지_않는다() {
-        // given
-        stageArtistRepository.save(StageArtistFixture.builder(테코대학교_두번째_공연.getId(), 아이유.getId()).build());
-
-        // when
-        List<Artist> expect = festivalIdStageArtistsResolver.resolve(festivalId);
-
-        // then
-        assertThat(expect)
-            .map(Artist::getName)
-            .containsOnly(뉴진스.getName(), 에픽하이.getName(), 아이유.getName());
-    }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #1003

## ✨ PR 세부 내용

이슈 내용대로 `FestivalIdStageArtistsQueryDslResolver`에서 `distinct`와 `orderBy` 절을 제거하고 어플리케이션 로직으로 이동시켜 비즈니스 로직의 응집도를 향상시켰습니다.

![image](https://github.com/woowacourse-teams/2023-festa-go/assets/116627736/fef47bd4-ccdf-4bd4-b5cc-2028c8c8ce7f)

성능에 큰 영향은 없을 것 같지만, 결과로 쿼리 cost가 9에서 6으로 약 30% 정도 줄었습니다.

다만 어플리케이션에서 distinct를 처리해야 하기에 `Artist`에서 equals, hashCode 메서드를 재정의 했습니다.
(equals만 재정의하면 되지만, equals를 재정의하면 hashCode 또한 같이 재정의를 해야합니다)

이때 `Artist`는 JPA 엔티티이기 때문에 일반적인 방법으로 equals, hashCode 메서드를 재정의하면 예상하지 못한 문제가 발생할 수 있습니다.
(프록시 문제)

따라서 엔티티의 경우에는 조금 특별한 방법으로 복잡하게 equals, hashCode를 재정의해야 하는데, `JPA Buddy` 플러그인을 사용하면 매우 간단하게 정의할 수 있습니다.

자세한 내용은 [JPA Buddy 아티클](https://jpa-buddy.com/blog/hopefully-the-final-article-about-equals-and-hashcode-for-jpa-entities-with-db-generated-ids/) 또는 [블로그](https://www.korecmblog.com/blog/jpa-equals-and-history) 참고하시면 좋을 것 같습니다.