### PR TITLE
[BE] feat: StageTicket 생성, 삭제 로직 추가 (#1007-2)

### DIFF
--- a/backend/src/main/java/com/festago/stage/application/command/StageDeleteService.java
+++ b/backend/src/main/java/com/festago/stage/application/command/StageDeleteService.java
@@ -1,7 +1,9 @@
 package com.festago.stage.application.command;
 
+import com.festago.stage.domain.validator.StageDeleteValidator;
 import com.festago.stage.dto.event.StageDeletedEvent;
 import com.festago.stage.repository.StageRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -13,10 +15,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class StageDeleteService {
 
     private final StageRepository stageRepository;
+    private final List<StageDeleteValidator> validators;
     private final ApplicationEventPublisher eventPublisher;
 
     public void deleteStage(Long stageId) {
         stageRepository.findById(stageId).ifPresent(stage -> {
+            validators.forEach(validator -> validator.validate(stage));
             stageRepository.deleteById(stageId);
             eventPublisher.publishEvent(new StageDeletedEvent(stage));
         });

--- a/backend/src/main/java/com/festago/stage/application/command/StageUpdateService.java
+++ b/backend/src/main/java/com/festago/stage/application/command/StageUpdateService.java
@@ -5,6 +5,7 @@ import com.festago.common.exception.ErrorCode;
 import com.festago.common.exception.NotFoundException;
 import com.festago.common.util.Validator;
 import com.festago.stage.domain.Stage;
+import com.festago.stage.domain.validator.StageUpdateValidator;
 import com.festago.stage.dto.command.StageUpdateCommand;
 import com.festago.stage.dto.event.StageUpdatedEvent;
 import com.festago.stage.repository.StageRepository;
@@ -24,6 +25,7 @@ public class StageUpdateService {
 
     private final StageRepository stageRepository;
     private final ArtistRepository artistRepository;
+    private final List<StageUpdateValidator> validators;
     private final ApplicationEventPublisher eventPublisher;
 
     public void updateStage(Long stageId, StageUpdateCommand command) {
@@ -35,6 +37,7 @@ public class StageUpdateService {
             .orElseThrow(() -> new NotFoundException(ErrorCode.STAGE_NOT_FOUND));
         stage.changeTime(startTime, ticketOpenTime);
         stage.renewArtists(artistIds);
+        validators.forEach(validator -> validator.validate(stage));
         eventPublisher.publishEvent(new StageUpdatedEvent(stage));
     }
 

--- a/backend/src/main/java/com/festago/stage/domain/validator/StageDeleteValidator.java
+++ b/backend/src/main/java/com/festago/stage/domain/validator/StageDeleteValidator.java
@@ -1,0 +1,8 @@
+package com.festago.stage.domain.validator;
+
+import com.festago.stage.domain.Stage;
+
+public interface StageDeleteValidator {
+
+    void validate(Stage stage);
+}

--- a/backend/src/main/java/com/festago/stage/domain/validator/StageUpdateValidator.java
+++ b/backend/src/main/java/com/festago/stage/domain/validator/StageUpdateValidator.java
@@ -1,0 +1,8 @@
+package com.festago.stage.domain.validator;
+
+import com.festago.stage.domain.Stage;
+
+public interface StageUpdateValidator {
+
+    void validate(Stage stage);
+}

--- a/backend/src/main/java/com/festago/stage/repository/StageRepository.java
+++ b/backend/src/main/java/com/festago/stage/repository/StageRepository.java
@@ -33,4 +33,12 @@ public interface StageRepository extends Repository<Stage, Long> {
         where s.id = :id
         """)
     Optional<Stage> findByIdWithFetch(@Param("id") Long id);
+
+    @Query("""
+        select s
+        from Stage s
+        join fetch s.festival
+        where s.id = :id
+        """)
+    Optional<Stage> findByIdWithFetchFestival(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/festago/ticket/application/command/stage/StageTicketCreateService.java
+++ b/backend/src/main/java/com/festago/ticket/application/command/stage/StageTicketCreateService.java
@@ -1,0 +1,49 @@
+package com.festago.ticket.application.command.stage;
+
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
+import com.festago.stage.domain.Stage;
+import com.festago.stage.repository.StageRepository;
+import com.festago.ticket.domain.StageTicket;
+import com.festago.ticket.domain.TicketExclusive;
+import com.festago.ticket.dto.command.StageTicketCreateCommand;
+import com.festago.ticket.dto.event.TicketCreatedEvent;
+import com.festago.ticket.repository.StageTicketRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class StageTicketCreateService {
+
+    private final StageTicketRepository stageTicketRepository;
+    private final StageRepository stageRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final Clock clock;
+
+    public Long createStageTicket(StageTicketCreateCommand command) {
+        Long schoolId = command.schoolId();
+        Long stageId = command.stageId();
+        TicketExclusive ticketType = command.ticketExclusive();
+        StageTicket stageTicket = stageTicketRepository.findByStageIdAndTicketExclusiveWithFetch(stageId, ticketType)
+            .orElseGet(() -> {
+                Stage stage = findStage(stageId);
+                return stageTicketRepository.save(new StageTicket(schoolId, ticketType, stage));
+            });
+        LocalDateTime entryTime = command.entryTime();
+        int amount = command.amount();
+        stageTicket.addTicketEntryTime(schoolId, LocalDateTime.now(clock), entryTime, amount);
+        eventPublisher.publishEvent(new TicketCreatedEvent(stageTicket));
+        return stageTicket.getId();
+    }
+
+    private Stage findStage(Long stageId) {
+        return stageRepository.findByIdWithFetchFestival(stageId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.STAGE_NOT_FOUND));
+    }
+}

--- a/backend/src/main/java/com/festago/ticket/application/command/stage/StageTicketDeleteService.java
+++ b/backend/src/main/java/com/festago/ticket/application/command/stage/StageTicketDeleteService.java
@@ -1,0 +1,40 @@
+package com.festago.ticket.application.command.stage;
+
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
+import com.festago.ticket.domain.StageTicket;
+import com.festago.ticket.dto.command.StageTicketDeleteCommand;
+import com.festago.ticket.dto.event.TicketDeletedEvent;
+import com.festago.ticket.repository.StageTicketRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StageTicketDeleteService {
+
+    private final StageTicketRepository stageTicketRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final Clock clock;
+
+    public void deleteStageTicket(StageTicketDeleteCommand command) {
+        Long ticketId = command.stageTicketId();
+        StageTicket stageTicket = stageTicketRepository.findByIdWithFetch(ticketId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.TICKET_NOT_FOUND));
+        Long schoolId = command.schoolId();
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime entryTime = command.entryTime();
+        boolean isDeleted = stageTicket.deleteTicketEntryTime(schoolId, now, entryTime);
+        if (stageTicket.isEmptyAmount()) {
+            stageTicketRepository.deleteById(ticketId);
+        }
+        if (isDeleted) {
+            eventPublisher.publishEvent(new TicketDeletedEvent(stageTicket));
+        }
+    }
+}

--- a/backend/src/main/java/com/festago/ticket/dto/command/StageTicketCreateCommand.java
+++ b/backend/src/main/java/com/festago/ticket/dto/command/StageTicketCreateCommand.java
@@ -1,0 +1,16 @@
+package com.festago.ticket.dto.command;
+
+import com.festago.ticket.domain.TicketExclusive;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record StageTicketCreateCommand(
+    Long schoolId,
+    Long stageId,
+    TicketExclusive ticketExclusive,
+    int amount,
+    LocalDateTime entryTime
+) {
+
+}

--- a/backend/src/main/java/com/festago/ticket/dto/command/StageTicketDeleteCommand.java
+++ b/backend/src/main/java/com/festago/ticket/dto/command/StageTicketDeleteCommand.java
@@ -1,0 +1,13 @@
+package com.festago.ticket.dto.command;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record StageTicketDeleteCommand(
+    Long schoolId,
+    Long stageTicketId,
+    LocalDateTime entryTime
+) {
+
+}

--- a/backend/src/main/java/com/festago/ticket/dto/event/TicketCreatedEvent.java
+++ b/backend/src/main/java/com/festago/ticket/dto/event/TicketCreatedEvent.java
@@ -1,0 +1,9 @@
+package com.festago.ticket.dto.event;
+
+import com.festago.ticket.domain.NewTicket;
+
+public record TicketCreatedEvent(
+    NewTicket ticket
+) {
+
+}

--- a/backend/src/main/java/com/festago/ticket/dto/event/TicketDeletedEvent.java
+++ b/backend/src/main/java/com/festago/ticket/dto/event/TicketDeletedEvent.java
@@ -1,0 +1,9 @@
+package com.festago.ticket.dto.event;
+
+import com.festago.ticket.domain.NewTicket;
+
+public record TicketDeletedEvent(
+    NewTicket ticket
+) {
+
+}

--- a/backend/src/main/java/com/festago/ticket/repository/StageTicketRepository.java
+++ b/backend/src/main/java/com/festago/ticket/repository/StageTicketRepository.java
@@ -1,0 +1,40 @@
+package com.festago.ticket.repository;
+
+import com.festago.ticket.domain.StageTicket;
+import com.festago.ticket.domain.TicketExclusive;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+public interface StageTicketRepository extends Repository<StageTicket, Long> {
+
+    StageTicket save(StageTicket stageTicket);
+
+    Optional<StageTicket> findById(Long id);
+
+    boolean existsByStageId(Long stageId);
+
+    void deleteById(Long id);
+
+    @Query("""
+            select st
+            from StageTicket st
+            join fetch st.stage
+            join fetch st.ticketEntryTimes
+            where st.id = :id
+        """)
+    Optional<StageTicket> findByIdWithFetch(@Param("id") Long id);
+
+    @Query("""
+            select st
+            from StageTicket st
+            join fetch st.stage
+            join fetch st.ticketEntryTimes
+            where st.stage.id = :stageId and st.ticketExclusive = :ticketExclusive
+        """)
+    Optional<StageTicket> findByStageIdAndTicketExclusiveWithFetch(
+        @Param("stageId") Long stageId,
+        @Param("ticketExclusive") TicketExclusive ticketExclusive
+    );
+}

--- a/backend/src/test/java/com/festago/stage/application/command/StageDeleteServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageDeleteServiceTest.java
@@ -17,6 +17,7 @@ import com.festago.support.fixture.ArtistFixture;
 import com.festago.support.fixture.FestivalFixture;
 import com.festago.support.fixture.StageFixture;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -46,7 +47,11 @@ class StageDeleteServiceTest {
         artistRepository = new MemoryArtistRepository();
         festivalRepository = new MemoryFestivalRepository();
         stageRepository = new MemoryStageRepository();
-        stageDeleteService = new StageDeleteService(stageRepository, mock(ApplicationEventPublisher.class));
+        stageDeleteService = new StageDeleteService(
+            stageRepository,
+            Collections.emptyList(),
+            mock(ApplicationEventPublisher.class)
+        );
 
         테코대학교_축제 = festivalRepository.save(
             FestivalFixture.builder()

--- a/backend/src/test/java/com/festago/stage/application/command/StageUpdateServiceTest.java
+++ b/backend/src/test/java/com/festago/stage/application/command/StageUpdateServiceTest.java
@@ -20,6 +20,7 @@ import com.festago.support.fixture.ArtistFixture;
 import com.festago.support.fixture.FestivalFixture;
 import com.festago.support.fixture.StageFixture;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.LongStream;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,6 +53,7 @@ class StageUpdateServiceTest {
         stageUpdateService = new StageUpdateService(
             stageRepository,
             artistRepository,
+            Collections.emptyList(),
             mock(ApplicationEventPublisher.class)
         );
 

--- a/backend/src/test/java/com/festago/stage/repository/MemoryStageRepository.java
+++ b/backend/src/test/java/com/festago/stage/repository/MemoryStageRepository.java
@@ -25,4 +25,9 @@ public class MemoryStageRepository extends AbstractMemoryRepository<Stage> imple
     public Optional<Stage> findByIdWithFetch(Long id) {
         return findById(id);
     }
+
+    @Override
+    public Optional<Stage> findByIdWithFetchFestival(Long id) {
+        return findById(id);
+    }
 }

--- a/backend/src/test/java/com/festago/ticket/application/command/stage/StageTicketCreateServiceTest.java
+++ b/backend/src/test/java/com/festago/ticket/application/command/stage/StageTicketCreateServiceTest.java
@@ -1,0 +1,165 @@
+package com.festago.ticket.application.command.stage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.spy;
+
+import com.festago.festival.domain.Festival;
+import com.festago.festival.repository.FestivalRepository;
+import com.festago.festival.repository.MemoryFestivalRepository;
+import com.festago.school.domain.School;
+import com.festago.school.repository.MemorySchoolRepository;
+import com.festago.school.repository.SchoolRepository;
+import com.festago.stage.domain.Stage;
+import com.festago.stage.repository.MemoryStageRepository;
+import com.festago.stage.repository.StageRepository;
+import com.festago.support.TimeInstantProvider;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StageFixture;
+import com.festago.ticket.domain.NewTicket;
+import com.festago.ticket.domain.TicketExclusive;
+import com.festago.ticket.dto.command.StageTicketCreateCommand;
+import com.festago.ticket.repository.MemoryStageTicketRepository;
+import com.festago.ticket.repository.StageTicketRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class StageTicketCreateServiceTest {
+
+    StageTicketCreateService stageTicketCreateService;
+
+    SchoolRepository schoolRepository;
+
+    FestivalRepository festivalRepository;
+
+    StageRepository stageRepository;
+
+    StageTicketRepository stageTicketRepository;
+
+    Clock clock;
+
+    @BeforeEach
+    void setUp() {
+        clock = spy(Clock.systemDefaultZone());
+        schoolRepository = new MemorySchoolRepository();
+        festivalRepository = new MemoryFestivalRepository();
+        stageRepository = new MemoryStageRepository();
+        stageTicketRepository = new MemoryStageTicketRepository();
+        stageTicketCreateService = new StageTicketCreateService(
+            stageTicketRepository,
+            stageRepository,
+            mock(ApplicationEventPublisher.class),
+            clock
+        );
+    }
+
+    @Nested
+    class createStageTicket {
+
+        School 테코대학교;
+        Festival 테코대학교_축제;
+        Stage 테코대학교_1일차_공연;
+        LocalDate _6월_15일 = LocalDate.parse("2077-06-15");
+        LocalDateTime _6월_7일_18시_0분 = LocalDateTime.parse("2077-06-07T18:00:00");
+        LocalDateTime _6월_8일_18시_0분 = LocalDateTime.parse("2077-06-08T18:00:00");
+        LocalDateTime _6월_15일_17시_0분 = LocalDateTime.parse("2077-06-15T17:00:00");
+        LocalDateTime _6월_15일_18시_0분 = LocalDateTime.parse("2077-06-15T18:00:00");
+
+        @BeforeEach
+        void setUp() {
+            테코대학교 = schoolRepository.save(SchoolFixture.builder().build());
+            테코대학교_축제 = festivalRepository.save(
+                FestivalFixture.builder().school(테코대학교).startDate(_6월_15일).endDate(_6월_15일).build());
+            테코대학교_1일차_공연 = stageRepository.save(
+                StageFixture.builder().festival(테코대학교_축제).startTime(_6월_15일_18시_0분).ticketOpenTime(_6월_8일_18시_0분)
+                    .build());
+            given(clock.instant())
+                .willReturn(TimeInstantProvider.from(_6월_7일_18시_0분));
+        }
+
+        @Test
+        void 기존_StageTicket이_존재하지_않으면_새로운_StageTicket이_생성된다() {
+            // given
+            var command = StageTicketCreateCommand.builder()
+                .schoolId(테코대학교.getId())
+                .stageId(테코대학교_1일차_공연.getId())
+                .ticketExclusive(TicketExclusive.STUDENT)
+                .amount(100)
+                .entryTime(_6월_15일_17시_0분)
+                .build();
+
+            // when
+            Long stageTicketId = stageTicketCreateService.createStageTicket(command);
+
+            // then
+            assertThat(stageTicketRepository.findById(stageTicketId))
+                .map(NewTicket::getAmount)
+                .hasValue(100);
+        }
+
+        @Test
+        void 공연과_티켓_타입이_같으면_기존_StageTicket에_TicketEntryTime이_추가된다() {
+            // given
+            var command = StageTicketCreateCommand.builder()
+                .schoolId(테코대학교.getId())
+                .stageId(테코대학교_1일차_공연.getId())
+                .ticketExclusive(TicketExclusive.STUDENT)
+                .amount(100)
+                .entryTime(_6월_15일_17시_0분)
+                .build();
+
+            // when
+            Long firstStageTicketId = stageTicketCreateService.createStageTicket(command);
+            Long secondStageTicketId = stageTicketCreateService.createStageTicket(command);
+
+            // then
+            assertThat(firstStageTicketId).isEqualTo(secondStageTicketId);
+            assertThat(stageTicketRepository.findById(firstStageTicketId))
+                .map(NewTicket::getAmount)
+                .hasValue(200);
+        }
+
+        @Test
+        void 공연이_같아도_티켓_타입이_다르면_새로운_Ticket이_추가된다() {
+            // given
+            var studentTicketCommand = StageTicketCreateCommand.builder()
+                .schoolId(테코대학교.getId())
+                .stageId(테코대학교_1일차_공연.getId())
+                .ticketExclusive(TicketExclusive.NONE)
+                .amount(100)
+                .entryTime(_6월_15일_17시_0분)
+                .build();
+            var visitorTicketCommand = StageTicketCreateCommand.builder()
+                .schoolId(테코대학교.getId())
+                .stageId(테코대학교_1일차_공연.getId())
+                .ticketExclusive(TicketExclusive.STUDENT)
+                .amount(50)
+                .entryTime(_6월_15일_17시_0분)
+                .build();
+
+            //when
+            Long studentTicketId = stageTicketCreateService.createStageTicket(studentTicketCommand);
+            Long visitorTicketId = stageTicketCreateService.createStageTicket(visitorTicketCommand);
+
+            // then
+            assertThat(studentTicketId).isNotEqualTo(visitorTicketId);
+            assertThat(stageTicketRepository.findById(studentTicketId))
+                .map(NewTicket::getAmount)
+                .hasValue(100);
+            assertThat(stageTicketRepository.findById(visitorTicketId))
+                .map(NewTicket::getAmount)
+                .hasValue(50);
+        }
+    }
+}

--- a/backend/src/test/java/com/festago/ticket/application/command/stage/StageTicketDeleteServiceTest.java
+++ b/backend/src/test/java/com/festago/ticket/application/command/stage/StageTicketDeleteServiceTest.java
@@ -1,0 +1,184 @@
+package com.festago.ticket.application.command.stage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.spy;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.festago.common.exception.ErrorCode;
+import com.festago.common.exception.NotFoundException;
+import com.festago.festival.domain.Festival;
+import com.festago.school.domain.School;
+import com.festago.stage.domain.Stage;
+import com.festago.support.TimeInstantProvider;
+import com.festago.support.fixture.FestivalFixture;
+import com.festago.support.fixture.SchoolFixture;
+import com.festago.support.fixture.StageFixture;
+import com.festago.support.fixture.StageTicketFixture;
+import com.festago.ticket.domain.StageTicket;
+import com.festago.ticket.dto.command.StageTicketDeleteCommand;
+import com.festago.ticket.dto.event.TicketDeletedEvent;
+import com.festago.ticket.repository.MemoryStageTicketRepository;
+import com.festago.ticket.repository.StageTicketRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class StageTicketDeleteServiceTest {
+
+    StageTicketDeleteService stageTicketDeleteService;
+
+    StageTicketRepository stageTicketRepository;
+
+    ApplicationEventPublisher eventPublisher;
+
+    Clock clock;
+
+    Long schoolId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        stageTicketRepository = new MemoryStageTicketRepository();
+        eventPublisher = mock(ApplicationEventPublisher.class);
+        clock = spy(Clock.systemDefaultZone());
+        stageTicketDeleteService = new StageTicketDeleteService(
+            stageTicketRepository,
+            eventPublisher,
+            clock
+        );
+    }
+
+    @Nested
+    class deleteStageTicket {
+
+        @Test
+        void 티켓의_식별자에_해당하는_티켓이_없으면_예외() {
+            // given
+            var command = StageTicketDeleteCommand.builder()
+                .stageTicketId(4885L)
+                .build();
+
+            // when & then
+            assertThatThrownBy(() -> stageTicketDeleteService.deleteStageTicket(command))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.TICKET_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 입장_시간을_삭제_후_남은_입장_시간이_있으면_티켓은_삭제되지_않는다() {
+            // given
+            StageTicket stageTicket = stageTicketRepository.save(createStageTicket());
+            LocalDateTime now = stageTicket.getStage().getTicketOpenTime().minusHours(1);
+            LocalDateTime entryTime = stageTicket.getStage().getStartTime().minusHours(1L);
+            stageTicket.addTicketEntryTime(schoolId, now, entryTime, 100);
+            stageTicket.addTicketEntryTime(schoolId, now, entryTime.plusSeconds(1), 100);
+            given(clock.instant())
+                .willReturn(TimeInstantProvider.from(now));
+            var command = StageTicketDeleteCommand.builder()
+                .schoolId(schoolId)
+                .stageTicketId(stageTicket.getId())
+                .entryTime(entryTime)
+                .build();
+
+            // when
+            stageTicketDeleteService.deleteStageTicket(command);
+
+            // then
+            assertThat(stageTicketRepository.findById(stageTicket.getId())).isPresent();
+        }
+
+        @Test
+        void 입장_시간을_삭제_후_남은_입장_시간이_없으면_티켓이_삭제된다() {
+            // given
+            StageTicket stageTicket = stageTicketRepository.save(createStageTicket());
+            LocalDateTime now = stageTicket.getStage().getTicketOpenTime().minusHours(1);
+            LocalDateTime entryTime = stageTicket.getStage().getStartTime().minusHours(1L);
+            stageTicket.addTicketEntryTime(schoolId, now, entryTime, 100);
+            given(clock.instant())
+                .willReturn(TimeInstantProvider.from(now));
+            var command = StageTicketDeleteCommand.builder()
+                .schoolId(schoolId)
+                .stageTicketId(stageTicket.getId())
+                .entryTime(entryTime)
+                .build();
+
+            // when
+            stageTicketDeleteService.deleteStageTicket(command);
+
+            // then
+            assertThat(stageTicketRepository.findById(stageTicket.getId())).isEmpty();
+        }
+
+        @Test
+        void 삭제된_입장_시간이_있으면_티켓_삭제_이벤트가_발행된다() {
+            // given
+            StageTicket stageTicket = stageTicketRepository.save(createStageTicket());
+            LocalDateTime now = stageTicket.getStage().getTicketOpenTime().minusHours(1);
+            LocalDateTime entryTime = stageTicket.getStage().getStartTime().minusHours(1L);
+            stageTicket.addTicketEntryTime(schoolId, now, entryTime, 100);
+            given(clock.instant())
+                .willReturn(TimeInstantProvider.from(now));
+            var command = StageTicketDeleteCommand.builder()
+                .schoolId(schoolId)
+                .stageTicketId(stageTicket.getId())
+                .entryTime(entryTime)
+                .build();
+
+            // when
+            stageTicketDeleteService.deleteStageTicket(command);
+
+            // then
+            verify(eventPublisher, times(1)).publishEvent(any(TicketDeletedEvent.class));
+        }
+
+        @Test
+        void 삭제된_입장_시간이_없으면_티켓_삭제_이벤트가_발행되지_않는다() {
+            // given
+            StageTicket stageTicket = stageTicketRepository.save(createStageTicket());
+            LocalDateTime now = stageTicket.getStage().getTicketOpenTime().minusHours(1);
+            LocalDateTime entryTime = stageTicket.getStage().getStartTime().minusHours(1L);
+            stageTicket.addTicketEntryTime(schoolId, now, entryTime, 100);
+            given(clock.instant())
+                .willReturn(TimeInstantProvider.from(now));
+            var command = StageTicketDeleteCommand.builder()
+                .schoolId(schoolId)
+                .stageTicketId(stageTicket.getId())
+                .entryTime(entryTime.plusSeconds(1))
+                .build();
+
+            // when
+            stageTicketDeleteService.deleteStageTicket(command);
+
+            // then
+            verify(eventPublisher, never()).publishEvent(any(TicketDeletedEvent.class));
+        }
+    }
+
+    private StageTicket createStageTicket() {
+        School school = SchoolFixture.builder()
+            .id(schoolId)
+            .build();
+        Festival festival = FestivalFixture.builder()
+            .school(school)
+            .build();
+        Stage stage = StageFixture.builder()
+            .festival(festival)
+            .build();
+        return StageTicketFixture.builder()
+            .stage(stage)
+            .schoolId(school.getId())
+            .build();
+    }
+}

--- a/backend/src/test/java/com/festago/ticket/repository/MemoryStageTicketRepository.java
+++ b/backend/src/test/java/com/festago/ticket/repository/MemoryStageTicketRepository.java
@@ -1,0 +1,30 @@
+package com.festago.ticket.repository;
+
+import com.festago.support.AbstractMemoryRepository;
+import com.festago.ticket.domain.StageTicket;
+import com.festago.ticket.domain.TicketExclusive;
+import java.util.Objects;
+import java.util.Optional;
+
+public class MemoryStageTicketRepository extends AbstractMemoryRepository<StageTicket> implements
+    StageTicketRepository {
+
+    @Override
+    public boolean existsByStageId(Long stageId) {
+        return memory.values().stream()
+            .anyMatch(it -> Objects.equals(it.getStage().getId(), stageId));
+    }
+
+    @Override
+    public Optional<StageTicket> findByIdWithFetch(Long id) {
+        return Optional.ofNullable(memory.get(id));
+    }
+
+    @Override
+    public Optional<StageTicket> findByStageIdAndTicketExclusiveWithFetch(Long stageId, TicketExclusive ticketType) {
+        return memory.values().stream()
+            .filter(it -> Objects.equals(it.getStage().getId(), stageId))
+            .filter(it -> it.getTicketExclusive() == ticketType)
+            .findAny();
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #1007

## ✨ PR 세부 내용

#1008 PR에 의존하는 다음 StageTicket 생성, 삭제 로직에 대한 PR입니다.

티켓을 생성, 삭제하면 `TicketCreatedEvent`, `TicketDeletedEvent`를 발행합니다.

생성, 삭제 기능만 있고 수정 기능은 없는데, 굳이 티켓을 수정할 필요가 없더군요. 😂

또한 티켓의 생성과 삭제는 공연의 `ticketOpenTime` 이후로 동작하지 않도록 했습니다.

공연의 수정과 삭제 또한 등록된 티켓이 있으면 동작하지 않도록 했습니다.

이는 티켓팅 시 발생하는 정합성의 문제를 해결하기 위함입니다.
(정합성 외에도 티켓 오픈 시간 이후 티켓 수량을 변경하는 일이 일어나면 논란이 생길 것 같네요 😂)

DB에는 티켓의 정보가 반영되지만, 레디스에서는 반영이 되지 않기 때문에 해당 변경을 반영하는 작업이 필요합니다.

해당 반영은 위에서 발행한 이벤트를 가지고 처리합니다.

해당 코드는 이후 PR에 있으니 참고하시면 될 것 같습니다.

그 외 의도했던 내용에 대해선 코드에 리뷰로 남기겠습니다!